### PR TITLE
feat: Upgrade to pywr-v1-schema v0.8.0.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,4 +45,4 @@ tracing = "0.1"
 csv = "1.1"
 hdf5 = { version="0.8.1" }
 hdf5-sys = { version="0.8.1", features=["static"] }
-pywr-v1-schema = { git = "https://github.com/pywr/pywr-schema/", tag="v0.7.0", package = "pywr-schema" }
+pywr-v1-schema = { git = "https://github.com/pywr/pywr-schema/", tag="v0.8.0", package = "pywr-schema" }

--- a/pywr-core/src/lib.rs
+++ b/pywr-core/src/lib.rs
@@ -3,7 +3,7 @@
 extern crate core;
 
 use crate::node::NodeIndex;
-use crate::parameters::{IndexParameterIndex, MultiValueParameterIndex, ParameterIndex};
+use crate::parameters::{IndexParameterIndex, InterpolationError, MultiValueParameterIndex, ParameterIndex};
 use crate::recorders::RecorderIndex;
 use pyo3::exceptions::{PyException, PyRuntimeError};
 use pyo3::{create_exception, PyErr};
@@ -127,6 +127,8 @@ pub enum PywrError {
     ParameterVariableValuesIncorrectLength,
     #[error("missing solver features")]
     MissingSolverFeatures,
+    #[error("interpolation error: {0}")]
+    Interpolation(#[from] InterpolationError),
 }
 
 // Python errors

--- a/pywr-core/src/parameters/array.rs
+++ b/pywr-core/src/parameters/array.rs
@@ -4,19 +4,21 @@ use crate::scenario::ScenarioIndex;
 use crate::state::State;
 use crate::timestep::Timestep;
 use crate::PywrError;
-use ndarray::{Array1, Array2};
+use ndarray::{Array1, Array2, Axis};
 use std::any::Any;
 
 pub struct Array1Parameter {
     meta: ParameterMeta,
     array: Array1<f64>,
+    timestep_offset: Option<i32>,
 }
 
 impl Array1Parameter {
-    pub fn new(name: &str, array: Array1<f64>) -> Self {
+    pub fn new(name: &str, array: Array1<f64>, timestep_offset: Option<i32>) -> Self {
         Self {
             meta: ParameterMeta::new(name),
             array,
+            timestep_offset,
         }
     }
 }
@@ -36,8 +38,12 @@ impl Parameter for Array1Parameter {
         _state: &State,
         _internal_state: &mut Option<Box<dyn Any + Send>>,
     ) -> Result<f64, PywrError> {
+        let idx = match self.timestep_offset {
+            None => timestep.index,
+            Some(offset) => (timestep.index as i32 + offset).max(0).min(self.array.len() as i32 - 1) as usize,
+        };
         // This panics if out-of-bounds
-        let value = self.array[[timestep.index]];
+        let value = self.array[[idx]];
         Ok(value)
     }
 }
@@ -46,14 +52,16 @@ pub struct Array2Parameter {
     meta: ParameterMeta,
     array: Array2<f64>,
     scenario_group_index: usize,
+    timestep_offset: Option<i32>,
 }
 
 impl Array2Parameter {
-    pub fn new(name: &str, array: Array2<f64>, scenario_group_index: usize) -> Self {
+    pub fn new(name: &str, array: Array2<f64>, scenario_group_index: usize, timestep_offset: Option<i32>) -> Self {
         Self {
             meta: ParameterMeta::new(name),
             array,
             scenario_group_index,
+            timestep_offset,
         }
     }
 }
@@ -75,8 +83,14 @@ impl Parameter for Array2Parameter {
         _internal_state: &mut Option<Box<dyn Any + Send>>,
     ) -> Result<f64, PywrError> {
         // This panics if out-of-bounds
-        let idx = scenario_index.indices[self.scenario_group_index];
+        let t_idx = match self.timestep_offset {
+            None => timestep.index,
+            Some(offset) => (timestep.index as i32 + offset)
+                .max(0)
+                .min(self.array.len_of(Axis(0)) as i32 - 1) as usize,
+        };
+        let s_idx = scenario_index.indices[self.scenario_group_index];
 
-        Ok(self.array[[timestep.index, idx]])
+        Ok(self.array[[t_idx, s_idx]])
     }
 }

--- a/pywr-core/src/parameters/control_curves/interpolated.rs
+++ b/pywr-core/src/parameters/control_curves/interpolated.rs
@@ -1,6 +1,6 @@
-use super::interpolate;
 use crate::metric::Metric;
 use crate::model::Model;
+use crate::parameters::interpolate::interpolate;
 use crate::parameters::{Parameter, ParameterMeta};
 use crate::scenario::ScenarioIndex;
 use crate::state::State;
@@ -8,14 +8,14 @@ use crate::timestep::Timestep;
 use crate::PywrError;
 use std::any::Any;
 
-pub struct InterpolatedParameter {
+pub struct ControlCurveInterpolatedParameter {
     meta: ParameterMeta,
     metric: Metric,
     control_curves: Vec<Metric>,
     values: Vec<Metric>,
 }
 
-impl InterpolatedParameter {
+impl ControlCurveInterpolatedParameter {
     pub fn new(name: &str, metric: Metric, control_curves: Vec<Metric>, values: Vec<Metric>) -> Self {
         Self {
             meta: ParameterMeta::new(name),
@@ -26,7 +26,7 @@ impl InterpolatedParameter {
     }
 }
 
-impl Parameter for InterpolatedParameter {
+impl Parameter for ControlCurveInterpolatedParameter {
     fn as_any_mut(&mut self) -> &mut dyn Any {
         self
     }

--- a/pywr-core/src/parameters/control_curves/mod.rs
+++ b/pywr-core/src/parameters/control_curves/mod.rs
@@ -6,39 +6,6 @@ mod simple;
 
 pub use apportion::ApportionParameter;
 pub use index::ControlCurveIndexParameter;
-pub use interpolated::InterpolatedParameter;
+pub use interpolated::ControlCurveInterpolatedParameter;
 pub use piecewise::PiecewiseInterpolatedParameter;
 pub use simple::ControlCurveParameter;
-
-/// Interpolate
-fn interpolate(value: f64, lower_bound: f64, upper_bound: f64, lower_value: f64, upper_value: f64) -> f64 {
-    if value <= lower_bound {
-        lower_value
-    } else if value >= upper_bound {
-        upper_value
-    } else if (lower_bound - upper_bound).abs() < 1E-6 {
-        lower_value
-    } else {
-        lower_value + (upper_value - lower_value) * (value - lower_bound) / (upper_bound - lower_bound)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use float_cmp::assert_approx_eq;
-
-    #[test]
-    fn test_interpolate() {
-        // Middle of the range
-        assert_approx_eq!(f64, interpolate(0.5, 0.0, 1.0, 0.0, 1.0), 0.5);
-        assert_approx_eq!(f64, interpolate(0.25, 0.0, 1.0, 0.0, 1.0), 0.25);
-        assert_approx_eq!(f64, interpolate(0.75, 0.0, 1.0, 0.0, 1.0), 0.75);
-        // Below bounds; returns lower value
-        assert_approx_eq!(f64, interpolate(-1.0, 0.0, 1.0, 0.0, 1.0), 0.0);
-        // Above bounds; returns upper value
-        assert_approx_eq!(f64, interpolate(2.0, 0.0, 1.0, 0.0, 1.0), 1.0);
-        // Equal bounds; returns lower value
-        assert_approx_eq!(f64, interpolate(0.0, 0.0, 0.0, 0.0, 1.0), 0.0);
-    }
-}

--- a/pywr-core/src/parameters/control_curves/piecewise.rs
+++ b/pywr-core/src/parameters/control_curves/piecewise.rs
@@ -1,6 +1,6 @@
-use super::interpolate;
 use crate::metric::Metric;
 use crate::model::Model;
+use crate::parameters::interpolate::interpolate;
 use crate::parameters::{Parameter, ParameterMeta};
 use crate::scenario::ScenarioIndex;
 use crate::state::State;
@@ -82,7 +82,7 @@ mod test {
         let mut model = simple_model(1);
 
         // Create an artificial volume series to use for the interpolation test
-        let volume = Array1Parameter::new("test-x", Array1::linspace(1.0, 0.0, 21));
+        let volume = Array1Parameter::new("test-x", Array1::linspace(1.0, 0.0, 21), None);
 
         let volume_idx = model.add_parameter(Box::new(volume)).unwrap();
 

--- a/pywr-core/src/parameters/delay.rs
+++ b/pywr-core/src/parameters/delay.rs
@@ -97,7 +97,7 @@ mod test {
 
         // Create an artificial volume series to use for the delay test
         let volumes = Array1::linspace(1.0, 0.0, 21);
-        let volume = Array1Parameter::new("test-x", volumes.clone());
+        let volume = Array1Parameter::new("test-x", volumes.clone(), None);
 
         let volume_idx = model.add_parameter(Box::new(volume)).unwrap();
 

--- a/pywr-core/src/parameters/discount_factor.rs
+++ b/pywr-core/src/parameters/discount_factor.rs
@@ -1,0 +1,86 @@
+use crate::metric::Metric;
+use crate::model::Model;
+use crate::parameters::{Parameter, ParameterMeta};
+use crate::scenario::ScenarioIndex;
+use crate::state::State;
+use crate::timestep::Timestep;
+use crate::PywrError;
+use std::any::Any;
+
+pub struct DiscountFactorParameter {
+    meta: ParameterMeta,
+    discount_rate: Metric,
+    base_year: i32,
+}
+
+impl DiscountFactorParameter {
+    pub fn new(name: &str, discount_rate: Metric, base_year: i32) -> Self {
+        Self {
+            meta: ParameterMeta::new(name),
+            discount_rate,
+            base_year,
+        }
+    }
+}
+
+impl Parameter for DiscountFactorParameter {
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+    fn meta(&self) -> &ParameterMeta {
+        &self.meta
+    }
+    fn compute(
+        &self,
+        timestep: &Timestep,
+        _scenario_index: &ScenarioIndex,
+        model: &Model,
+        state: &State,
+        _internal_state: &mut Option<Box<dyn Any + Send>>,
+    ) -> Result<f64, PywrError> {
+        let year = timestep.date.year() - self.base_year;
+        let rate = self.discount_rate.get_value(model, state)?;
+
+        let factor = 1.0 / (1.0 + rate).powi(year);
+        Ok(factor)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::metric::Metric;
+    use crate::parameters::{Array1Parameter, DiscountFactorParameter};
+    use crate::test_utils::{run_and_assert_parameter, simple_model};
+    use ndarray::{concatenate, s, Array1, Array2, Axis};
+
+    /// Basic functional test of the delay parameter.
+    #[test]
+    fn test_basic() {
+        let mut model = simple_model(1);
+
+        // Create an artificial volume series to use for the delay test
+        let volumes = Array1::linspace(1.0, 0.0, 21);
+        let volume = Array1Parameter::new("test-x", volumes.clone(), None);
+
+        let volume_idx = model.add_parameter(Box::new(volume)).unwrap();
+
+        const DELAY: usize = 3; // 3 time-step delay
+        let parameter = DiscountFactorParameter::new(
+            "test-parameter",
+            Metric::Constant(0.03), // Interpolate with the parameter based values
+            2020,
+        );
+
+        // We should have DELAY number of initial values to start with, and then follow the
+        // values in the `volumes` array.
+        let expected_values: Array1<f64> = [
+            1.0; 21 // initial values
+        ]
+            .to_vec()
+            .into();
+
+        let expected_values: Array2<f64> = expected_values.insert_axis(Axis(1));
+
+        run_and_assert_parameter(&mut model, Box::new(parameter), expected_values, None, Some(1e-12));
+    }
+}

--- a/pywr-core/src/parameters/interpolate.rs
+++ b/pywr-core/src/parameters/interpolate.rs
@@ -1,0 +1,110 @@
+use thiserror::Error;
+
+/// Interpolate a value between two bounds.
+pub fn interpolate(value: f64, lower_bound: f64, upper_bound: f64, lower_value: f64, upper_value: f64) -> f64 {
+    if value <= lower_bound {
+        lower_value
+    } else if value >= upper_bound {
+        upper_value
+    } else if (lower_bound - upper_bound).abs() < 1E-6 {
+        lower_value
+    } else {
+        lower_value + (upper_value - lower_value) * (value - lower_bound) / (upper_bound - lower_bound)
+    }
+}
+
+#[derive(Error, Debug, PartialEq, Eq)]
+pub enum InterpolationError {
+    #[error("At least 2 points are required for interpolation")]
+    InsufficientPoints,
+    #[error("The")]
+    InconsistentPoints,
+    #[error("Value below lower bounds")]
+    BelowLowerBounds,
+    #[error("Value above upper bounds")]
+    AboveUpperBounds,
+    #[error("Points are not strictly monotonic")]
+    NotStrictlyMonotonic,
+}
+
+pub fn linear_interpolation(
+    value: f64,
+    points: &[(f64, f64)],
+    error_on_bounds: bool,
+) -> Result<f64, InterpolationError> {
+    if points.len() < 2 {
+        return Err(InterpolationError::InsufficientPoints);
+    }
+
+    // Handle lower bounds checking
+    if value < points[0].0 {
+        return if error_on_bounds {
+            Err(InterpolationError::BelowLowerBounds)
+        } else {
+            Ok(points[0].1)
+        };
+    }
+
+    for pts in points.windows(2) {
+        let lp = pts[0];
+        let up = pts[1];
+
+        if lp.0 >= up.0 {
+            return Err(InterpolationError::NotStrictlyMonotonic);
+        }
+
+        if value < up.0 {
+            return Ok(interpolate(value, lp.0, up.0, lp.1, up.1));
+        }
+    }
+
+    return if error_on_bounds {
+        Err(InterpolationError::AboveUpperBounds)
+    } else {
+        Ok(points
+            .last()
+            .expect("This should be impossible because fp has been checked for a length of at least 2")
+            .1)
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use float_cmp::assert_approx_eq;
+
+    #[test]
+    fn test_interpolate() {
+        // Middle of the range
+        assert_approx_eq!(f64, interpolate(0.5, 0.0, 1.0, 0.0, 1.0), 0.5);
+        assert_approx_eq!(f64, interpolate(0.25, 0.0, 1.0, 0.0, 1.0), 0.25);
+        assert_approx_eq!(f64, interpolate(0.75, 0.0, 1.0, 0.0, 1.0), 0.75);
+        // Below bounds; returns lower value
+        assert_approx_eq!(f64, interpolate(-1.0, 0.0, 1.0, 0.0, 1.0), 0.0);
+        // Above bounds; returns upper value
+        assert_approx_eq!(f64, interpolate(2.0, 0.0, 1.0, 0.0, 1.0), 1.0);
+        // Equal bounds; returns lower value
+        assert_approx_eq!(f64, interpolate(0.0, 0.0, 0.0, 0.0, 1.0), 0.0);
+    }
+
+    #[test]
+    fn test_linear_interpolation() {
+        let points = vec![(1.0, 3.0), (2.0, 4.5), (3.0, 6.0), (4.0, 7.5), (5.0, 9.0)];
+
+        assert_approx_eq!(f64, linear_interpolation(1.0, &points, true).unwrap(), 3.0);
+        assert_approx_eq!(f64, linear_interpolation(0.5, &points, false).unwrap(), 3.0);
+        assert_approx_eq!(f64, linear_interpolation(2.5, &points, false).unwrap(), 5.25);
+        assert_approx_eq!(f64, linear_interpolation(5.0, &points, false).unwrap(), 9.0);
+        assert_approx_eq!(f64, linear_interpolation(5.5, &points, false).unwrap(), 9.0);
+
+        // Check errors
+        assert!(linear_interpolation(0.0, &points, true).is_err());
+        assert!(linear_interpolation(6.0, &points, true).is_err());
+
+        let not_enough_points = vec![(1.0, 3.0)];
+        assert!(linear_interpolation(1.0, &not_enough_points, true).is_err());
+
+        let non_monotonic_points = vec![(1.0, 3.0), (2.0, 4.5), (2.0, 6.0), (4.0, 7.5), (5.0, 9.0)];
+        assert!(linear_interpolation(1.0, &not_enough_points, true).is_err());
+    }
+}

--- a/pywr-core/src/parameters/interpolated.rs
+++ b/pywr-core/src/parameters/interpolated.rs
@@ -1,0 +1,63 @@
+use crate::metric::Metric;
+use crate::model::Model;
+use crate::parameters::interpolate::linear_interpolation;
+use crate::parameters::{Parameter, ParameterMeta};
+use crate::scenario::ScenarioIndex;
+use crate::state::State;
+use crate::timestep::Timestep;
+use crate::PywrError;
+use std::any::Any;
+
+/// A parameter that interpolates a value to a function with given discrete data points.
+pub struct InterpolatedParameter {
+    meta: ParameterMeta,
+    x: Metric,
+    points: Vec<(Metric, Metric)>,
+    error_on_bounds: bool,
+}
+
+impl InterpolatedParameter {
+    pub fn new(name: &str, x: Metric, points: Vec<(Metric, Metric)>, error_on_bounds: bool) -> Self {
+        Self {
+            meta: ParameterMeta::new(name),
+            x,
+            points,
+            error_on_bounds,
+        }
+    }
+}
+
+impl Parameter for InterpolatedParameter {
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+    fn meta(&self) -> &ParameterMeta {
+        &self.meta
+    }
+    fn compute(
+        &self,
+        _timestep: &Timestep,
+        _scenario_index: &ScenarioIndex,
+        model: &Model,
+        state: &State,
+        _internal_state: &mut Option<Box<dyn Any + Send>>,
+    ) -> Result<f64, PywrError> {
+        // Current value
+        let x = self.x.get_value(model, state)?;
+
+        let points = self
+            .points
+            .iter()
+            .map(|(x, f)| {
+                let xp = x.get_value(model, state)?;
+                let fp = f.get_value(model, state)?;
+
+                Ok::<(f64, f64), PywrError>((xp, fp))
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let f = linear_interpolation(x, &points, self.error_on_bounds)?;
+
+        Ok(f)
+    }
+}

--- a/pywr-core/src/parameters/mod.rs
+++ b/pywr-core/src/parameters/mod.rs
@@ -6,8 +6,11 @@ mod asymmetric;
 mod constant;
 mod control_curves;
 mod delay;
+mod discount_factor;
 mod division;
 mod indexed_array;
+mod interpolate;
+mod interpolated;
 mod max;
 mod min;
 mod negative;
@@ -35,12 +38,15 @@ pub use array::{Array1Parameter, Array2Parameter};
 pub use asymmetric::AsymmetricSwitchIndexParameter;
 pub use constant::ConstantParameter;
 pub use control_curves::{
-    ApportionParameter, ControlCurveIndexParameter, ControlCurveParameter, InterpolatedParameter,
+    ApportionParameter, ControlCurveIndexParameter, ControlCurveInterpolatedParameter, ControlCurveParameter,
     PiecewiseInterpolatedParameter,
 };
 pub use delay::DelayParameter;
+pub use discount_factor::DiscountFactorParameter;
 pub use division::DivisionParameter;
 pub use indexed_array::IndexedArrayParameter;
+pub use interpolate::{interpolate, linear_interpolation, InterpolationError};
+pub use interpolated::InterpolatedParameter;
 pub use max::MaxParameter;
 pub use min::MinParameter;
 pub use negative::NegativeParameter;

--- a/pywr-core/src/test_utils.rs
+++ b/pywr-core/src/test_utils.rs
@@ -38,7 +38,7 @@ pub fn simple_model(num_scenarios: usize) -> Model {
     model.connect_nodes(link_node, output_node).unwrap();
 
     let inflow = Array::from_shape_fn((366, num_scenarios), |(i, j)| 1.0 + i as f64 + j as f64);
-    let inflow = Array2Parameter::new("inflow", inflow, scenario_idx);
+    let inflow = Array2Parameter::new("inflow", inflow, scenario_idx, None);
 
     let inflow = model.add_parameter(Box::new(inflow)).unwrap();
 
@@ -208,7 +208,7 @@ fn make_simple_system<R: Rng>(
     for x in inflow.iter_mut() {
         *x = inflow_distr.sample(rng).max(0.0);
     }
-    let inflow = Array2Parameter::new(&format!("inflow-{suffix}"), inflow, scenario_group_index);
+    let inflow = Array2Parameter::new(&format!("inflow-{suffix}"), inflow, scenario_group_index, None);
     let idx = model.add_parameter(Box::new(inflow))?;
 
     model.set_node_max_flow(

--- a/pywr-schema/src/data_tables/mod.rs
+++ b/pywr-schema/src/data_tables/mod.rs
@@ -1,4 +1,5 @@
 use crate::parameters::TableIndex;
+use crate::ConversionError;
 use pywr_v1_schema::parameters::TableDataRef as TableDataRefV1;
 use std::collections::HashMap;
 use std::fs::File;
@@ -509,13 +510,22 @@ impl TableDataRef {
     }
 }
 
-impl From<TableDataRefV1> for TableDataRef {
-    fn from(v1: TableDataRefV1) -> Self {
-        Self {
+impl TryFrom<TableDataRefV1> for TableDataRef {
+    type Error = ConversionError;
+    fn try_from(v1: TableDataRefV1) -> Result<Self, Self::Error> {
+        let column = match v1.column {
+            None => None,
+            Some(c) => Some(c.try_into()?),
+        };
+        let index = match v1.index {
+            None => None,
+            Some(i) => Some(i.try_into()?),
+        };
+        Ok(Self {
             table: v1.table,
-            column: v1.column.map(|i| i.into()),
-            index: v1.index.map(|i| i.into()),
-        }
+            column,
+            index,
+        })
     }
 }
 

--- a/pywr-schema/src/data_tables/scalar.rs
+++ b/pywr-schema/src/data_tables/scalar.rs
@@ -1,0 +1,242 @@
+use crate::data_tables::{make_path, TableError};
+use crate::parameters::TableIndexEntry;
+use std::collections::HashMap;
+use std::fs::File;
+use std::io::BufReader;
+use std::path::Path;
+use std::str::FromStr;
+
+fn table_index_to_position(key: &TableIndexEntry, keys: &[String]) -> Result<usize, TableError> {
+    match key {
+        TableIndexEntry::Index(idx) => Ok(*idx),
+        TableIndexEntry::Name(name) => keys.iter().position(|k| k == name).ok_or(TableError::EntryNotFound),
+    }
+}
+
+fn table_index_to_str(key: &TableIndexEntry) -> Result<&str, TableError> {
+    match key {
+        TableIndexEntry::Index(_) => Err(TableError::IndexingByPositionNotSupported),
+        TableIndexEntry::Name(name) => Ok(name.as_str()),
+    }
+}
+
+/// A simple table with a string based key for scalar values.
+struct ScalarTableOne<T> {
+    keys: Vec<String>,
+    values: Vec<T>,
+}
+
+impl<T> ScalarTableOne<T>
+where
+    T: Copy,
+{
+    fn get_scalar(&self, index: &TableIndexEntry) -> Result<T, TableError> {
+        let k = table_index_to_position(index, &self.keys)?;
+        self.values.get(k).ok_or(TableError::IndexOutOfBounds(k)).copied()
+    }
+}
+
+/// A simple table with two strings for a key to scalar values.
+struct ScalarTableTwo<T> {
+    index: (Vec<String>, Vec<String>),
+    // Could this be flattened for a small performance gain?
+    values: Vec<Vec<T>>,
+}
+
+impl<T> ScalarTableTwo<T>
+where
+    T: Copy,
+{
+    fn get_scalar(&self, index: &[&TableIndexEntry]) -> Result<T, TableError> {
+        if index.len() == 2 {
+            // I think this copies the strings and is not very efficient.
+            let k0 = table_index_to_position(index[0], &self.index.0)?;
+            let k1 = table_index_to_position(index[1], &self.index.1)?;
+
+            self.values
+                .get(k0)
+                .ok_or(TableError::IndexOutOfBounds(k0))?
+                .get(k1)
+                .ok_or(TableError::IndexOutOfBounds(k1))
+                .copied()
+        } else {
+            Err(TableError::WrongKeySize(2, index.len()))
+        }
+    }
+}
+
+/// A simple table with three strings for a key to scalar values.
+///
+/// This table can not be indexed by position.
+struct ScalarTableThree<T> {
+    values: HashMap<(String, String, String), T>,
+}
+
+impl<T> ScalarTableThree<T>
+where
+    T: Copy,
+{
+    fn get_scalar(&self, index: &[&TableIndexEntry]) -> Result<T, TableError> {
+        if index.len() == 3 {
+            // I think this copies the strings and is not very efficient.
+            let k0 = table_index_to_str(index[0])?;
+            let k1 = table_index_to_str(index[1])?;
+            let k2 = table_index_to_str(index[2])?;
+
+            let k = (k0.to_string(), k1.to_string(), k2.to_string());
+
+            self.values.get(&k).ok_or(TableError::EntryNotFound).copied()
+        } else {
+            Err(TableError::WrongKeySize(3, index.len()))
+        }
+    }
+}
+
+pub enum LoadedScalarTable<T> {
+    One(ScalarTableOne<T>),
+    Two(ScalarTableTwo<T>),
+    Three(ScalarTableThree<T>),
+}
+
+impl<T> LoadedScalarTable<T>
+where
+    T: Copy,
+{
+    fn get_scalar(&self, key: &[&TableIndexEntry]) -> Result<T, TableError> {
+        match self {
+            LoadedScalarTable::One(tbl) => {
+                if key.len() == 1 {
+                    tbl.get_scalar(key[0])
+                } else {
+                    Err(TableError::WrongKeySize(1, key.len()))
+                }
+            }
+            LoadedScalarTable::Two(tbl) => tbl.get_scalar(key),
+            LoadedScalarTable::Three(tbl) => tbl.get_scalar(key),
+        }
+    }
+}
+
+/// Load a CSV file with looks for each rows & columns
+pub fn load_csv_row_col_scalar_table_one<T>(
+    table_path: &Path,
+    data_path: Option<&Path>,
+) -> Result<LoadedScalarTable<T>, TableError>
+where
+    T: FromStr + Copy,
+    TableError: From<T::Err>,
+{
+    let path = make_path(table_path, data_path);
+
+    let file = File::open(path).map_err(|e| TableError::IO(e.to_string()))?;
+    let buf_reader = BufReader::new(file);
+    let mut rdr = csv::Reader::from_reader(buf_reader);
+
+    let col_headers: Vec<String> = rdr
+        .headers()
+        .map_err(|e| TableError::Csv(e.to_string()))?
+        .iter()
+        .skip(1)
+        .map(|s| s.to_string())
+        .collect();
+
+    let mut row_headers: Vec<String> = Vec::new();
+    let values: Vec<Vec<T>> = rdr
+        .records()
+        .map(|result| {
+            // The iterator yields Result<StringRecord, Error>, so we check the
+            // error here.
+            let record = result.map_err(|e| TableError::Csv(e.to_string()))?;
+
+            let key = record.get(0).ok_or(TableError::KeyParse)?.to_string();
+
+            let values: Vec<T> = record.iter().skip(1).map(|v| v.parse()).collect::<Result<_, _>>()?;
+
+            row_headers.push(key.clone());
+
+            Ok(values)
+        })
+        .collect::<Result<Vec<_>, TableError>>()?;
+
+    Ok(LoadedScalarTable::Two(ScalarTableTwo {
+        index: (row_headers, col_headers),
+        values,
+    }))
+}
+
+pub fn load_csv_row_scalar_table_one<T>(
+    table_path: &Path,
+    data_path: Option<&Path>,
+) -> Result<LoadedScalarTable<T>, TableError>
+where
+    T: FromStr + Copy,
+    TableError: From<T::Err>,
+{
+    let path = make_path(table_path, data_path);
+
+    let file = File::open(path.clone()).map_err(|e| TableError::IO(e.to_string()))?;
+    let buf_reader = BufReader::new(file);
+    let mut rdr = csv::Reader::from_reader(buf_reader);
+
+    let (keys, values): (Vec<String>, Vec<T>) = rdr
+        .records()
+        .map(|result| {
+            // The iterator yields Result<StringRecord, Error>, so we check the
+            // error here.
+            let record = result.map_err(|e| TableError::Csv(e.to_string()))?;
+
+            let key = record.get(0).ok_or(TableError::KeyParse)?.to_string();
+
+            let values: Vec<T> = record.iter().skip(1).map(|v| v.parse()).collect::<Result<_, _>>()?;
+
+            if values.len() > 1 {
+                return Err(TableError::TooManyValues(path.clone()));
+            }
+
+            Ok((key, values[0]))
+        })
+        .collect::<Result<Vec<_>, TableError>>()?
+        .into_iter()
+        .unzip();
+
+    Ok(LoadedScalarTable::One(ScalarTableOne { keys, values }))
+}
+
+pub fn load_csv_row2_scalar_table_one<T>(
+    table_path: &Path,
+    data_path: Option<&Path>,
+) -> Result<LoadedScalarTable<T>, TableError>
+where
+    T: FromStr + Copy,
+    TableError: From<T::Err>,
+{
+    let path = make_path(table_path, data_path);
+
+    let file = File::open(path.clone()).map_err(|e| TableError::IO(e.to_string()))?;
+    let buf_reader = BufReader::new(file);
+    let mut rdr = csv::Reader::from_reader(buf_reader);
+
+    let values: HashMap<(String, String), T> = rdr
+        .records()
+        .map(|result| {
+            // The iterator yields Result<StringRecord, Error>, so we check the
+            // error here.
+            let record = result.map_err(|e| TableError::Csv(e.to_string()))?;
+
+            let key = (
+                record.get(0).ok_or(TableError::KeyParse)?.to_string(),
+                record.get(1).ok_or(TableError::KeyParse)?.to_string(),
+            );
+
+            let values: Vec<T> = record.iter().skip(2).map(|v| v.parse()).collect::<Result<_, _>>()?;
+
+            if values.len() > 1 {
+                return Err(TableError::TooManyValues(path.clone()));
+            }
+
+            Ok((key, values[0]))
+        })
+        .collect::<Result<_, TableError>>()?;
+
+    Ok(LoadedScalarTable::Three(ScalarTableThree { values }))
+}

--- a/pywr-schema/src/data_tables/vec.rs
+++ b/pywr-schema/src/data_tables/vec.rs
@@ -1,0 +1,115 @@
+use crate::data_tables::{make_path, TableError};
+use crate::parameters::TableIndexEntry;
+use std::collections::HashMap;
+use std::fs::File;
+use std::io::BufReader;
+use std::path::Path;
+use std::str::FromStr;
+
+pub enum LoadedVecTable<T> {
+    One(HashMap<String, Vec<T>>),
+    Two(HashMap<(String, String), Vec<T>>),
+    Three(HashMap<(String, String, String), Vec<T>>),
+}
+
+impl<T> LoadedVecTable<T>
+where
+    T: Copy,
+{
+    fn get_vec(&self, key: &[&TableIndexEntry]) -> Result<&Vec<T>, TableError> {
+        match self {
+            LoadedVecTable::One(tbl) => {
+                if key.len() == 1 {
+                    tbl.get(key[0]).ok_or(TableError::EntryNotFound)
+                } else {
+                    Err(TableError::WrongKeySize(1, key.len()))
+                }
+            }
+            LoadedVecTable::Two(tbl) => {
+                if key.len() == 2 {
+                    // I think this copies the strings and is not very efficient.
+                    let k = (key[0].to_string(), key[1].to_string());
+                    tbl.get(&k).ok_or(TableError::EntryNotFound)
+                } else {
+                    Err(TableError::WrongKeySize(2, key.len()))
+                }
+            }
+            LoadedVecTable::Three(tbl) => {
+                if key.len() == 3 {
+                    // I think this copies the strings and is not very efficient.
+                    let k = (key[0].to_string(), key[1].to_string(), key[2].to_string());
+                    tbl.get(&k).ok_or(TableError::EntryNotFound)
+                } else {
+                    Err(TableError::WrongKeySize(3, key.len()))
+                }
+            }
+        }
+    }
+}
+
+pub fn load_csv_row_vec_table_one<T>(
+    table_path: &Path,
+    data_path: Option<&Path>,
+) -> Result<LoadedVecTable<T>, TableError>
+where
+    T: FromStr,
+    TableError: From<T::Err>,
+{
+    let path = make_path(table_path, data_path);
+
+    let file = File::open(path).map_err(|e| TableError::IO(e.to_string()))?;
+    let buf_reader = BufReader::new(file);
+    let mut rdr = csv::Reader::from_reader(buf_reader);
+
+    let tbl: HashMap<String, Vec<T>> = rdr
+        .records()
+        .map(|result| {
+            // The iterator yields Result<StringRecord, Error>, so we check the
+            // error here.
+            let record = result.map_err(|e| TableError::Csv(e.to_string()))?;
+
+            let key = record.get(0).ok_or(TableError::KeyParse)?.to_string();
+
+            let values: Vec<T> = record.iter().skip(1).map(|v| v.parse()).collect::<Result<_, _>>()?;
+
+            Ok((key, values))
+        })
+        .collect::<Result<_, TableError>>()?;
+
+    Ok(LoadedVecTable::One(tbl))
+}
+
+pub fn load_csv_row2_vec_table_one<T>(
+    table_path: &Path,
+    data_path: Option<&Path>,
+) -> Result<LoadedVecTable<T>, TableError>
+where
+    T: FromStr,
+    TableError: From<T::Err>,
+{
+    let path = make_path(table_path, data_path);
+
+    let file = File::open(path).map_err(|e| TableError::IO(e.to_string()))?;
+    let buf_reader = BufReader::new(file);
+    let mut rdr = csv::Reader::from_reader(buf_reader);
+
+    let tbl: HashMap<(String, String), Vec<T>> = rdr
+        .records()
+        .map(|result| {
+            // The iterator yields Result<StringRecord, Error>, so we check the
+            // error here.
+            let record = result.map_err(|e| TableError::Csv(e.to_string()))?;
+
+            let key = (
+                record.get(0).ok_or(TableError::KeyParse)?.to_string(),
+                record.get(1).ok_or(TableError::KeyParse)?.to_string(),
+            );
+
+            let values: Vec<T> = record.iter().skip(2).map(|v| v.parse()).collect::<Result<_, _>>()?;
+
+            Ok((key, values))
+        })
+        .collect::<Result<_, TableError>>()?;
+
+    Ok(LoadedVecTable::Two(tbl))
+}

--- a/pywr-schema/src/data_tables/vec.rs
+++ b/pywr-schema/src/data_tables/vec.rs
@@ -1,5 +1,4 @@
 use crate::data_tables::{make_path, TableError};
-use crate::parameters::TableIndexEntry;
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::BufReader;
@@ -16,7 +15,7 @@ impl<T> LoadedVecTable<T>
 where
     T: Copy,
 {
-    fn get_vec(&self, key: &[&TableIndexEntry]) -> Result<&Vec<T>, TableError> {
+    pub fn get_vec(&self, key: &[&str]) -> Result<&Vec<T>, TableError> {
         match self {
             LoadedVecTable::One(tbl) => {
                 if key.len() == 1 {

--- a/pywr-schema/src/error.rs
+++ b/pywr-schema/src/error.rs
@@ -39,6 +39,8 @@ pub enum SchemaError {
     CSVError(String),
     #[error("unexpected parameter type: {0}")]
     UnexpectedParameterType(String),
+    #[error("mismatch in the length of data provided. expected: {expected}, found: {found}")]
+    DataLengthMismatch { expected: usize, found: usize },
 }
 
 impl From<SchemaError> for PyErr {
@@ -69,4 +71,12 @@ pub enum ConversionError {
     ExtraNodeAttribute { attr: String, name: String },
     #[error("Custom node of type {ty:?} on node {name:?} is not supported .")]
     CustomNodeNotSupported { ty: String, name: String },
+    #[error("Integer table indices are not supported.")]
+    IntegerTableIndicesNotSupported,
+    #[error("Conversion of one of the following attributes {attrs:?} is not supported on parameter {name:?}.")]
+    UnsupportedAttribute { attrs: Vec<String>, name: String },
+    #[error("Conversion of one of the following feature is not supported on parameter {name:?}: {feature}")]
+    UnsupportedFeature { feature: String, name: String },
+    #[error("Parameter {name:?} of type `{ty:?}` are not supported in Pywr v2. {instead:?}")]
+    DeprecatedParameter { ty: String, name: String, instead: String },
 }

--- a/pywr-schema/src/model.rs
+++ b/pywr-schema/src/model.rs
@@ -22,7 +22,9 @@ impl TryFrom<pywr_v1_schema::model::Metadata> for Metadata {
 
     fn try_from(v1: pywr_v1_schema::model::Metadata) -> Result<Self, Self::Error> {
         Ok(Self {
-            title: v1.title,
+            title: v1
+                .title
+                .unwrap_or("Model converted from Pywr v1.x with no title.".to_string()),
             description: v1.description,
             minimum_version: v1.minimum_version,
         })

--- a/pywr-schema/src/parameters/control_curves.rs
+++ b/pywr-schema/src/parameters/control_curves.rs
@@ -56,7 +56,12 @@ impl ControlCurveInterpolatedParameter {
             .map(|val| val.load(model, tables, data_path))
             .collect::<Result<_, _>>()?;
 
-        let p = pywr_core::parameters::InterpolatedParameter::new(&self.meta.name, metric, control_curves, values);
+        let p = pywr_core::parameters::ControlCurveInterpolatedParameter::new(
+            &self.meta.name,
+            metric,
+            control_curves,
+            values,
+        );
         Ok(model.add_parameter(Box::new(p))?)
     }
 }
@@ -85,7 +90,26 @@ impl TryFromV1Parameter<ControlCurveInterpolatedParameterV1> for ControlCurveInt
             });
         };
 
-        let values = v1.values.into_iter().map(DynamicFloatValue::from_f64).collect();
+        // Handle the case where neither or both "values" and "parameters" are defined.
+        let values = match (v1.values, v1.parameters) {
+            (None, None) => {
+                return Err(ConversionError::MissingAttribute {
+                    name: meta.name,
+                    attrs: vec!["values".to_string(), "parameters".to_string()],
+                });
+            }
+            (Some(_), Some(_)) => {
+                return Err(ConversionError::UnexpectedAttribute {
+                    name: meta.name,
+                    attrs: vec!["values".to_string(), "parameters".to_string()],
+                });
+            }
+            (Some(values), None) => values.into_iter().map(DynamicFloatValue::from_f64).collect(),
+            (None, Some(parameters)) => parameters
+                .into_iter()
+                .map(|p| p.try_into_v2_parameter(Some(&meta.name), unnamed_count))
+                .collect::<Result<Vec<_>, _>>()?,
+        };
 
         let p = Self {
             meta,
@@ -388,7 +412,7 @@ impl TryFromV1Parameter<ControlCurvePiecewiseInterpolatedParameterV1> for Contro
             control_curves,
             storage_node: v1.storage_node,
             values: v1.values,
-            minimum: Some(v1.minimum),
+            minimum: v1.minimum,
             maximum: None,
         };
         Ok(p)

--- a/pywr-schema/src/parameters/core.rs
+++ b/pywr-schema/src/parameters/core.rs
@@ -195,7 +195,7 @@ impl TryFromV1Parameter<ConstantParameterV1> for ConstantParameter {
         let value = if let Some(v) = v1.value {
             ConstantValue::Literal(v)
         } else if let Some(tbl) = v1.table {
-            ConstantValue::Table(tbl.into())
+            ConstantValue::Table(tbl.try_into()?)
         } else {
             ConstantValue::Literal(0.0)
         };

--- a/pywr-schema/src/parameters/discount_factor.rs
+++ b/pywr-schema/src/parameters/discount_factor.rs
@@ -1,0 +1,61 @@
+use crate::data_tables::LoadedTableCollection;
+use crate::error::SchemaError;
+use crate::parameters::{DynamicFloatValue, DynamicFloatValueType, IntoV2Parameter, ParameterMeta, TryFromV1Parameter};
+use crate::ConversionError;
+use pywr_core::parameters::ParameterIndex;
+use pywr_v1_schema::parameters::DiscountFactorParameter as DiscountFactorParameterV1;
+use std::collections::HashMap;
+use std::path::Path;
+
+/// A parameter that returns the current discount factor for a given time-step.
+#[derive(serde::Deserialize, serde::Serialize, Debug, Clone)]
+pub struct DiscountFactorParameter {
+    #[serde(flatten)]
+    pub meta: ParameterMeta,
+    pub discount_rate: DynamicFloatValue,
+    pub base_year: i32,
+}
+
+impl DiscountFactorParameter {
+    pub fn node_references(&self) -> HashMap<&str, &str> {
+        HashMap::new()
+    }
+
+    pub fn parameters(&self) -> HashMap<&str, DynamicFloatValueType> {
+        let mut attributes = HashMap::new();
+
+        let metric = &self.discount_rate;
+        attributes.insert("discount_rate", metric.into());
+
+        attributes
+    }
+
+    pub fn add_to_model(
+        &self,
+        model: &mut pywr_core::model::Model,
+        tables: &LoadedTableCollection,
+        data_path: Option<&Path>,
+    ) -> Result<ParameterIndex, SchemaError> {
+        let discount_rate = self.discount_rate.load(model, tables, data_path)?;
+        let p = pywr_core::parameters::DiscountFactorParameter::new(&self.meta.name, discount_rate, self.base_year);
+        Ok(model.add_parameter(Box::new(p))?)
+    }
+}
+
+impl TryFromV1Parameter<DiscountFactorParameterV1> for DiscountFactorParameter {
+    type Error = ConversionError;
+
+    fn try_from_v1_parameter(
+        v1: DiscountFactorParameterV1,
+        parent_node: Option<&str>,
+        unnamed_count: &mut usize,
+    ) -> Result<Self, Self::Error> {
+        let meta: ParameterMeta = v1.meta.into_v2_parameter(parent_node, unnamed_count);
+        let discount_rate = DynamicFloatValue::from_f64(v1.rate);
+        Ok(Self {
+            meta,
+            discount_rate,
+            base_year: v1.base_year as i32,
+        })
+    }
+}

--- a/pywr-schema/src/parameters/interpolated.rs
+++ b/pywr-schema/src/parameters/interpolated.rs
@@ -1,0 +1,218 @@
+use crate::data_tables::LoadedTableCollection;
+use crate::error::SchemaError;
+use crate::parameters::{
+    DynamicFloatValue, DynamicFloatValueType, IntoV2Parameter, MetricFloatValue, NodeReference, ParameterMeta,
+    TryFromV1Parameter, TryIntoV2Parameter,
+};
+use crate::ConversionError;
+use pywr_core::parameters::ParameterIndex;
+use pywr_v1_schema::parameters::{
+    InterpolatedFlowParameter as InterpolatedFlowParameterV1,
+    InterpolatedVolumeParameter as InterpolatedVolumeParameterV1,
+};
+use std::collections::HashMap;
+use std::path::Path;
+
+/// A parameter that interpolates a value to a function with given discrete data points.
+///
+/// Internally this is implemented as a piecewise linear interpolation via
+/// [`pywr_core::parameters::InterpolatedParameter`].
+#[derive(serde::Deserialize, serde::Serialize, Debug, Clone)]
+pub struct InterpolatedParameter {
+    #[serde(flatten)]
+    pub meta: ParameterMeta,
+    pub x: DynamicFloatValue,
+    pub xp: Vec<DynamicFloatValue>,
+    pub fp: Vec<DynamicFloatValue>,
+    /// If not given or true, raise an error if the x value is outside the range of the data points.
+    pub error_on_bounds: Option<bool>,
+}
+
+impl InterpolatedParameter {
+    pub fn node_references(&self) -> HashMap<&str, &str> {
+        HashMap::new()
+    }
+
+    pub fn parameters(&self) -> HashMap<&str, DynamicFloatValueType> {
+        let mut attributes = HashMap::new();
+
+        let x = &self.x;
+        attributes.insert("x", x.into());
+
+        let xp = &self.xp;
+        attributes.insert("xp", xp.into());
+
+        let fp = &self.fp;
+        attributes.insert("fp", fp.into());
+
+        attributes
+    }
+
+    pub fn add_to_model(
+        &self,
+        model: &mut pywr_core::model::Model,
+        tables: &LoadedTableCollection,
+        data_path: Option<&Path>,
+    ) -> Result<ParameterIndex, SchemaError> {
+        let x = self.x.load(model, tables, data_path)?;
+
+        // Sense check the points
+        if self.xp.len() != self.fp.len() {
+            return Err(SchemaError::DataLengthMismatch {
+                expected: self.xp.len(),
+                found: self.fp.len(),
+            });
+        }
+
+        let xp = self
+            .xp
+            .iter()
+            .map(|p| p.load(model, tables, data_path))
+            .collect::<Result<Vec<_>, _>>()?;
+        let fp = self
+            .fp
+            .iter()
+            .map(|p| p.load(model, tables, data_path))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let points = xp
+            .into_iter()
+            .zip(fp.into_iter())
+            .map(|(xp, fp)| (xp, fp))
+            .collect::<Vec<_>>();
+
+        let p = pywr_core::parameters::InterpolatedParameter::new(
+            &self.meta.name,
+            x,
+            points,
+            self.error_on_bounds.unwrap_or(true),
+        );
+        Ok(model.add_parameter(Box::new(p))?)
+    }
+}
+
+impl TryFromV1Parameter<InterpolatedFlowParameterV1> for InterpolatedParameter {
+    type Error = ConversionError;
+
+    fn try_from_v1_parameter(
+        v1: InterpolatedFlowParameterV1,
+        parent_node: Option<&str>,
+        unnamed_count: &mut usize,
+    ) -> Result<Self, Self::Error> {
+        let meta: ParameterMeta = v1.meta.into_v2_parameter(parent_node, unnamed_count);
+
+        // Convert the node reference to a metric
+        let node_ref = NodeReference {
+            name: v1.node,
+            sub_name: None,
+        };
+        // This defaults to the node's inflow; not sure if we can do better than that.
+        let x = DynamicFloatValue::Dynamic(MetricFloatValue::NodeInFlow(node_ref));
+
+        let xp = v1
+            .flows
+            .into_iter()
+            .map(|p| p.try_into_v2_parameter(Some(&meta.name), unnamed_count))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let fp = v1
+            .values
+            .into_iter()
+            .map(|p| p.try_into_v2_parameter(Some(&meta.name), unnamed_count))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        // Default values
+        let mut error_on_bounds = None;
+        if let Some(interp_kwargs) = v1.interp_kwargs {
+            if let Some(error_on_bounds_value) = interp_kwargs.get("bounds_error") {
+                // Try to get the value as a boolean;
+                if let Some(eob) = error_on_bounds_value.as_bool() {
+                    error_on_bounds = Some(eob);
+                }
+            }
+
+            // Check if non-linear interpolation is requested; this is not supported at the moment.
+            if let Some(kind) = interp_kwargs.get("kind") {
+                if let Some(kind_str) = kind.as_str() {
+                    if kind_str != "linear" {
+                        return Err(ConversionError::UnsupportedFeature {
+                            feature: "Interpolation with `kind` other than `linear` is not supported.".to_string(),
+                            name: meta.name.clone(),
+                        });
+                    }
+                }
+            }
+        }
+
+        Ok(Self {
+            meta,
+            x,
+            xp,
+            fp,
+            error_on_bounds,
+        })
+    }
+}
+
+impl TryFromV1Parameter<InterpolatedVolumeParameterV1> for InterpolatedParameter {
+    type Error = ConversionError;
+
+    fn try_from_v1_parameter(
+        v1: InterpolatedVolumeParameterV1,
+        parent_node: Option<&str>,
+        unnamed_count: &mut usize,
+    ) -> Result<Self, Self::Error> {
+        let meta: ParameterMeta = v1.meta.into_v2_parameter(parent_node, unnamed_count);
+
+        // Convert the node reference to a metric
+        let node_ref = NodeReference {
+            name: v1.node,
+            sub_name: None,
+        };
+        // This defaults to the node's inflow; not sure if we can do better than that.
+        let x = DynamicFloatValue::Dynamic(MetricFloatValue::NodeVolume(node_ref));
+
+        let xp = v1
+            .volumes
+            .into_iter()
+            .map(|p| p.try_into_v2_parameter(Some(&meta.name), unnamed_count))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let fp = v1
+            .values
+            .into_iter()
+            .map(|p| p.try_into_v2_parameter(Some(&meta.name), unnamed_count))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        // Default values
+        let mut error_on_bounds = None;
+        if let Some(interp_kwargs) = v1.interp_kwargs {
+            if let Some(error_on_bounds_value) = interp_kwargs.get("bounds_error") {
+                // Try to get the value as a boolean;
+                if let Some(eob) = error_on_bounds_value.as_bool() {
+                    error_on_bounds = Some(eob);
+                }
+            }
+
+            // Check if non-linear interpolation is requested; this is not supported at the moment.
+            if let Some(kind) = interp_kwargs.get("kind") {
+                if let Some(kind_str) = kind.as_str() {
+                    if kind_str != "linear" {
+                        return Err(ConversionError::UnsupportedFeature {
+                            feature: "Interpolation with `kind` other than `linear` is not supported.".to_string(),
+                            name: meta.name.clone(),
+                        });
+                    }
+                }
+            }
+        }
+
+        Ok(Self {
+            meta,
+            x,
+            xp,
+            fp,
+            error_on_bounds,
+        })
+    }
+}

--- a/pywr-schema/src/parameters/mod.rs
+++ b/pywr-schema/src/parameters/mod.rs
@@ -13,7 +13,9 @@ mod control_curves;
 mod core;
 mod data_frame;
 mod delay;
+mod discount_factor;
 mod indexed_array;
+mod interpolated;
 mod offset;
 mod polynomial;
 mod profiles;
@@ -32,6 +34,7 @@ pub use super::parameters::core::{
     ActivationFunction, ConstantParameter, MaxParameter, MinParameter, NegativeParameter, VariableSettings,
 };
 pub use super::parameters::delay::DelayParameter;
+pub use super::parameters::discount_factor::DiscountFactorParameter;
 pub use super::parameters::indexed_array::IndexedArrayParameter;
 pub use super::parameters::polynomial::Polynomial1DParameter;
 pub use super::parameters::profiles::{
@@ -43,16 +46,17 @@ pub use super::parameters::thresholds::ParameterThresholdParameter;
 use crate::error::{ConversionError, SchemaError};
 use crate::parameters::core::DivisionParameter;
 pub use crate::parameters::data_frame::DataFrameParameter;
+use crate::parameters::interpolated::InterpolatedParameter;
 pub use offset::OffsetParameter;
 use pywr_core::metric::Metric;
 use pywr_core::node::NodeIndex;
 use pywr_core::parameters::{IndexParameterIndex, IndexValue, ParameterType};
 use pywr_v1_schema::parameters::{
     CoreParameter, ExternalDataRef as ExternalDataRefV1, Parameter as ParameterV1, ParameterMeta as ParameterMetaV1,
-    ParameterValue as ParameterValueV1, TableIndex as TableIndexV1,
+    ParameterValue as ParameterValueV1, TableIndex as TableIndexV1, TableIndexEntry,
 };
 use std::collections::HashMap;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 #[derive(serde::Deserialize, serde::Serialize, Debug, Clone)]
 pub struct ParameterMeta {
@@ -159,6 +163,8 @@ pub enum Parameter {
     Delay(DelayParameter),
     Division(DivisionParameter),
     Offset(OffsetParameter),
+    DiscountFactor(DiscountFactorParameter),
+    Interpolated(InterpolatedParameter),
 }
 
 impl Parameter {
@@ -187,6 +193,8 @@ impl Parameter {
             Self::Division(p) => p.meta.name.as_str(),
             Self::Delay(p) => p.meta.name.as_str(),
             Self::Offset(p) => p.meta.name.as_str(),
+            Self::DiscountFactor(p) => p.meta.name.as_str(),
+            Self::Interpolated(p) => p.meta.name.as_str(),
         }
     }
 
@@ -217,6 +225,8 @@ impl Parameter {
             Self::Delay(p) => p.node_references(),
             Self::Division(p) => p.node_references(),
             Self::Offset(p) => p.node_references(),
+            Self::DiscountFactor(p) => p.node_references(),
+            Self::Interpolated(p) => p.node_references(),
         }
     }
 
@@ -264,6 +274,8 @@ impl Parameter {
             Self::Delay(_) => "Delay",
             Self::Division(_) => "Division",
             Self::Offset(_) => "Offset",
+            Self::DiscountFactor(_) => "DiscountFactor",
+            Self::Interpolated(_) => "Interpolated",
         }
     }
 
@@ -299,6 +311,8 @@ impl Parameter {
             Self::Delay(p) => ParameterType::Parameter(p.add_to_model(model, tables, data_path)?),
             Self::Division(p) => ParameterType::Parameter(p.add_to_model(model, tables, data_path)?),
             Self::Offset(p) => ParameterType::Parameter(p.add_to_model(model, tables, data_path)?),
+            Self::DiscountFactor(p) => ParameterType::Parameter(p.add_to_model(model, tables, data_path)?),
+            Self::Interpolated(p) => ParameterType::Parameter(p.add_to_model(model, tables, data_path)?),
         };
 
         Ok(ty)
@@ -363,6 +377,42 @@ impl TryFromV1Parameter<ParameterV1> for Parameter {
                 }
                 CoreParameter::Min(p) => Parameter::Min(p.try_into_v2_parameter(parent_node, unnamed_count)?),
                 CoreParameter::Division(p) => Parameter::Division(p.try_into_v2_parameter(parent_node, unnamed_count)?),
+                CoreParameter::DataFrame(p) => {
+                    Parameter::DataFrame(p.try_into_v2_parameter(parent_node, unnamed_count)?)
+                }
+                CoreParameter::Deficit(p) => {
+                    return Err(ConversionError::DeprecatedParameter {
+                        ty: "DeficitParameter".to_string(),
+                        name: p.meta.map(|m| m.name).flatten().unwrap_or("unnamed".to_string()),
+                        instead: "Use a derived metric instead.".to_string(),
+                    })
+                }
+                CoreParameter::DiscountFactor(p) => {
+                    Parameter::DiscountFactor(p.try_into_v2_parameter(parent_node, unnamed_count)?)
+                }
+                CoreParameter::InterpolatedVolume(p) => {
+                    Parameter::Interpolated(p.try_into_v2_parameter(parent_node, unnamed_count)?)
+                }
+                CoreParameter::InterpolatedFlow(p) => {
+                    Parameter::Interpolated(p.try_into_v2_parameter(parent_node, unnamed_count)?)
+                }
+                CoreParameter::HydropowerTarget(_) => todo!("Implement HydropowerTargetParameter"),
+                CoreParameter::Storage(p) => {
+                    return Err(ConversionError::DeprecatedParameter {
+                        ty: "StorageParameter".to_string(),
+                        name: p.meta.map(|m| m.name).flatten().unwrap_or("unnamed".to_string()),
+                        instead: "Use a derived metric instead.".to_string(),
+                    })
+                }
+                CoreParameter::RollingMeanFlowNode(_) => todo!("Implement RollingMeanFlowNodeParameter"),
+                CoreParameter::ScenarioWrapper(_) => todo!("Implement ScenarioWrapperParameter"),
+                CoreParameter::Flow(p) => {
+                    return Err(ConversionError::DeprecatedParameter {
+                        ty: "FlowParameter".to_string(),
+                        name: p.meta.map(|m| m.name).flatten().unwrap_or("unnamed".to_string()),
+                        instead: "Use a derived metric instead.".to_string(),
+                    })
+                }
             },
             ParameterV1::Custom(p) => {
                 println!("Custom parameter: {:?} ({})", p.meta.name, p.ty);
@@ -435,7 +485,7 @@ impl TryFrom<ParameterValueV1> for ConstantValue<f64> {
         match v1 {
             ParameterValueV1::Constant(v) => Ok(Self::Literal(v)),
             ParameterValueV1::Reference(_) => Err(ConversionError::ConstantFloatReferencesParameter),
-            ParameterValueV1::Table(tbl) => Ok(Self::Table(tbl.into())),
+            ParameterValueV1::Table(tbl) => Ok(Self::Table(tbl.try_into()?)),
             ParameterValueV1::Inline(_) => Err(ConversionError::ConstantFloatInlineParameter),
         }
     }
@@ -443,8 +493,8 @@ impl TryFrom<ParameterValueV1> for ConstantValue<f64> {
 
 #[derive(serde::Deserialize, serde::Serialize, Debug, Clone)]
 pub struct NodeReference {
-    name: String,
-    sub_name: Option<String>,
+    pub name: String,
+    pub sub_name: Option<String>,
 }
 
 impl NodeReference {
@@ -620,7 +670,7 @@ impl TryFromV1Parameter<ParameterValueV1> for DynamicFloatValue {
                 name: p_name,
                 key: None,
             }),
-            ParameterValueV1::Table(tbl) => Self::Constant(ConstantValue::Table(tbl.into())),
+            ParameterValueV1::Table(tbl) => Self::Constant(ConstantValue::Table(tbl.try_into()?)),
             ParameterValueV1::Inline(param) => Self::Dynamic(MetricFloatValue::InlineParameter {
                 definition: Box::new((*param).try_into_v2_parameter(parent_node, unnamed_count)?),
             }),
@@ -673,7 +723,7 @@ impl TryFromV1Parameter<ParameterValueV1> for DynamicIndexValue {
             // TODO this could print a warning and do a cast to usize instead.
             ParameterValueV1::Constant(_) => return Err(ConversionError::FloatToIndex),
             ParameterValueV1::Reference(p_name) => Self::Dynamic(ParameterIndexValue::Reference(p_name)),
-            ParameterValueV1::Table(tbl) => Self::Constant(ConstantValue::Table(tbl.into())),
+            ParameterValueV1::Table(tbl) => Self::Constant(ConstantValue::Table(tbl.try_into()?)),
             ParameterValueV1::Inline(param) => Self::Dynamic(ParameterIndexValue::Inline(Box::new(
                 (*param).try_into_v2_parameter(parent_node, unnamed_count)?,
             ))),
@@ -706,18 +756,27 @@ impl ConstantFloatVec {
 
 #[derive(serde::Deserialize, serde::Serialize, Debug, Clone)]
 pub struct ExternalDataRef {
-    url: String,
+    url: PathBuf,
     column: Option<TableIndex>,
     index: Option<TableIndex>,
 }
 
-impl From<ExternalDataRefV1> for ExternalDataRef {
-    fn from(v1: ExternalDataRefV1) -> Self {
-        Self {
+impl TryFrom<ExternalDataRefV1> for ExternalDataRef {
+    type Error = ConversionError;
+    fn try_from(v1: ExternalDataRefV1) -> Result<Self, Self::Error> {
+        let column = match v1.column {
+            None => None,
+            Some(c) => Some(c.try_into()?),
+        };
+        let index = match v1.index {
+            None => None,
+            Some(i) => Some(i.try_into()?),
+        };
+        Ok(Self {
             url: v1.url,
-            column: v1.column.map(|i| i.into()),
-            index: v1.index.map(|i| i.into()),
-        }
+            column,
+            index,
+        })
     }
 }
 
@@ -728,11 +787,25 @@ pub enum TableIndex {
     Multi(Vec<String>),
 }
 
-impl From<TableIndexV1> for TableIndex {
-    fn from(v1: TableIndexV1) -> Self {
+impl TryFrom<TableIndexV1> for TableIndex {
+    type Error = ConversionError;
+
+    fn try_from(v1: TableIndexV1) -> Result<Self, Self::Error> {
         match v1 {
-            TableIndexV1::Single(s) => Self::Single(s),
-            TableIndexV1::Multi(s) => Self::Multi(s),
+            TableIndexV1::Single(s) => match s {
+                TableIndexEntry::Name(s) => Ok(TableIndex::Single(s)),
+                TableIndexEntry::Index(_) => Err(ConversionError::IntegerTableIndicesNotSupported),
+            },
+            TableIndexV1::Multi(s) => {
+                let names = s
+                    .into_iter()
+                    .map(|e| match e {
+                        TableIndexEntry::Name(s) => Ok(s),
+                        TableIndexEntry::Index(_) => Err(ConversionError::IntegerTableIndicesNotSupported),
+                    })
+                    .collect::<Result<Vec<_>, _>>()?;
+                Ok(Self::Multi(names))
+            }
         }
     }
 }

--- a/pywr-schema/src/parameters/mod.rs
+++ b/pywr-schema/src/parameters/mod.rs
@@ -53,7 +53,7 @@ use pywr_core::node::NodeIndex;
 use pywr_core::parameters::{IndexParameterIndex, IndexValue, ParameterType};
 use pywr_v1_schema::parameters::{
     CoreParameter, ExternalDataRef as ExternalDataRefV1, Parameter as ParameterV1, ParameterMeta as ParameterMetaV1,
-    ParameterValue as ParameterValueV1, TableIndex as TableIndexV1, TableIndexEntry,
+    ParameterValue as ParameterValueV1, TableIndex as TableIndexV1, TableIndexEntry as TableIndexEntryV1,
 };
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -793,15 +793,15 @@ impl TryFrom<TableIndexV1> for TableIndex {
     fn try_from(v1: TableIndexV1) -> Result<Self, Self::Error> {
         match v1 {
             TableIndexV1::Single(s) => match s {
-                TableIndexEntry::Name(s) => Ok(TableIndex::Single(s)),
-                TableIndexEntry::Index(_) => Err(ConversionError::IntegerTableIndicesNotSupported),
+                TableIndexEntryV1::Name(s) => Ok(TableIndex::Single(s)),
+                TableIndexEntryV1::Index(_) => Err(ConversionError::IntegerTableIndicesNotSupported),
             },
             TableIndexV1::Multi(s) => {
                 let names = s
                     .into_iter()
                     .map(|e| match e {
-                        TableIndexEntry::Name(s) => Ok(s),
-                        TableIndexEntry::Index(_) => Err(ConversionError::IntegerTableIndicesNotSupported),
+                        TableIndexEntryV1::Name(s) => Ok(s),
+                        TableIndexEntryV1::Index(_) => Err(ConversionError::IntegerTableIndicesNotSupported),
                     })
                     .collect::<Result<Vec<_>, _>>()?;
                 Ok(Self::Multi(names))

--- a/pywr-schema/src/parameters/profiles.rs
+++ b/pywr-schema/src/parameters/profiles.rs
@@ -50,9 +50,9 @@ impl TryFromV1Parameter<DailyProfileParameterV1> for DailyProfileParameter {
         let values: ConstantFloatVec = if let Some(values) = v1.values {
             ConstantFloatVec::Literal(values)
         } else if let Some(external) = v1.external {
-            ConstantFloatVec::External(external.into())
+            ConstantFloatVec::External(external.try_into()?)
         } else if let Some(table_ref) = v1.table_ref {
-            ConstantFloatVec::Table(table_ref.into())
+            ConstantFloatVec::Table(table_ref.try_into()?)
         } else {
             return Err(ConversionError::MissingAttribute {
                 name: meta.name,
@@ -134,9 +134,9 @@ impl TryFromV1Parameter<MonthlyProfileParameterV1> for MonthlyProfileParameter {
         let values: ConstantFloatVec = if let Some(values) = v1.values {
             ConstantFloatVec::Literal(values.to_vec())
         } else if let Some(external) = v1.external {
-            ConstantFloatVec::External(external.into())
+            ConstantFloatVec::External(external.try_into()?)
         } else if let Some(table_ref) = v1.table_ref {
-            ConstantFloatVec::Table(table_ref.into())
+            ConstantFloatVec::Table(table_ref.try_into()?)
         } else {
             return Err(ConversionError::MissingAttribute {
                 name: meta.name,

--- a/pywr-schema/src/parameters/tables.rs
+++ b/pywr-schema/src/parameters/tables.rs
@@ -16,6 +16,7 @@ pub struct TablesArrayParameter {
     pub scenario: Option<String>,
     pub checksum: Option<HashMap<String, String>>,
     pub url: PathBuf,
+    pub timestep_offset: Option<i32>,
 }
 
 impl TablesArrayParameter {
@@ -60,11 +61,16 @@ impl TablesArrayParameter {
         // 3. Create an ArrayParameter using the loaded array.
         if let Some(scenario) = &self.scenario {
             let scenario_group = model.get_scenario_group_index_by_name(scenario)?;
-            let p = pywr_core::parameters::Array2Parameter::new(&self.meta.name, array, scenario_group);
+            let p = pywr_core::parameters::Array2Parameter::new(
+                &self.meta.name,
+                array,
+                scenario_group,
+                self.timestep_offset,
+            );
             Ok(model.add_parameter(Box::new(p))?)
         } else {
             let array = array.slice_move(s![.., 0]);
-            let p = pywr_core::parameters::Array1Parameter::new(&self.meta.name, array);
+            let p = pywr_core::parameters::Array1Parameter::new(&self.meta.name, array, self.timestep_offset);
             Ok(model.add_parameter(Box::new(p))?)
         }
     }
@@ -85,6 +91,7 @@ impl TryFromV1Parameter<TablesArrayParameterV1> for TablesArrayParameter {
             scenario: v1.scenario,
             checksum: v1.checksum,
             url: v1.url,
+            timestep_offset: None,
         };
         Ok(p)
     }


### PR DESCRIPTION
Required implementing several new parameters:

- InterpolatedParameter
- DiscountFactorParameter
- DataFrameParameter

Conversion from Storage, Deficit and Flow parameters is now returns an error as these should become metrics in pywr-next.

Todos are left for HydropowerTarget, RollingMeanFlowNode and ScenarioWrapper parameter.

Also the control curve interpolated parameter was renamed due to a naming conflict with InterpolatedParameter.