### PR TITLE
feat: Add initial implementation of PiecewiseStorage.

### DIFF
--- a/src/node.rs
+++ b/src/node.rs
@@ -484,8 +484,8 @@ impl Node {
             (Ok(min_vol), Ok(max_vol)) => {
                 let current_volume = state.get_network_state().get_node_volume(&self.index())?;
 
-                let available = (current_volume - min_vol).max(0.0);
-                let missing = (max_vol - current_volume).max(0.0);
+                let available = current_volume - min_vol;
+                let missing = max_vol - current_volume;
 
                 Ok((available, missing))
             }

--- a/src/recorders/hdf.rs
+++ b/src/recorders/hdf.rs
@@ -135,6 +135,9 @@ impl Recorder for HDF5Recorder {
                     let node = model.get_node(idx)?;
                     require_node_dataset(root_grp, shape, node.name(), node.sub_name(), "flow-deficit")?
                 }
+                Metric::VolumeBetweenControlCurves(_) => {
+                    continue; // TODO
+                }
             };
 
             datasets.push(ds);

--- a/src/schema/nodes/mod.rs
+++ b/src/schema/nodes/mod.rs
@@ -4,6 +4,7 @@ mod delay;
 mod loss_link;
 mod monthly_virtual_storage;
 mod piecewise_link;
+mod piecewise_storage;
 mod river;
 mod river_gauge;
 mod river_split_with_gauge;
@@ -23,6 +24,7 @@ pub use annual_virtual_storage::AnnualVirtualStorageNode;
 pub use loss_link::LossLinkNode;
 pub use monthly_virtual_storage::MonthlyVirtualStorageNode;
 pub use piecewise_link::{PiecewiseLinkNode, PiecewiseLinkStep};
+pub use piecewise_storage::PiecewiseStorageNode;
 use pywr_schema::nodes::{
     CoreNode as CoreNodeV1, CustomNode as CustomNodeV1, Node as NodeV1, NodeMeta as NodeMetaV1,
     NodePosition as NodePositionV1,
@@ -103,6 +105,7 @@ pub enum CoreNode {
     LossLink(LossLinkNode),
     Delay(DelayNode),
     PiecewiseLink(PiecewiseLinkNode),
+    PiecewiseStorage(PiecewiseStorageNode),
     River(RiverNode),
     RiverSplitWithGauge(RiverSplitWithGaugeNode),
     WaterTreatmentWorks(WaterTreatmentWorks),
@@ -139,6 +142,7 @@ impl CoreNode {
             CoreNode::VirtualStorage(_) => "VirtualStorage",
             CoreNode::AnnualVirtualStorage(_) => "AnnualVirtualStorage",
             CoreNode::PiecewiseLink(_) => "PiecewiseLink",
+            CoreNode::PiecewiseStorage(_) => "PiecewiseStorage",
             CoreNode::Delay(_) => "Delay",
             CoreNode::MonthlyVirtualStorage(_) => "MonthlyVirtualStorage",
         }
@@ -161,6 +165,7 @@ impl CoreNode {
             CoreNode::VirtualStorage(n) => &n.meta,
             CoreNode::AnnualVirtualStorage(n) => &n.meta,
             CoreNode::PiecewiseLink(n) => &n.meta,
+            CoreNode::PiecewiseStorage(n) => &n.meta,
             CoreNode::Delay(n) => &n.meta,
             CoreNode::MonthlyVirtualStorage(n) => &n.meta,
         }
@@ -198,6 +203,7 @@ impl CoreNode {
             CoreNode::VirtualStorage(n) => n.add_to_model(model, tables, data_path),
             CoreNode::AnnualVirtualStorage(n) => n.add_to_model(model, tables, data_path),
             CoreNode::PiecewiseLink(n) => n.add_to_model(model),
+            CoreNode::PiecewiseStorage(n) => n.add_to_model(model, tables, data_path),
             CoreNode::Delay(n) => n.add_to_model(model),
             CoreNode::MonthlyVirtualStorage(n) => n.add_to_model(model, tables, data_path),
         }
@@ -225,6 +231,7 @@ impl CoreNode {
             CoreNode::VirtualStorage(_) => Ok(()),    // TODO
             CoreNode::AnnualVirtualStorage(_) => Ok(()), // TODO
             CoreNode::PiecewiseLink(n) => n.set_constraints(model, tables, data_path),
+            CoreNode::PiecewiseStorage(n) => n.set_constraints(model, tables, data_path),
             CoreNode::Delay(n) => n.set_constraints(model, tables),
             CoreNode::MonthlyVirtualStorage(_) => Ok(()), // TODO
         }
@@ -249,6 +256,7 @@ impl CoreNode {
             CoreNode::AnnualVirtualStorage(n) => n.input_connectors(),
             CoreNode::MonthlyVirtualStorage(n) => n.input_connectors(),
             CoreNode::PiecewiseLink(n) => n.input_connectors(),
+            CoreNode::PiecewiseStorage(n) => n.input_connectors(),
             CoreNode::Delay(n) => n.input_connectors(),
         }
     }
@@ -272,6 +280,7 @@ impl CoreNode {
             CoreNode::AnnualVirtualStorage(n) => n.output_connectors(),
             CoreNode::MonthlyVirtualStorage(n) => n.output_connectors(),
             CoreNode::PiecewiseLink(n) => n.output_connectors(),
+            CoreNode::PiecewiseStorage(n) => n.output_connectors(),
             CoreNode::Delay(n) => n.output_connectors(),
         }
     }

