### PR TITLE
Cannot compile polars-core-0.30.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,8 +30,8 @@ highs-sys = {  git = "https://github.com/jetuk/highs-sys", branch="fix-build-lib
 # highs-sys = { path = "../../highs-sys" }
 pyo3 = { version = "0.19.0" }
 rayon = "1.6.1"
-polars = { version = "0.30.0", features = ["lazy", "rows", "ndarray"] }
-pyo3-polars = "0.4.0"
+polars = { version = "0.32.0", features = ["lazy", "rows", "ndarray"] }
+pyo3-polars = "0.6.0"
 pywr-schema = { git = "https://github.com/pywr/pywr-schema/", tag="v0.6.0" }
 rhai = { version="1.12.0", features=["sync"] }
 

--- a/src/schema/parameters/data_frame.rs
+++ b/src/schema/parameters/data_frame.rs
@@ -4,7 +4,7 @@ use crate::schema::parameters::{DynamicFloatValueType, ParameterMeta};
 use crate::{ParameterIndex, PywrError};
 use ndarray::Array2;
 use polars::prelude::DataType::Float64;
-use polars::prelude::{DataFrame, Float64Type};
+use polars::prelude::{DataFrame, Float64Type, IndexOrder};
 use pyo3::prelude::PyModule;
 use pyo3::types::{PyDict, PyTuple};
 use pyo3::{IntoPy, PyErr, PyObject, Python, ToPyObject};
@@ -124,7 +124,7 @@ impl DataFrameParameter {
         match &self.columns {
             DataFrameColumns::Scenario(scenario) => {
                 let scenario_group = model.get_scenario_group_index_by_name(scenario)?;
-                let array: Array2<f64> = df.to_ndarray::<Float64Type>().unwrap();
+                let array: Array2<f64> = df.to_ndarray::<Float64Type>(IndexOrder::default()).unwrap();
                 let p = Array2Parameter::new(&self.meta.name, array, scenario_group);
                 model.add_parameter(Box::new(p))
             }


### PR DESCRIPTION
Hello,

When compiling the `polars-core` crate with `maturin`, the build fails. The problem does not occur after updating to `polars-0.32.0`. 

However the new version changed the signature of `to_ndarray` which is used in the `DataFrameParameter`. The function is now properly called with the `IndexOrder::default()` parameter (Fortran). This is the same behaviour in 0.30.0.