--- a/src/schema/nodes/piecewise_storage.rs
+++ b/src/schema/nodes/piecewise_storage.rs
@@ -1,0 +1,229 @@
+use crate::metric::{Metric, VolumeBetweenControlCurves};
+use crate::node::{ConstraintValue, StorageInitialVolume};
+use crate::schema::data_tables::LoadedTableCollection;
+use crate::schema::nodes::NodeMeta;
+use crate::schema::parameters::DynamicFloatValue;
+use crate::PywrError;
+use std::path::Path;
+
+#[derive(serde::Deserialize, serde::Serialize, Clone)]
+pub struct PiecewiseStore {
+    pub control_curve: DynamicFloatValue,
+    pub cost: Option<DynamicFloatValue>,
+}
+
+#[doc = svgbobdoc::transform!(
+/// This node is used to create a series of storage nodes with separate costs.
+///
+/// The series of storage nodes are created with bi-directional transfers to enable transfer
+/// between the layers of storage. This node can be used as a more sophisticated storage
+/// node where it is important for the volume to follow a control curve that separates the
+/// volume into two or more stores (zones). By applying different penalty costs in each store
+/// (zone) the allocation algorithm makes independent decisions regarding the use of each.
+///
+/// Note that this node adds additional complexity to models over the standard storage node.
+///
+/// ```svgbob
+///
+///            <node>.00            D
+///     -*---------->S ----------->*-
+///      U           ^
+///                  |
+///                  v
+///       <node>.01  S
+///                  ^
+///                  :
+///                  v
+///      <node>.n    S
+/// ```
+///
+)]
+#[derive(serde::Deserialize, serde::Serialize, Clone)]
+pub struct PiecewiseStorageNode {
+    #[serde(flatten)]
+    pub meta: NodeMeta,
+    pub max_volume: DynamicFloatValue,
+    // TODO implement min volume
+    // pub min_volume: Option<DynamicFloatValue>,
+    pub steps: Vec<PiecewiseStore>,
+    // TODO implement initial volume
+    // pub initial_volume: Option<f64>,
+    // pub initial_volume_pc: Option<f64>,
+}
+
+impl PiecewiseStorageNode {
+    fn step_sub_name(i: usize) -> Option<String> {
+        Some(format!("store-{i:02}"))
+    }
+
+    pub fn add_to_model(
+        &self,
+        model: &mut crate::model::Model,
+        tables: &LoadedTableCollection,
+        data_path: Option<&Path>,
+    ) -> Result<(), PywrError> {
+        // These are the min and max volume of the overall node
+        let max_volume = self.max_volume.load(model, tables, data_path)?;
+
+        let mut store_node_indices = Vec::new();
+
+        // create a storage node for each step
+        for (i, step) in self.steps.iter().enumerate() {
+            // The volume of this step is the proportion between the last control curve
+            // (or zero if first) and this control curve.
+            let lower = if i > 0 {
+                Some(self.steps[i - 1].control_curve.load(model, tables, data_path)?)
+            } else {
+                None
+            };
+
+            let upper = step.control_curve.load(model, tables, data_path)?;
+
+            let max_volume = ConstraintValue::Metric(Metric::VolumeBetweenControlCurves(
+                VolumeBetweenControlCurves::new(max_volume.clone(), Some(upper), lower),
+            ));
+
+            // Each store has min volume of zero
+            let min_volume = ConstraintValue::Scalar(0.0);
+            // Assume each store is full to start with
+            let initial_volume = StorageInitialVolume::Proportional(1.0);
+
+            let idx = model.add_storage_node(
+                self.meta.name.as_str(),
+                Self::step_sub_name(i).as_deref(),
+                initial_volume,
+                min_volume,
+                max_volume,
+            )?;
+
+            if let Some(prev_idx) = store_node_indices.last() {
+                // There was a lower store; connect to it in both directions
+                model.connect_nodes(idx, *prev_idx)?;
+                model.connect_nodes(*prev_idx, idx)?;
+            }
+
+            store_node_indices.push(idx);
+        }
+
+        // The volume of this store the remain proportion above the last control curve
+        let lower = match self.steps.last() {
+            Some(step) => Some(step.control_curve.load(model, tables, data_path)?),
+            None => None,
+        };
+
+        let upper = None;
+
+        let max_volume = ConstraintValue::Metric(Metric::VolumeBetweenControlCurves(VolumeBetweenControlCurves::new(
+            max_volume.clone(),
+            upper,
+            lower,
+        )));
+
+        // Each store has min volume of zero
+        let min_volume = ConstraintValue::Scalar(0.0);
+        // Assume each store is full to start with
+        let initial_volume = StorageInitialVolume::Proportional(1.0);
+
+        // And one for the residual part above the less step
+        let idx = model.add_storage_node(
+            self.meta.name.as_str(),
+            Self::step_sub_name(self.steps.len()).as_deref(),
+            initial_volume,
+            min_volume,
+            max_volume,
+        )?;
+
+        if let Some(prev_idx) = store_node_indices.last() {
+            // There was a lower store; connect to it in both directions
+            model.connect_nodes(idx, *prev_idx)?;
+            model.connect_nodes(*prev_idx, idx)?;
+        }
+
+        store_node_indices.push(idx);
+
+        // Finally, add an aggregate storage node covering all the individual stores
+        model.add_aggregated_storage_node(self.meta.name.as_str(), None, store_node_indices)?;
+
+        Ok(())
+    }
+
+    pub fn set_constraints(
+        &self,
+        model: &mut crate::model::Model,
+        tables: &LoadedTableCollection,
+        data_path: Option<&Path>,
+    ) -> Result<(), PywrError> {
+        for (i, step) in self.steps.iter().enumerate() {
+            let sub_name = Self::step_sub_name(i);
+
+            if let Some(cost) = &step.cost {
+                let value = cost.load(model, tables, data_path)?;
+                model.set_node_cost(self.meta.name.as_str(), sub_name.as_deref(), value.into())?;
+            }
+        }
+
+        Ok(())
+    }
+
+    pub fn input_connectors(&self) -> Vec<(&str, Option<String>)> {
+        vec![(self.meta.name.as_str(), Self::step_sub_name(self.steps.len()))]
+    }
+    pub fn output_connectors(&self) -> Vec<(&str, Option<String>)> {
+        vec![(self.meta.name.as_str(), Self::step_sub_name(self.steps.len()))]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::metric::Metric;
+    use crate::model::RunOptions;
+    use crate::recorders::AssertionRecorder;
+    use crate::schema::model::PywrModel;
+    use crate::solvers::ClpSolver;
+    use crate::timestep::Timestepper;
+    use ndarray::Array2;
+
+    fn model_str() -> &'static str {
+        include_str!("../test_models/piecewise_storage1.json")
+    }
+
+    /// Test running `piecewise_storage1.json`
+    #[test]
+    fn test_piecewise_storage1() {
+        let data = model_str();
+        let schema: PywrModel = serde_json::from_str(data).unwrap();
+        let (mut model, timestepper): (crate::model::Model, Timestepper) = schema.try_into_model(None).unwrap();
+
+        assert_eq!(model.nodes.len(), 5);
+        assert_eq!(model.edges.len(), 6);
+
+        // TODO put this assertion data in the test model file.
+        let idx = model
+            .get_aggregated_storage_node_index_by_name("storage1", None)
+            .unwrap();
+
+        let expected = Array2::from_shape_fn((366, 1), |(i, j)| {
+            if i < 33 {
+                // Draw-down top store at 15 until it is emptied
+                985.0 - i as f64 * 15.0
+            } else if i < 58 {
+                // The second store activates the input (via costs) such that the net draw down is now 10
+                495.0 - (i as f64 - 33.0) * 10.0
+            } else {
+                // Finally the abstraction stops to maintain the bottom store at 250
+                250.0
+            }
+        });
+
+        let recorder = AssertionRecorder::new(
+            "storage1-volume",
+            Metric::AggregatedNodeVolume(idx),
+            expected,
+            None,
+            None,
+        );
+        model.add_recorder(Box::new(recorder)).unwrap();
+
+        model.run::<ClpSolver>(&timestepper, &RunOptions::default()).unwrap();
+    }
+}

--- a/src/schema/test_models/piecewise_storage1.json
+++ b/src/schema/test_models/piecewise_storage1.json
@@ -1,0 +1,51 @@
+{
+  "metadata": {
+    "title": "PiecewiseStorage 1",
+    "description": "A test of PiecewiseStorageNode.",
+    "minimum_version": "0.1"
+  },
+  "timestepper": {
+    "start": "2015-01-01",
+    "end": "2015-12-31",
+    "timestep": 1
+  },
+  "nodes": [
+    {
+      "name": "input1",
+      "type": "Input",
+      "max_flow": 5,
+      "cost": 2.0
+    },
+    {
+      "name": "storage1",
+      "type": "PiecewiseStorage",
+      "max_volume": 1000.0,
+      "steps": [
+        {
+          "cost": -15.0,
+          "control_curve": 0.25
+        },
+        {
+          "cost": -5.0,
+          "control_curve": 0.5
+        }
+      ]
+    },
+    {
+      "name": "demand1",
+      "type": "Output",
+      "max_flow": 15.0,
+      "cost": -10
+    }
+  ],
+  "edges": [
+    {
+      "from_node": "input1",
+      "to_node": "storage1"
+    },
+    {
+      "from_node": "storage1",
+      "to_node": "demand1"
+    }
+  ]
+}

--- a/src/schema/test_models/piecewise_storage2.json
+++ b/src/schema/test_models/piecewise_storage2.json
@@ -1,0 +1,58 @@
+{
+  "metadata": {
+    "title": "PiecewiseStorage 2",
+    "description": "A test of PiecewiseStorageNode with a monthly profile control curve.",
+    "minimum_version": "0.1"
+  },
+  "timestepper": {
+    "start": "2015-01-01",
+    "end": "2015-12-31",
+    "timestep": 1
+  },
+  "nodes": [
+    {
+      "name": "input1",
+      "type": "Input",
+      "max_flow": 3.0,
+      "cost": 2.0
+    },
+    {
+      "name": "storage1",
+      "type": "PiecewiseStorage",
+      "max_volume": 1000.0,
+      "steps": [
+        {
+          "cost": -15.0,
+          "control_curve": 0.25
+        },
+        {
+          "cost": -5.0,
+          "control_curve": {
+            "type": "InlineParameter",
+            "definition": {
+              "type": "MonthlyProfile",
+              "name": "storage1-control-curve",
+              "values": [0.75, 0.75, 0.75, 0.5, 0.5, 0.5, 0.3, 0.3, 0.3, 0.5, 0.5, 0.5]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "demand1",
+      "type": "Output",
+      "max_flow": 5.0,
+      "cost": -10
+    }
+  ],
+  "edges": [
+    {
+      "from_node": "input1",
+      "to_node": "storage1"
+    },
+    {
+      "from_node": "storage1",
+      "to_node": "demand1"
+    }
+  ]
+}


### PR DESCRIPTION
This is a working prototype of a PiecewiseStorage node that includes multiple internal stores. There is a basic unit test but limited functionality (e.g. no min volume, initial volume, or cost on the upper residual store).