### PR TITLE
feat: Initial implementation of NodeAttribute

### DIFF
--- a/pywr-core/benches/random_models.rs
+++ b/pywr-core/benches/random_models.rs
@@ -20,8 +20,6 @@ use pywr_core::test_utils::make_random_model;
 use rand::SeedableRng;
 use rand_chacha::ChaCha8Rng;
 
-
-
 fn random_benchmark(
     c: &mut Criterion,
     group_name: &str,

--- a/pywr-core/src/metric.rs
+++ b/pywr-core/src/metric.rs
@@ -21,11 +21,8 @@ pub enum Metric {
     ParameterValue(ParameterIndex),
     MultiParameterValue((MultiValueParameterIndex, String)),
     VirtualStorageVolume(VirtualStorageIndex),
-    MultiNodeInFlow {
-        indices: Vec<NodeIndex>,
-        name: String,
-        sub_name: Option<String>,
-    },
+    MultiNodeInFlow { indices: Vec<NodeIndex>, name: String },
+    MultiNodeOutFlow { indices: Vec<NodeIndex>, name: String },
     // TODO implement other MultiNodeXXX variants
     Constant(f64),
     DerivedMetric(DerivedMetricIndex),
@@ -73,6 +70,13 @@ impl Metric {
                 let flow = indices
                     .iter()
                     .map(|idx| state.get_network_state().get_node_in_flow(idx))
+                    .sum::<Result<_, _>>()?;
+                Ok(flow)
+            }
+            Metric::MultiNodeOutFlow { indices, .. } => {
+                let flow = indices
+                    .iter()
+                    .map(|idx| state.get_network_state().get_node_out_flow(idx))
                     .sum::<Result<_, _>>()?;
                 Ok(flow)
             }

--- a/pywr-core/src/parameters/delay.rs
+++ b/pywr-core/src/parameters/delay.rs
@@ -39,7 +39,6 @@ impl Parameter for DelayParameter {
         _timesteps: &[Timestep],
         _scenario_index: &ScenarioIndex,
     ) -> Result<Option<Box<dyn ParameterState>>, PywrError> {
-
         // Internally we need to store a history of previous values
         let memory: VecDeque<f64> = (0..self.delay).map(|_| self.initial_value).collect();
         Ok(Some(Box::new(memory)))

--- a/pywr-core/src/recorders/csv.rs
+++ b/pywr-core/src/recorders/csv.rs
@@ -109,11 +109,8 @@ impl Recorder for CSVRecorder {
 
                     (name.to_string(), sub_name, "outflow".to_string())
                 }
-                Metric::MultiNodeInFlow { name, sub_name, .. } => (
-                    name.to_string(),
-                    sub_name.clone().unwrap_or("".to_string()),
-                    "inflow".to_string(),
-                ),
+                Metric::MultiNodeInFlow { name, .. } => (name.to_string(), "".to_string(), "inflow".to_string()),
+                Metric::MultiNodeOutFlow { name, .. } => (name.to_string(), "".to_string(), "outflow".to_string()),
                 Metric::InterNetworkTransfer(_) => {
                     continue; // TODO
                 }

--- a/pywr-core/src/recorders/hdf.rs
+++ b/pywr-core/src/recorders/hdf.rs
@@ -123,9 +123,8 @@ impl Recorder for HDF5Recorder {
                     let node = model.get_aggregated_node(idx)?;
                     require_node_dataset(root_grp, shape, node.name(), node.sub_name(), "outflow")?
                 }
-                Metric::MultiNodeInFlow { name, sub_name, .. } => {
-                    require_node_dataset(root_grp, shape, name, sub_name.as_deref(), "inflow")?
-                }
+                Metric::MultiNodeInFlow { name, .. } => require_node_dataset(root_grp, shape, name, None, "inflow")?,
+                Metric::MultiNodeOutFlow { name, .. } => require_node_dataset(root_grp, shape, name, None, "outflow")?,
                 Metric::InterNetworkTransfer(_) => {
                     continue; // TODO
                 }

--- a/pywr-schema/src/error.rs
+++ b/pywr-schema/src/error.rs
@@ -12,8 +12,12 @@ pub enum SchemaError {
     Json(#[from] serde_json::Error),
     #[error("node with name {0} not found")]
     NodeNotFound(String),
-    #[error("node with name {name} does not support attribute {attr}")]
-    NodeAttributeNotSupported { name: String, attr: NodeAttribute },
+    #[error("node ({ty}) with name {name} does not support attribute {attr}")]
+    NodeAttributeNotSupported {
+        ty: String,
+        name: String,
+        attr: NodeAttribute,
+    },
     #[error("parameter {0} not found")]
     ParameterNotFound(String),
     #[error("network {0} not found")]

--- a/pywr-schema/src/error.rs
+++ b/pywr-schema/src/error.rs
@@ -1,4 +1,5 @@
 use crate::data_tables::TableError;
+use crate::nodes::NodeAttribute;
 use pyo3::exceptions::PyRuntimeError;
 use pyo3::PyErr;
 use thiserror::Error;
@@ -11,6 +12,8 @@ pub enum SchemaError {
     Json(#[from] serde_json::Error),
     #[error("node with name {0} not found")]
     NodeNotFound(String),
+    #[error("node with name {name} does not support attribute {attr}")]
+    NodeAttributeNotSupported { name: String, attr: NodeAttribute },
     #[error("parameter {0} not found")]
     ParameterNotFound(String),
     #[error("network {0} not found")]

--- a/pywr-schema/src/metric_sets/mod.rs
+++ b/pywr-schema/src/metric_sets/mod.rs
@@ -13,7 +13,7 @@ pub enum OutputMetric {
 impl OutputMetric {
     fn try_clone_into_metric(
         &self,
-        network: &pywr_core::network::Network,
+        network: &mut pywr_core::network::Network,
         schema: &PywrNetwork,
     ) -> Result<pywr_core::metric::Metric, SchemaError> {
         match self {
@@ -23,7 +23,7 @@ impl OutputMetric {
                     .get_node_by_name(node_name)
                     .ok_or_else(|| SchemaError::NodeNotFound(node_name.to_string()))?;
                 // Create and return the node's default metric
-                node.default_metric(network)
+                node.create_metric(network, None)
             }
         }
     }

--- a/pywr-schema/src/model.rs
+++ b/pywr-schema/src/model.rs
@@ -85,7 +85,7 @@ pub struct Scenario {
     pub ensemble_names: Option<Vec<String>>,
 }
 
-#[derive(serde::Deserialize, serde::Serialize, Clone)]
+#[derive(serde::Deserialize, serde::Serialize, Clone, Default)]
 pub struct PywrNetwork {
     pub nodes: Vec<Node>,
     pub edges: Vec<Edge>,
@@ -146,7 +146,14 @@ impl PywrNetwork {
             let mut failed_nodes: Vec<Node> = Vec::new();
             let n = remaining_nodes.len();
             for node in remaining_nodes.into_iter() {
-                if let Err(e) = node.add_to_model(&mut network, &domain, &tables, data_path, inter_network_transfers) {
+                if let Err(e) = node.add_to_model(
+                    &mut network,
+                    &self,
+                    &domain,
+                    &tables,
+                    data_path,
+                    inter_network_transfers,
+                ) {
                     // Adding the node failed!
                     match e {
                         SchemaError::PywrCore(core_err) => match core_err {
@@ -197,9 +204,14 @@ impl PywrNetwork {
                 let mut failed_parameters: Vec<Parameter> = Vec::new();
                 let n = remaining_parameters.len();
                 for parameter in remaining_parameters.into_iter() {
-                    if let Err(e) =
-                        parameter.add_to_model(&mut network, &domain, &tables, data_path, inter_network_transfers)
-                    {
+                    if let Err(e) = parameter.add_to_model(
+                        &mut network,
+                        &self,
+                        &domain,
+                        &tables,
+                        data_path,
+                        inter_network_transfers,
+                    ) {
                         // Adding the parameter failed!
                         match e {
                             SchemaError::PywrCore(core_err) => match core_err {
@@ -225,7 +237,14 @@ impl PywrNetwork {
 
         // Apply the inline parameters & constraints to the nodes
         for node in &self.nodes {
-            node.set_constraints(&mut network, &domain, &tables, data_path, inter_network_transfers)?;
+            node.set_constraints(
+                &mut network,
+                &self,
+                &domain,
+                &tables,
+                data_path,
+                inter_network_transfers,
+            )?;
         }
 
         // Create all of the metric sets
@@ -477,6 +496,7 @@ impl PywrMultiNetworkModel {
 
         let domain = ModelDomain::from(timestepper, scenario_collection);
         let mut model = pywr_core::models::MultiNetworkModel::new(domain);
+        let mut schemas = Vec::with_capacity(self.networks.len());
 
         // First load all the networks
         // These will contain any parameters that are referenced by the inter-model transfers
@@ -496,10 +516,24 @@ impl PywrMultiNetworkModel {
                     };
 
                     let network_schema = PywrNetwork::from_path(pth)?;
-                    network_schema.build_network(model.domain(), data_path, output_path, &network_entry.transfers)?
+                    let net = network_schema.build_network(
+                        model.domain(),
+                        data_path,
+                        output_path,
+                        &network_entry.transfers,
+                    )?;
+                    schemas.push(network_schema);
+                    net
                 }
                 PywrNetworkRef::Inline(network_schema) => {
-                    network_schema.build_network(model.domain(), data_path, output_path, &network_entry.transfers)?
+                    let net = network_schema.build_network(
+                        model.domain(),
+                        data_path,
+                        output_path,
+                        &network_entry.transfers,
+                    )?;
+                    schemas.push(network_schema.clone());
+                    net
                 }
             };
 
@@ -514,7 +548,7 @@ impl PywrMultiNetworkModel {
                 // Load the metric from the "from" network
                 let from_network = model.network_mut(from_network_idx)?;
                 // The transfer metric will fail to load if it is defined as an inter-model transfer itself.
-                let from_metric = transfer.metric.load(from_network, &[])?;
+                let from_metric = transfer.metric.load(from_network, &schemas[from_network_idx], &[])?;
 
                 model.add_inter_network_transfer(from_network_idx, from_metric, to_network_idx, transfer.initial_value);
             }

--- a/pywr-schema/src/nodes/annual_virtual_storage.rs
+++ b/pywr-schema/src/nodes/annual_virtual_storage.rs
@@ -135,6 +135,7 @@ impl AnnualVirtualStorageNode {
             }
             _ => {
                 return Err(SchemaError::NodeAttributeNotSupported {
+                    ty: "AnnualVirtualStorageNode".to_string(),
                     name: self.meta.name.clone(),
                     attr,
                 })

--- a/pywr-schema/src/nodes/annual_virtual_storage.rs
+++ b/pywr-schema/src/nodes/annual_virtual_storage.rs
@@ -43,6 +43,8 @@ pub struct AnnualVirtualStorageNode {
 }
 
 impl AnnualVirtualStorageNode {
+    pub const DEFAULT_ATTRIBUTE: NodeAttribute = NodeAttribute::Volume;
+
     pub fn add_to_model(
         &self,
         network: &mut pywr_core::network::Network,
@@ -120,7 +122,7 @@ impl AnnualVirtualStorageNode {
         attribute: Option<NodeAttribute>,
     ) -> Result<Metric, SchemaError> {
         // Use the default attribute if none is specified
-        let attr = attribute.unwrap_or_else(|| self.default_attribute());
+        let attr = attribute.unwrap_or(Self::DEFAULT_ATTRIBUTE);
 
         let idx = network.get_virtual_storage_node_index_by_name(self.meta.name.as_str(), None)?;
 
@@ -140,10 +142,6 @@ impl AnnualVirtualStorageNode {
         };
 
         Ok(metric)
-    }
-
-    pub fn default_attribute(&self) -> NodeAttribute {
-        NodeAttribute::Volume
     }
 }
 

--- a/pywr-schema/src/nodes/annual_virtual_storage.rs
+++ b/pywr-schema/src/nodes/annual_virtual_storage.rs
@@ -1,8 +1,9 @@
 use crate::data_tables::LoadedTableCollection;
 use crate::error::{ConversionError, SchemaError};
 use crate::model::PywrMultiNetworkTransfer;
-use crate::nodes::NodeMeta;
+use crate::nodes::{NodeAttribute, NodeMeta};
 use crate::parameters::{DynamicFloatValue, TryIntoV2Parameter};
+use pywr_core::derived_metric::DerivedMetric;
 use pywr_core::metric::Metric;
 use pywr_core::models::ModelDomain;
 use pywr_core::node::{ConstraintValue, StorageInitialVolume};
@@ -45,6 +46,7 @@ impl AnnualVirtualStorageNode {
     pub fn add_to_model(
         &self,
         network: &mut pywr_core::network::Network,
+        schema: &crate::model::PywrNetwork,
         domain: &ModelDomain,
         tables: &LoadedTableCollection,
         data_path: Option<&Path>,
@@ -60,21 +62,21 @@ impl AnnualVirtualStorageNode {
 
         let cost = match &self.cost {
             Some(v) => v
-                .load(network, domain, tables, data_path, inter_network_transfers)?
+                .load(network, schema, domain, tables, data_path, inter_network_transfers)?
                 .into(),
             None => ConstraintValue::Scalar(0.0),
         };
 
         let min_volume = match &self.min_volume {
             Some(v) => v
-                .load(network, domain, tables, data_path, inter_network_transfers)?
+                .load(network, schema, domain, tables, data_path, inter_network_transfers)?
                 .into(),
             None => ConstraintValue::Scalar(0.0),
         };
 
         let max_volume = match &self.max_volume {
             Some(v) => v
-                .load(network, domain, tables, data_path, inter_network_transfers)?
+                .load(network, schema, domain, tables, data_path, inter_network_transfers)?
                 .into(),
             None => ConstraintValue::None,
         };
@@ -112,9 +114,36 @@ impl AnnualVirtualStorageNode {
         vec![]
     }
 
-    pub fn default_metric(&self, network: &pywr_core::network::Network) -> Result<Metric, SchemaError> {
+    pub fn create_metric(
+        &self,
+        network: &mut pywr_core::network::Network,
+        attribute: Option<NodeAttribute>,
+    ) -> Result<Metric, SchemaError> {
+        // Use the default attribute if none is specified
+        let attr = attribute.unwrap_or_else(|| self.default_attribute());
+
         let idx = network.get_virtual_storage_node_index_by_name(self.meta.name.as_str(), None)?;
-        Ok(Metric::VirtualStorageVolume(idx))
+
+        let metric = match attr {
+            NodeAttribute::Volume => Metric::VirtualStorageVolume(idx),
+            NodeAttribute::ProportionalVolume => {
+                let dm = DerivedMetric::VirtualStorageProportionalVolume(idx);
+                let derived_metric_idx = network.add_derived_metric(dm);
+                Metric::DerivedMetric(derived_metric_idx)
+            }
+            _ => {
+                return Err(SchemaError::NodeAttributeNotSupported {
+                    name: self.meta.name.clone(),
+                    attr,
+                })
+            }
+        };
+
+        Ok(metric)
+    }
+
+    pub fn default_attribute(&self) -> NodeAttribute {
+        NodeAttribute::Volume
     }
 }
 

--- a/pywr-schema/src/nodes/core.rs
+++ b/pywr-schema/src/nodes/core.rs
@@ -95,6 +95,7 @@ impl InputNode {
             NodeAttribute::Outflow => Metric::NodeOutFlow(idx),
             _ => {
                 return Err(SchemaError::NodeAttributeNotSupported {
+                    ty: "InputNode".to_string(),
                     name: self.meta.name.clone(),
                     attr,
                 })
@@ -217,6 +218,7 @@ impl LinkNode {
             NodeAttribute::Inflow => Metric::NodeInFlow(idx),
             _ => {
                 return Err(SchemaError::NodeAttributeNotSupported {
+                    ty: "LinkNode".to_string(),
                     name: self.meta.name.clone(),
                     attr,
                 })
@@ -338,6 +340,7 @@ impl OutputNode {
             NodeAttribute::Inflow => Metric::NodeInFlow(idx),
             _ => {
                 return Err(SchemaError::NodeAttributeNotSupported {
+                    ty: "OutputNode".to_string(),
                     name: self.meta.name.clone(),
                     attr,
                 })
@@ -486,6 +489,7 @@ impl StorageNode {
             }
             _ => {
                 return Err(SchemaError::NodeAttributeNotSupported {
+                    ty: "StorageNode".to_string(),
                     name: self.meta.name.clone(),
                     attr,
                 })
@@ -652,6 +656,7 @@ impl CatchmentNode {
             NodeAttribute::Outflow => Metric::NodeOutFlow(idx),
             _ => {
                 return Err(SchemaError::NodeAttributeNotSupported {
+                    ty: "CatchmentNode".to_string(),
                     name: self.meta.name.clone(),
                     attr,
                 })
@@ -783,6 +788,7 @@ impl AggregatedNode {
             NodeAttribute::Inflow => Metric::AggregatedNodeInFlow(idx),
             _ => {
                 return Err(SchemaError::NodeAttributeNotSupported {
+                    ty: "AggregatedNode".to_string(),
                     name: self.meta.name.clone(),
                     attr,
                 })
@@ -882,6 +888,7 @@ impl AggregatedStorageNode {
             }
             _ => {
                 return Err(SchemaError::NodeAttributeNotSupported {
+                    ty: "AggregatedStorageNode".to_string(),
                     name: self.meta.name.clone(),
                     attr,
                 })

--- a/pywr-schema/src/nodes/core.rs
+++ b/pywr-schema/src/nodes/core.rs
@@ -25,6 +25,8 @@ pub struct InputNode {
 }
 
 impl InputNode {
+    pub const DEFAULT_ATTRIBUTE: NodeAttribute = NodeAttribute::Outflow;
+
     pub fn parameters(&self) -> HashMap<&str, &DynamicFloatValue> {
         let mut attributes = HashMap::new();
         if let Some(p) = &self.max_flow {
@@ -85,7 +87,7 @@ impl InputNode {
         attribute: Option<NodeAttribute>,
     ) -> Result<Metric, SchemaError> {
         // Use the default attribute if none is specified
-        let attr = attribute.unwrap_or_else(|| self.default_attribute());
+        let attr = attribute.unwrap_or(Self::DEFAULT_ATTRIBUTE);
 
         let idx = network.get_node_index_by_name(self.meta.name.as_str(), None)?;
 
@@ -100,10 +102,6 @@ impl InputNode {
         };
 
         Ok(metric)
-    }
-
-    pub fn default_attribute(&self) -> NodeAttribute {
-        NodeAttribute::Outflow
     }
 }
 
@@ -148,6 +146,8 @@ pub struct LinkNode {
 }
 
 impl LinkNode {
+    const DEFAULT_ATTRIBUTE: NodeAttribute = NodeAttribute::Outflow;
+
     pub fn parameters(&self) -> HashMap<&str, &DynamicFloatValue> {
         let mut attributes = HashMap::new();
         if let Some(p) = &self.max_flow {
@@ -208,7 +208,7 @@ impl LinkNode {
         attribute: Option<NodeAttribute>,
     ) -> Result<Metric, SchemaError> {
         // Use the default attribute if none is specified
-        let attr = attribute.unwrap_or_else(|| self.default_attribute());
+        let attr = attribute.unwrap_or(Self::DEFAULT_ATTRIBUTE);
 
         let idx = network.get_node_index_by_name(self.meta.name.as_str(), None)?;
 
@@ -224,10 +224,6 @@ impl LinkNode {
         };
 
         Ok(metric)
-    }
-
-    pub fn default_attribute(&self) -> NodeAttribute {
-        NodeAttribute::Outflow
     }
 }
 
@@ -271,6 +267,8 @@ pub struct OutputNode {
 }
 
 impl OutputNode {
+    const DEFAULT_ATTRIBUTE: NodeAttribute = NodeAttribute::Inflow;
+
     pub fn parameters(&self) -> HashMap<&str, &DynamicFloatValue> {
         let mut attributes = HashMap::new();
         if let Some(p) = &self.max_flow {
@@ -332,7 +330,7 @@ impl OutputNode {
         attribute: Option<NodeAttribute>,
     ) -> Result<Metric, SchemaError> {
         // Use the default attribute if none is specified
-        let attr = attribute.unwrap_or_else(|| self.default_attribute());
+        let attr = attribute.unwrap_or(Self::DEFAULT_ATTRIBUTE);
 
         let idx = network.get_node_index_by_name(self.meta.name.as_str(), None)?;
 
@@ -347,10 +345,6 @@ impl OutputNode {
         };
 
         Ok(metric)
-    }
-
-    pub fn default_attribute(&self) -> NodeAttribute {
-        NodeAttribute::Inflow
     }
 }
 
@@ -396,6 +390,8 @@ pub struct StorageNode {
 }
 
 impl StorageNode {
+    const DEFAULT_ATTRIBUTE: NodeAttribute = NodeAttribute::Volume;
+
     pub fn parameters(&self) -> HashMap<&str, &DynamicFloatValue> {
         let mut attributes = HashMap::new();
         // if let Some(p) = &self.max_volume {
@@ -477,7 +473,7 @@ impl StorageNode {
         attribute: Option<NodeAttribute>,
     ) -> Result<Metric, SchemaError> {
         // Use the default attribute if none is specified
-        let attr = attribute.unwrap_or_else(|| self.default_attribute());
+        let attr = attribute.unwrap_or(Self::DEFAULT_ATTRIBUTE);
 
         let idx = network.get_node_index_by_name(self.meta.name.as_str(), None)?;
 
@@ -497,10 +493,6 @@ impl StorageNode {
         };
 
         Ok(metric)
-    }
-
-    pub fn default_attribute(&self) -> NodeAttribute {
-        NodeAttribute::Volume
     }
 }
 
@@ -608,6 +600,8 @@ pub struct CatchmentNode {
 }
 
 impl CatchmentNode {
+    const DEFAULT_ATTRIBUTE: NodeAttribute = NodeAttribute::Outflow;
+
     pub fn add_to_model(&self, network: &mut pywr_core::network::Network) -> Result<(), SchemaError> {
         network.add_input_node(self.meta.name.as_str(), None)?;
         Ok(())
@@ -650,7 +644,7 @@ impl CatchmentNode {
         attribute: Option<NodeAttribute>,
     ) -> Result<Metric, SchemaError> {
         // Use the default attribute if none is specified
-        let attr = attribute.unwrap_or_else(|| self.default_attribute());
+        let attr = attribute.unwrap_or(Self::DEFAULT_ATTRIBUTE);
 
         let idx = network.get_node_index_by_name(self.meta.name.as_str(), None)?;
 
@@ -665,10 +659,6 @@ impl CatchmentNode {
         };
 
         Ok(metric)
-    }
-
-    pub fn default_attribute(&self) -> NodeAttribute {
-        NodeAttribute::Outflow
     }
 }
 
@@ -711,6 +701,8 @@ pub struct AggregatedNode {
 }
 
 impl AggregatedNode {
+    const DEFAULT_ATTRIBUTE: NodeAttribute = NodeAttribute::Outflow;
+
     pub fn add_to_model(&self, network: &mut pywr_core::network::Network) -> Result<(), SchemaError> {
         let nodes = self
             .nodes
@@ -782,7 +774,7 @@ impl AggregatedNode {
         attribute: Option<NodeAttribute>,
     ) -> Result<Metric, SchemaError> {
         // Use the default attribute if none is specified
-        let attr = attribute.unwrap_or_else(|| self.default_attribute());
+        let attr = attribute.unwrap_or(Self::DEFAULT_ATTRIBUTE);
 
         let idx = network.get_aggregated_node_index_by_name(self.meta.name.as_str(), None)?;
 
@@ -798,10 +790,6 @@ impl AggregatedNode {
         };
 
         Ok(metric)
-    }
-
-    pub fn default_attribute(&self) -> NodeAttribute {
-        NodeAttribute::Outflow
     }
 }
 
@@ -851,6 +839,8 @@ pub struct AggregatedStorageNode {
 }
 
 impl AggregatedStorageNode {
+    const DEFAULT_ATTRIBUTE: NodeAttribute = NodeAttribute::Outflow;
+
     pub fn add_to_model(&self, network: &mut pywr_core::network::Network) -> Result<(), SchemaError> {
         let nodes = self
             .storage_nodes
@@ -879,7 +869,7 @@ impl AggregatedStorageNode {
         attribute: Option<NodeAttribute>,
     ) -> Result<Metric, SchemaError> {
         // Use the default attribute if none is specified
-        let attr = attribute.unwrap_or_else(|| self.default_attribute());
+        let attr = attribute.unwrap_or(Self::DEFAULT_ATTRIBUTE);
 
         let idx = network.get_aggregated_storage_node_index_by_name(self.meta.name.as_str(), None)?;
 
@@ -899,10 +889,6 @@ impl AggregatedStorageNode {
         };
 
         Ok(metric)
-    }
-
-    pub fn default_attribute(&self) -> NodeAttribute {
-        NodeAttribute::Outflow
     }
 }
 

--- a/pywr-schema/src/nodes/delay.rs
+++ b/pywr-schema/src/nodes/delay.rs
@@ -99,6 +99,7 @@ impl DelayNode {
             }
             _ => {
                 return Err(SchemaError::NodeAttributeNotSupported {
+                    ty: "DelayNode".to_string(),
                     name: self.meta.name.clone(),
                     attr,
                 })

--- a/pywr-schema/src/nodes/delay.rs
+++ b/pywr-schema/src/nodes/delay.rs
@@ -33,6 +33,8 @@ pub struct DelayNode {
 }
 
 impl DelayNode {
+    const DEFAULT_ATTRIBUTE: NodeAttribute = NodeAttribute::Outflow;
+
     fn output_sub_name() -> Option<&'static str> {
         Some("inflow")
     }
@@ -84,7 +86,7 @@ impl DelayNode {
         attribute: Option<NodeAttribute>,
     ) -> Result<Metric, SchemaError> {
         // Use the default attribute if none is specified
-        let attr = attribute.unwrap_or_else(|| self.default_attribute());
+        let attr = attribute.unwrap_or(Self::DEFAULT_ATTRIBUTE);
 
         let metric = match attr {
             NodeAttribute::Outflow => {
@@ -104,10 +106,6 @@ impl DelayNode {
         };
 
         Ok(metric)
-    }
-
-    pub fn default_attribute(&self) -> NodeAttribute {
-        NodeAttribute::Outflow
     }
 }
 

--- a/pywr-schema/src/nodes/delay.rs
+++ b/pywr-schema/src/nodes/delay.rs
@@ -1,6 +1,6 @@
 use crate::data_tables::LoadedTableCollection;
 use crate::error::{ConversionError, SchemaError};
-use crate::nodes::NodeMeta;
+use crate::nodes::{NodeAttribute, NodeMeta};
 use crate::parameters::ConstantValue;
 use pywr_core::metric::Metric;
 use pywr_v1_schema::nodes::DelayNode as DelayNodeV1;
@@ -78,9 +78,36 @@ impl DelayNode {
         vec![(self.meta.name.as_str(), Self::input_sub_now().map(|s| s.to_string()))]
     }
 
-    pub fn default_metric(&self, network: &pywr_core::network::Network) -> Result<Metric, SchemaError> {
-        let idx = network.get_node_index_by_name(self.meta.name.as_str(), Self::input_sub_now().as_deref())?;
-        Ok(Metric::NodeOutFlow(idx))
+    pub fn create_metric(
+        &self,
+        network: &pywr_core::network::Network,
+        attribute: Option<NodeAttribute>,
+    ) -> Result<Metric, SchemaError> {
+        // Use the default attribute if none is specified
+        let attr = attribute.unwrap_or_else(|| self.default_attribute());
+
+        let metric = match attr {
+            NodeAttribute::Outflow => {
+                let idx = network.get_node_index_by_name(self.meta.name.as_str(), Self::input_sub_now())?;
+                Metric::NodeOutFlow(idx)
+            }
+            NodeAttribute::Inflow => {
+                let idx = network.get_node_index_by_name(self.meta.name.as_str(), Self::output_sub_name())?;
+                Metric::NodeInFlow(idx)
+            }
+            _ => {
+                return Err(SchemaError::NodeAttributeNotSupported {
+                    name: self.meta.name.clone(),
+                    attr,
+                })
+            }
+        };
+
+        Ok(metric)
+    }
+
+    pub fn default_attribute(&self) -> NodeAttribute {
+        NodeAttribute::Outflow
     }
 }
 

--- a/pywr-schema/src/nodes/loss_link.rs
+++ b/pywr-schema/src/nodes/loss_link.rs
@@ -127,6 +127,7 @@ impl LossLinkNode {
             }
             _ => {
                 return Err(SchemaError::NodeAttributeNotSupported {
+                    ty: "LossLinkNode".to_string(),
                     name: self.meta.name.clone(),
                     attr,
                 })

--- a/pywr-schema/src/nodes/loss_link.rs
+++ b/pywr-schema/src/nodes/loss_link.rs
@@ -36,6 +36,8 @@ pub struct LossLinkNode {
 }
 
 impl LossLinkNode {
+    const DEFAULT_ATTRIBUTE: NodeAttribute = NodeAttribute::Outflow;
+
     fn loss_sub_name() -> Option<&'static str> {
         Some("loss")
     }
@@ -100,7 +102,7 @@ impl LossLinkNode {
         attribute: Option<NodeAttribute>,
     ) -> Result<Metric, SchemaError> {
         // Use the default attribute if none is specified
-        let attr = attribute.unwrap_or_else(|| self.default_attribute());
+        let attr = attribute.unwrap_or(Self::DEFAULT_ATTRIBUTE);
 
         let metric = match attr {
             NodeAttribute::Inflow => {
@@ -132,10 +134,6 @@ impl LossLinkNode {
         };
 
         Ok(metric)
-    }
-
-    pub fn default_attribute(&self) -> NodeAttribute {
-        NodeAttribute::Outflow
     }
 }
 

--- a/pywr-schema/src/nodes/mod.rs
+++ b/pywr-schema/src/nodes/mod.rs
@@ -34,7 +34,7 @@ pub use river_gauge::RiverGaugeNode;
 pub use river_split_with_gauge::RiverSplitWithGaugeNode;
 use std::collections::HashMap;
 use std::path::Path;
-use strum_macros::{Display, EnumString, EnumVariantNames, IntoStaticStr};
+use strum_macros::{Display, EnumDiscriminants, EnumString, EnumVariantNames, IntoStaticStr};
 pub use virtual_storage::VirtualStorageNode;
 pub use water_treatment_works::WaterTreatmentWorks;
 
@@ -74,26 +74,16 @@ impl From<NodeMetaV1> for NodeMeta {
     }
 }
 
-#[derive(Display, IntoStaticStr, EnumString, EnumVariantNames, Copy, Clone)]
-pub enum NodeType {
-    Input,
-    Link,
-    Output,
-    Storage,
-    Catchment,
-    RiverGauge,
-    LossLink,
-    Delay,
-    PiecewiseLink,
-    PiecewiseStorage,
-    River,
-    RiverSplitWithGauge,
-    WaterTreatmentWorks,
-    Aggregated,
-    AggregatedStorage,
-    VirtualStorage,
-    AnnualVirtualStorage,
-    MonthlyVirtualStorage,
+/// All possible attributes that could be produced by a node.
+///
+///
+#[derive(serde::Deserialize, serde::Serialize, Debug, Clone, Copy, Display)]
+pub enum NodeAttribute {
+    Inflow,
+    Outflow,
+    Volume,
+    ProportionalVolume,
+    Loss,
 }
 
 pub struct NodeBuilder {
@@ -223,8 +213,11 @@ impl NodeBuilder {
     }
 }
 
-#[derive(serde::Deserialize, serde::Serialize, Clone)]
+#[derive(serde::Deserialize, serde::Serialize, Clone, EnumDiscriminants)]
 #[serde(tag = "type")]
+#[strum_discriminants(derive(Display, IntoStaticStr, EnumString, EnumVariantNames))]
+// This creates a separate enum called `NodeType` that is available in this module.
+#[strum_discriminants(name(NodeType))]
 pub enum Node {
     Input(InputNode),
     Link(LinkNode),
@@ -256,26 +249,8 @@ impl Node {
     }
 
     pub fn node_type(&self) -> NodeType {
-        match self {
-            Node::Input(_) => NodeType::Input,
-            Node::Link(_) => NodeType::Link,
-            Node::Output(_) => NodeType::Output,
-            Node::Storage(_) => NodeType::Storage,
-            Node::Catchment(_) => NodeType::Catchment,
-            Node::RiverGauge(_) => NodeType::RiverGauge,
-            Node::LossLink(_) => NodeType::LossLink,
-            Node::River(_) => NodeType::River,
-            Node::RiverSplitWithGauge(_) => NodeType::RiverSplitWithGauge,
-            Node::WaterTreatmentWorks(_) => NodeType::WaterTreatmentWorks,
-            Node::Aggregated(_) => NodeType::Aggregated,
-            Node::AggregatedStorage(_) => NodeType::AggregatedStorage,
-            Node::VirtualStorage(_) => NodeType::VirtualStorage,
-            Node::AnnualVirtualStorage(_) => NodeType::AnnualVirtualStorage,
-            Node::PiecewiseLink(_) => NodeType::PiecewiseLink,
-            Node::PiecewiseStorage(_) => NodeType::PiecewiseStorage,
-            Node::Delay(_) => NodeType::Delay,
-            Node::MonthlyVirtualStorage(_) => NodeType::MonthlyVirtualStorage,
-        }
+        // Implementation provided by the `EnumDiscriminants` derive macro.
+        self.into()
     }
 
     pub fn meta(&self) -> &NodeMeta {
@@ -314,6 +289,7 @@ impl Node {
     pub fn add_to_model(
         &self,
         network: &mut pywr_core::network::Network,
+        schema: &PywrNetwork,
         domain: &ModelDomain,
         tables: &LoadedTableCollection,
         data_path: Option<&Path>,
@@ -323,7 +299,7 @@ impl Node {
             Node::Input(n) => n.add_to_model(network),
             Node::Link(n) => n.add_to_model(network),
             Node::Output(n) => n.add_to_model(network),
-            Node::Storage(n) => n.add_to_model(network, domain, tables, data_path, inter_network_transfers),
+            Node::Storage(n) => n.add_to_model(network, schema, domain, tables, data_path, inter_network_transfers),
             Node::Catchment(n) => n.add_to_model(network),
             Node::RiverGauge(n) => n.add_to_model(network),
             Node::LossLink(n) => n.add_to_model(network),
@@ -332,15 +308,19 @@ impl Node {
             Node::WaterTreatmentWorks(n) => n.add_to_model(network),
             Node::Aggregated(n) => n.add_to_model(network),
             Node::AggregatedStorage(n) => n.add_to_model(network),
-            Node::VirtualStorage(n) => n.add_to_model(network, domain, tables, data_path, inter_network_transfers),
+            Node::VirtualStorage(n) => {
+                n.add_to_model(network, schema, domain, tables, data_path, inter_network_transfers)
+            }
             Node::AnnualVirtualStorage(n) => {
-                n.add_to_model(network, domain, tables, data_path, inter_network_transfers)
+                n.add_to_model(network, schema, domain, tables, data_path, inter_network_transfers)
             }
             Node::PiecewiseLink(n) => n.add_to_model(network),
-            Node::PiecewiseStorage(n) => n.add_to_model(network, domain, tables, data_path, inter_network_transfers),
+            Node::PiecewiseStorage(n) => {
+                n.add_to_model(network, schema, domain, tables, data_path, inter_network_transfers)
+            }
             Node::Delay(n) => n.add_to_model(network),
             Node::MonthlyVirtualStorage(n) => {
-                n.add_to_model(network, domain, tables, data_path, inter_network_transfers)
+                n.add_to_model(network, schema, domain, tables, data_path, inter_network_transfers)
             }
         }
     }
@@ -348,32 +328,43 @@ impl Node {
     pub fn set_constraints(
         &self,
         network: &mut pywr_core::network::Network,
+        schema: &PywrNetwork,
         domain: &ModelDomain,
         tables: &LoadedTableCollection,
         data_path: Option<&Path>,
         inter_network_transfers: &[PywrMultiNetworkTransfer],
     ) -> Result<(), SchemaError> {
         match self {
-            Node::Input(n) => n.set_constraints(network, domain, tables, data_path, inter_network_transfers),
-            Node::Link(n) => n.set_constraints(network, domain, tables, data_path, inter_network_transfers),
-            Node::Output(n) => n.set_constraints(network, domain, tables, data_path, inter_network_transfers),
-            Node::Storage(n) => n.set_constraints(network, domain, tables, data_path, inter_network_transfers),
-            Node::Catchment(n) => n.set_constraints(network, domain, tables, data_path, inter_network_transfers),
-            Node::RiverGauge(n) => n.set_constraints(network, domain, tables, data_path, inter_network_transfers),
-            Node::LossLink(n) => n.set_constraints(network, domain, tables, data_path, inter_network_transfers),
+            Node::Input(n) => n.set_constraints(network, schema, domain, tables, data_path, inter_network_transfers),
+            Node::Link(n) => n.set_constraints(network, schema, domain, tables, data_path, inter_network_transfers),
+            Node::Output(n) => n.set_constraints(network, schema, domain, tables, data_path, inter_network_transfers),
+            Node::Storage(n) => n.set_constraints(network, schema, domain, tables, data_path, inter_network_transfers),
+            Node::Catchment(n) => {
+                n.set_constraints(network, schema, domain, tables, data_path, inter_network_transfers)
+            }
+            Node::RiverGauge(n) => {
+                n.set_constraints(network, schema, domain, tables, data_path, inter_network_transfers)
+            }
+            Node::LossLink(n) => n.set_constraints(network, schema, domain, tables, data_path, inter_network_transfers),
             Node::River(_) => Ok(()), // No constraints on river node
             Node::RiverSplitWithGauge(n) => {
-                n.set_constraints(network, domain, tables, data_path, inter_network_transfers)
+                n.set_constraints(network, schema, domain, tables, data_path, inter_network_transfers)
             }
             Node::WaterTreatmentWorks(n) => {
-                n.set_constraints(network, domain, tables, data_path, inter_network_transfers)
+                n.set_constraints(network, schema, domain, tables, data_path, inter_network_transfers)
             }
-            Node::Aggregated(n) => n.set_constraints(network, domain, tables, data_path, inter_network_transfers),
+            Node::Aggregated(n) => {
+                n.set_constraints(network, schema, domain, tables, data_path, inter_network_transfers)
+            }
             Node::AggregatedStorage(_) => Ok(()), // No constraints on aggregated storage nodes.
             Node::VirtualStorage(_) => Ok(()),    // TODO
             Node::AnnualVirtualStorage(_) => Ok(()), // TODO
-            Node::PiecewiseLink(n) => n.set_constraints(network, domain, tables, data_path, inter_network_transfers),
-            Node::PiecewiseStorage(n) => n.set_constraints(network, domain, tables, data_path, inter_network_transfers),
+            Node::PiecewiseLink(n) => {
+                n.set_constraints(network, schema, domain, tables, data_path, inter_network_transfers)
+            }
+            Node::PiecewiseStorage(n) => {
+                n.set_constraints(network, schema, domain, tables, data_path, inter_network_transfers)
+            }
             Node::Delay(n) => n.set_constraints(network, tables),
             Node::MonthlyVirtualStorage(_) => Ok(()), // TODO
         }
@@ -427,27 +418,31 @@ impl Node {
         }
     }
 
-    /// Returns the default metric for this node.
-    pub fn default_metric(&self, network: &pywr_core::network::Network) -> Result<Metric, SchemaError> {
+    /// Create a metric for the given attribute on this node.
+    pub fn create_metric(
+        &self,
+        network: &mut pywr_core::network::Network,
+        attribute: Option<NodeAttribute>,
+    ) -> Result<Metric, SchemaError> {
         match self {
-            Node::Input(n) => n.default_metric(network),
-            Node::Link(n) => n.default_metric(network),
-            Node::Output(n) => n.default_metric(network),
-            Node::Storage(n) => n.default_metric(network),
-            Node::Catchment(n) => n.default_metric(network),
-            Node::RiverGauge(n) => n.default_metric(network),
-            Node::LossLink(n) => n.default_metric(network),
-            Node::River(n) => n.default_metric(network),
-            Node::RiverSplitWithGauge(n) => n.default_metric(network),
-            Node::WaterTreatmentWorks(n) => n.default_metric(network),
-            Node::Aggregated(n) => n.default_metric(network),
-            Node::AggregatedStorage(n) => n.default_metric(network),
-            Node::VirtualStorage(n) => n.default_metric(network),
-            Node::AnnualVirtualStorage(n) => n.default_metric(network),
-            Node::MonthlyVirtualStorage(n) => n.default_metric(network),
-            Node::PiecewiseLink(n) => n.default_metric(network),
-            Node::Delay(n) => n.default_metric(network),
-            Node::PiecewiseStorage(n) => n.default_metric(network),
+            Node::Input(n) => n.create_metric(network, attribute),
+            Node::Link(n) => n.create_metric(network, attribute),
+            Node::Output(n) => n.create_metric(network, attribute),
+            Node::Storage(n) => n.create_metric(network, attribute),
+            Node::Catchment(n) => n.create_metric(network, attribute),
+            Node::RiverGauge(n) => n.create_metric(network, attribute),
+            Node::LossLink(n) => n.create_metric(network, attribute),
+            Node::River(n) => n.create_metric(network, attribute),
+            Node::RiverSplitWithGauge(n) => n.create_metric(network, attribute),
+            Node::WaterTreatmentWorks(n) => n.create_metric(network, attribute),
+            Node::Aggregated(n) => n.create_metric(network, attribute),
+            Node::AggregatedStorage(n) => n.create_metric(network, attribute),
+            Node::VirtualStorage(n) => n.create_metric(network, attribute),
+            Node::AnnualVirtualStorage(n) => n.create_metric(network, attribute),
+            Node::MonthlyVirtualStorage(n) => n.create_metric(network, attribute),
+            Node::PiecewiseLink(n) => n.create_metric(network, attribute),
+            Node::PiecewiseStorage(n) => n.create_metric(network, attribute),
+            Node::Delay(n) => n.create_metric(network, attribute),
         }
     }
 }

--- a/pywr-schema/src/nodes/monthly_virtual_storage.rs
+++ b/pywr-schema/src/nodes/monthly_virtual_storage.rs
@@ -37,6 +37,8 @@ pub struct MonthlyVirtualStorageNode {
 }
 
 impl MonthlyVirtualStorageNode {
+    const DEFAULT_ATTRIBUTE: NodeAttribute = NodeAttribute::Volume;
+
     pub fn add_to_model(
         &self,
         network: &mut pywr_core::network::Network,
@@ -114,7 +116,7 @@ impl MonthlyVirtualStorageNode {
         attribute: Option<NodeAttribute>,
     ) -> Result<Metric, SchemaError> {
         // Use the default attribute if none is specified
-        let attr = attribute.unwrap_or_else(|| self.default_attribute());
+        let attr = attribute.unwrap_or(Self::DEFAULT_ATTRIBUTE);
 
         let idx = network.get_virtual_storage_node_index_by_name(self.meta.name.as_str(), None)?;
 
@@ -134,10 +136,6 @@ impl MonthlyVirtualStorageNode {
         };
 
         Ok(metric)
-    }
-
-    pub fn default_attribute(&self) -> NodeAttribute {
-        NodeAttribute::Volume
     }
 }
 

--- a/pywr-schema/src/nodes/monthly_virtual_storage.rs
+++ b/pywr-schema/src/nodes/monthly_virtual_storage.rs
@@ -129,6 +129,7 @@ impl MonthlyVirtualStorageNode {
             }
             _ => {
                 return Err(SchemaError::NodeAttributeNotSupported {
+                    ty: "MonthlyVirtualStorageNode".to_string(),
                     name: self.meta.name.clone(),
                     attr,
                 })

--- a/pywr-schema/src/nodes/monthly_virtual_storage.rs
+++ b/pywr-schema/src/nodes/monthly_virtual_storage.rs
@@ -1,8 +1,9 @@
 use crate::data_tables::LoadedTableCollection;
 use crate::error::{ConversionError, SchemaError};
 use crate::model::PywrMultiNetworkTransfer;
-use crate::nodes::NodeMeta;
+use crate::nodes::{NodeAttribute, NodeMeta};
 use crate::parameters::{DynamicFloatValue, TryIntoV2Parameter};
+use pywr_core::derived_metric::DerivedMetric;
 use pywr_core::metric::Metric;
 use pywr_core::models::ModelDomain;
 use pywr_core::node::{ConstraintValue, StorageInitialVolume};
@@ -39,6 +40,7 @@ impl MonthlyVirtualStorageNode {
     pub fn add_to_model(
         &self,
         network: &mut pywr_core::network::Network,
+        schema: &crate::model::PywrNetwork,
         domain: &ModelDomain,
         tables: &LoadedTableCollection,
         data_path: Option<&Path>,
@@ -54,21 +56,21 @@ impl MonthlyVirtualStorageNode {
 
         let cost = match &self.cost {
             Some(v) => v
-                .load(network, domain, tables, data_path, inter_network_transfers)?
+                .load(network, schema, domain, tables, data_path, inter_network_transfers)?
                 .into(),
             None => ConstraintValue::Scalar(0.0),
         };
 
         let min_volume = match &self.min_volume {
             Some(v) => v
-                .load(network, domain, tables, data_path, inter_network_transfers)?
+                .load(network, schema, domain, tables, data_path, inter_network_transfers)?
                 .into(),
             None => ConstraintValue::Scalar(0.0),
         };
 
         let max_volume = match &self.max_volume {
             Some(v) => v
-                .load(network, domain, tables, data_path, inter_network_transfers)?
+                .load(network, schema, domain, tables, data_path, inter_network_transfers)?
                 .into(),
             None => ConstraintValue::None,
         };
@@ -106,9 +108,36 @@ impl MonthlyVirtualStorageNode {
         vec![]
     }
 
-    pub fn default_metric(&self, network: &pywr_core::network::Network) -> Result<Metric, SchemaError> {
+    pub fn create_metric(
+        &self,
+        network: &mut pywr_core::network::Network,
+        attribute: Option<NodeAttribute>,
+    ) -> Result<Metric, SchemaError> {
+        // Use the default attribute if none is specified
+        let attr = attribute.unwrap_or_else(|| self.default_attribute());
+
         let idx = network.get_virtual_storage_node_index_by_name(self.meta.name.as_str(), None)?;
-        Ok(Metric::VirtualStorageVolume(idx))
+
+        let metric = match attr {
+            NodeAttribute::Volume => Metric::VirtualStorageVolume(idx),
+            NodeAttribute::ProportionalVolume => {
+                let dm = DerivedMetric::VirtualStorageProportionalVolume(idx);
+                let derived_metric_idx = network.add_derived_metric(dm);
+                Metric::DerivedMetric(derived_metric_idx)
+            }
+            _ => {
+                return Err(SchemaError::NodeAttributeNotSupported {
+                    name: self.meta.name.clone(),
+                    attr,
+                })
+            }
+        };
+
+        Ok(metric)
+    }
+
+    pub fn default_attribute(&self) -> NodeAttribute {
+        NodeAttribute::Volume
     }
 }
 

--- a/pywr-schema/src/nodes/piecewise_link.rs
+++ b/pywr-schema/src/nodes/piecewise_link.rs
@@ -1,7 +1,7 @@
 use crate::data_tables::LoadedTableCollection;
 use crate::error::{ConversionError, SchemaError};
 use crate::model::PywrMultiNetworkTransfer;
-use crate::nodes::NodeMeta;
+use crate::nodes::{NodeAttribute, NodeMeta};
 use crate::parameters::{DynamicFloatValue, TryIntoV2Parameter};
 use pywr_core::metric::Metric;
 use pywr_core::models::ModelDomain;
@@ -60,6 +60,7 @@ impl PiecewiseLinkNode {
     pub fn set_constraints(
         &self,
         network: &mut pywr_core::network::Network,
+        schema: &crate::model::PywrNetwork,
         domain: &ModelDomain,
         tables: &LoadedTableCollection,
         data_path: Option<&Path>,
@@ -69,17 +70,17 @@ impl PiecewiseLinkNode {
             let sub_name = Self::step_sub_name(i);
 
             if let Some(cost) = &step.cost {
-                let value = cost.load(network, domain, tables, data_path, inter_network_transfers)?;
+                let value = cost.load(network, schema, domain, tables, data_path, inter_network_transfers)?;
                 network.set_node_cost(self.meta.name.as_str(), sub_name.as_deref(), value.into())?;
             }
 
             if let Some(max_flow) = &step.max_flow {
-                let value = max_flow.load(network, domain, tables, data_path, inter_network_transfers)?;
+                let value = max_flow.load(network, schema, domain, tables, data_path, inter_network_transfers)?;
                 network.set_node_max_flow(self.meta.name.as_str(), sub_name.as_deref(), value.into())?;
             }
 
             if let Some(min_flow) = &step.min_flow {
-                let value = min_flow.load(network, domain, tables, data_path, inter_network_transfers)?;
+                let value = min_flow.load(network, schema, domain, tables, data_path, inter_network_transfers)?;
                 network.set_node_min_flow(self.meta.name.as_str(), sub_name.as_deref(), value.into())?;
             }
         }
@@ -102,7 +103,14 @@ impl PiecewiseLinkNode {
             .collect()
     }
 
-    pub fn default_metric(&self, network: &pywr_core::network::Network) -> Result<Metric, SchemaError> {
+    pub fn create_metric(
+        &self,
+        network: &pywr_core::network::Network,
+        attribute: Option<NodeAttribute>,
+    ) -> Result<Metric, SchemaError> {
+        // Use the default attribute if none is specified
+        let attr = attribute.unwrap_or_else(|| self.default_attribute());
+
         let indices = self
             .steps
             .iter()
@@ -110,11 +118,28 @@ impl PiecewiseLinkNode {
             .map(|(i, _)| network.get_node_index_by_name(self.meta.name.as_str(), Self::step_sub_name(i).as_deref()))
             .collect::<Result<Vec<_>, _>>()?;
 
-        Ok(Metric::MultiNodeInFlow {
-            indices,
-            name: self.meta.name.to_string(),
-            sub_name: Some("total".to_string()),
-        })
+        let metric = match attr {
+            NodeAttribute::Inflow => Metric::MultiNodeInFlow {
+                indices,
+                name: self.meta.name.to_string(),
+            },
+            NodeAttribute::Outflow => Metric::MultiNodeOutFlow {
+                indices,
+                name: self.meta.name.to_string(),
+            },
+            _ => {
+                return Err(SchemaError::NodeAttributeNotSupported {
+                    name: self.meta.name.clone(),
+                    attr,
+                })
+            }
+        };
+
+        Ok(metric)
+    }
+
+    pub fn default_attribute(&self) -> NodeAttribute {
+        NodeAttribute::Outflow
     }
 }
 

--- a/pywr-schema/src/nodes/piecewise_link.rs
+++ b/pywr-schema/src/nodes/piecewise_link.rs
@@ -45,6 +45,8 @@ pub struct PiecewiseLinkNode {
 }
 
 impl PiecewiseLinkNode {
+    const DEFAULT_ATTRIBUTE: NodeAttribute = NodeAttribute::Outflow;
+
     fn step_sub_name(i: usize) -> Option<String> {
         Some(format!("step-{i:02}"))
     }
@@ -109,7 +111,7 @@ impl PiecewiseLinkNode {
         attribute: Option<NodeAttribute>,
     ) -> Result<Metric, SchemaError> {
         // Use the default attribute if none is specified
-        let attr = attribute.unwrap_or_else(|| self.default_attribute());
+        let attr = attribute.unwrap_or(Self::DEFAULT_ATTRIBUTE);
 
         let indices = self
             .steps
@@ -136,10 +138,6 @@ impl PiecewiseLinkNode {
         };
 
         Ok(metric)
-    }
-
-    pub fn default_attribute(&self) -> NodeAttribute {
-        NodeAttribute::Outflow
     }
 }
 

--- a/pywr-schema/src/nodes/piecewise_link.rs
+++ b/pywr-schema/src/nodes/piecewise_link.rs
@@ -131,6 +131,7 @@ impl PiecewiseLinkNode {
             },
             _ => {
                 return Err(SchemaError::NodeAttributeNotSupported {
+                    ty: "PiecewiseLinkNode".to_string(),
                     name: self.meta.name.clone(),
                     attr,
                 })

--- a/pywr-schema/src/nodes/piecewise_storage.rs
+++ b/pywr-schema/src/nodes/piecewise_storage.rs
@@ -236,6 +236,7 @@ impl PiecewiseStorageNode {
             }
             _ => {
                 return Err(SchemaError::NodeAttributeNotSupported {
+                    ty: "PiecewiseStorageNode".to_string(),
                     name: self.meta.name.clone(),
                     attr,
                 })

--- a/pywr-schema/src/nodes/piecewise_storage.rs
+++ b/pywr-schema/src/nodes/piecewise_storage.rs
@@ -56,7 +56,7 @@ pub struct PiecewiseStorageNode {
 }
 
 impl PiecewiseStorageNode {
-    const DEFAULT_ATTRIBUTE: NodeAttribute = NodeAttribute::Outflow;
+    const DEFAULT_ATTRIBUTE: NodeAttribute = NodeAttribute::Volume;
 
     fn step_sub_name(i: usize) -> Option<String> {
         Some(format!("store-{i:02}"))

--- a/pywr-schema/src/nodes/piecewise_storage.rs
+++ b/pywr-schema/src/nodes/piecewise_storage.rs
@@ -56,6 +56,8 @@ pub struct PiecewiseStorageNode {
 }
 
 impl PiecewiseStorageNode {
+    const DEFAULT_ATTRIBUTE: NodeAttribute = NodeAttribute::Outflow;
+
     fn step_sub_name(i: usize) -> Option<String> {
         Some(format!("store-{i:02}"))
     }
@@ -221,7 +223,7 @@ impl PiecewiseStorageNode {
         attribute: Option<NodeAttribute>,
     ) -> Result<Metric, SchemaError> {
         // Use the default attribute if none is specified
-        let attr = attribute.unwrap_or_else(|| self.default_attribute());
+        let attr = attribute.unwrap_or(Self::DEFAULT_ATTRIBUTE);
 
         let idx = network.get_aggregated_storage_node_index_by_name(self.meta.name.as_str(), Self::agg_sub_name())?;
 
@@ -241,10 +243,6 @@ impl PiecewiseStorageNode {
         };
 
         Ok(metric)
-    }
-
-    pub fn default_attribute(&self) -> NodeAttribute {
-        NodeAttribute::Outflow
     }
 }
 

--- a/pywr-schema/src/nodes/piecewise_storage.rs
+++ b/pywr-schema/src/nodes/piecewise_storage.rs
@@ -1,8 +1,9 @@
 use crate::data_tables::LoadedTableCollection;
 use crate::error::SchemaError;
 use crate::model::PywrMultiNetworkTransfer;
-use crate::nodes::NodeMeta;
+use crate::nodes::{NodeAttribute, NodeMeta};
 use crate::parameters::DynamicFloatValue;
+use pywr_core::derived_metric::DerivedMetric;
 use pywr_core::metric::Metric;
 use pywr_core::models::ModelDomain;
 use pywr_core::node::{ConstraintValue, StorageInitialVolume};
@@ -59,9 +60,14 @@ impl PiecewiseStorageNode {
         Some(format!("store-{i:02}"))
     }
 
+    fn agg_sub_name() -> Option<&'static str> {
+        Some("agg-store")
+    }
+
     pub fn add_to_model(
         &self,
         network: &mut pywr_core::network::Network,
+        schema: &crate::model::PywrNetwork,
         domain: &ModelDomain,
         tables: &LoadedTableCollection,
         data_path: Option<&Path>,
@@ -70,7 +76,7 @@ impl PiecewiseStorageNode {
         // These are the min and max volume of the overall node
         let max_volume = self
             .max_volume
-            .load(network, domain, tables, data_path, inter_network_transfers)?;
+            .load(network, schema, domain, tables, data_path, inter_network_transfers)?;
 
         let mut store_node_indices = Vec::new();
 
@@ -81,6 +87,7 @@ impl PiecewiseStorageNode {
             let lower = if i > 0 {
                 Some(self.steps[i - 1].control_curve.load(
                     network,
+                    schema,
                     domain,
                     tables,
                     data_path,
@@ -92,7 +99,7 @@ impl PiecewiseStorageNode {
 
             let upper = step
                 .control_curve
-                .load(network, domain, tables, data_path, inter_network_transfers)?;
+                .load(network, schema, domain, tables, data_path, inter_network_transfers)?;
 
             let max_volume_parameter = VolumeBetweenControlCurvesParameter::new(
                 format!("{}-{}-max-volume", self.meta.name, Self::step_sub_name(i).unwrap()).as_str(),
@@ -127,10 +134,12 @@ impl PiecewiseStorageNode {
 
         // The volume of this store the remain proportion above the last control curve
         let lower = match self.steps.last() {
-            Some(step) => Some(
-                step.control_curve
-                    .load(network, domain, tables, data_path, inter_network_transfers)?,
-            ),
+            Some(step) => {
+                Some(
+                    step.control_curve
+                        .load(network, schema, domain, tables, data_path, inter_network_transfers)?,
+                )
+            }
             None => None,
         };
 
@@ -173,7 +182,7 @@ impl PiecewiseStorageNode {
         store_node_indices.push(idx);
 
         // Finally, add an aggregate storage node covering all the individual stores
-        network.add_aggregated_storage_node(self.meta.name.as_str(), None, store_node_indices)?;
+        network.add_aggregated_storage_node(self.meta.name.as_str(), Self::agg_sub_name(), store_node_indices)?;
 
         Ok(())
     }
@@ -181,6 +190,7 @@ impl PiecewiseStorageNode {
     pub fn set_constraints(
         &self,
         network: &mut pywr_core::network::Network,
+        schema: &crate::model::PywrNetwork,
         domain: &ModelDomain,
         tables: &LoadedTableCollection,
         data_path: Option<&Path>,
@@ -190,7 +200,7 @@ impl PiecewiseStorageNode {
             let sub_name = Self::step_sub_name(i);
 
             if let Some(cost) = &step.cost {
-                let value = cost.load(network, domain, tables, data_path, inter_network_transfers)?;
+                let value = cost.load(network, schema, domain, tables, data_path, inter_network_transfers)?;
                 network.set_node_cost(self.meta.name.as_str(), sub_name.as_deref(), value.into())?;
             }
         }
@@ -205,15 +215,43 @@ impl PiecewiseStorageNode {
         vec![(self.meta.name.as_str(), Self::step_sub_name(self.steps.len()))]
     }
 
-    pub fn default_metric(&self, network: &pywr_core::network::Network) -> Result<Metric, SchemaError> {
-        let idx = network.get_aggregated_storage_node_index_by_name(self.meta.name.as_str(), None)?;
-        Ok(Metric::AggregatedNodeVolume(idx))
+    pub fn create_metric(
+        &self,
+        network: &mut pywr_core::network::Network,
+        attribute: Option<NodeAttribute>,
+    ) -> Result<Metric, SchemaError> {
+        // Use the default attribute if none is specified
+        let attr = attribute.unwrap_or_else(|| self.default_attribute());
+
+        let idx = network.get_aggregated_storage_node_index_by_name(self.meta.name.as_str(), Self::agg_sub_name())?;
+
+        let metric = match attr {
+            NodeAttribute::Volume => Metric::AggregatedNodeVolume(idx),
+            NodeAttribute::ProportionalVolume => {
+                let dm = DerivedMetric::AggregatedNodeProportionalVolume(idx);
+                let derived_metric_idx = network.add_derived_metric(dm);
+                Metric::DerivedMetric(derived_metric_idx)
+            }
+            _ => {
+                return Err(SchemaError::NodeAttributeNotSupported {
+                    name: self.meta.name.clone(),
+                    attr,
+                })
+            }
+        };
+
+        Ok(metric)
+    }
+
+    pub fn default_attribute(&self) -> NodeAttribute {
+        NodeAttribute::Outflow
     }
 }
 
 #[cfg(test)]
 mod tests {
     use crate::model::PywrModel;
+    use crate::nodes::PiecewiseStorageNode;
     use ndarray::{concatenate, Array, Array2, Axis};
     use pywr_core::metric::{IndexMetric, Metric};
     use pywr_core::recorders::{AssertionRecorder, IndexAssertionRecorder};
@@ -240,7 +278,7 @@ mod tests {
 
         // TODO put this assertion data in the test model file.
         let idx = network
-            .get_aggregated_storage_node_index_by_name("storage1", None)
+            .get_aggregated_storage_node_index_by_name("storage1", PiecewiseStorageNode::agg_sub_name())
             .unwrap();
 
         let expected = Array2::from_shape_fn((366, 1), |(i, _)| {
@@ -282,7 +320,7 @@ mod tests {
 
         // TODO put this assertion data in the test model file.
         let idx = network
-            .get_aggregated_storage_node_index_by_name("storage1", None)
+            .get_aggregated_storage_node_index_by_name("storage1", PiecewiseStorageNode::agg_sub_name())
             .unwrap();
 
         let expected_volume = Array2::from_shape_fn((366, 1), |(i, _)| {

--- a/pywr-schema/src/nodes/river.rs
+++ b/pywr-schema/src/nodes/river.rs
@@ -45,6 +45,7 @@ impl RiverNode {
             NodeAttribute::Inflow => Metric::NodeInFlow(idx),
             _ => {
                 return Err(SchemaError::NodeAttributeNotSupported {
+                    ty: "RiverNode".to_string(),
                     name: self.meta.name.clone(),
                     attr,
                 })

--- a/pywr-schema/src/nodes/river.rs
+++ b/pywr-schema/src/nodes/river.rs
@@ -12,6 +12,8 @@ pub struct RiverNode {
 }
 
 impl RiverNode {
+    const DEFAULT_ATTRIBUTE: NodeAttribute = NodeAttribute::Outflow;
+
     pub fn parameters(&self) -> HashMap<&str, &DynamicFloatValue> {
         HashMap::new()
     }
@@ -34,7 +36,7 @@ impl RiverNode {
         attribute: Option<NodeAttribute>,
     ) -> Result<Metric, SchemaError> {
         // Use the default attribute if none is specified
-        let attr = attribute.unwrap_or_else(|| self.default_attribute());
+        let attr = attribute.unwrap_or(Self::DEFAULT_ATTRIBUTE);
 
         let idx = network.get_node_index_by_name(self.meta.name.as_str(), None)?;
 
@@ -50,10 +52,6 @@ impl RiverNode {
         };
 
         Ok(metric)
-    }
-
-    pub fn default_attribute(&self) -> NodeAttribute {
-        NodeAttribute::Outflow
     }
 }
 

--- a/pywr-schema/src/nodes/river.rs
+++ b/pywr-schema/src/nodes/river.rs
@@ -1,5 +1,5 @@
 use crate::error::{ConversionError, SchemaError};
-use crate::nodes::NodeMeta;
+use crate::nodes::{NodeAttribute, NodeMeta};
 use crate::parameters::DynamicFloatValue;
 use pywr_core::metric::Metric;
 use pywr_v1_schema::nodes::LinkNode as LinkNodeV1;
@@ -28,9 +28,32 @@ impl RiverNode {
         vec![(self.meta.name.as_str(), None)]
     }
 
-    pub fn default_metric(&self, network: &pywr_core::network::Network) -> Result<Metric, SchemaError> {
+    pub fn create_metric(
+        &self,
+        network: &pywr_core::network::Network,
+        attribute: Option<NodeAttribute>,
+    ) -> Result<Metric, SchemaError> {
+        // Use the default attribute if none is specified
+        let attr = attribute.unwrap_or_else(|| self.default_attribute());
+
         let idx = network.get_node_index_by_name(self.meta.name.as_str(), None)?;
-        Ok(Metric::NodeOutFlow(idx))
+
+        let metric = match attr {
+            NodeAttribute::Outflow => Metric::NodeOutFlow(idx),
+            NodeAttribute::Inflow => Metric::NodeInFlow(idx),
+            _ => {
+                return Err(SchemaError::NodeAttributeNotSupported {
+                    name: self.meta.name.clone(),
+                    attr,
+                })
+            }
+        };
+
+        Ok(metric)
+    }
+
+    pub fn default_attribute(&self) -> NodeAttribute {
+        NodeAttribute::Outflow
     }
 }
 

--- a/pywr-schema/src/nodes/river_gauge.rs
+++ b/pywr-schema/src/nodes/river_gauge.rs
@@ -32,6 +32,8 @@ pub struct RiverGaugeNode {
 }
 
 impl RiverGaugeNode {
+    const DEFAULT_ATTRIBUTE: NodeAttribute = NodeAttribute::Outflow;
+
     fn mrf_sub_name() -> Option<&'static str> {
         Some("mrf")
     }
@@ -90,7 +92,7 @@ impl RiverGaugeNode {
         attribute: Option<NodeAttribute>,
     ) -> Result<Metric, SchemaError> {
         // Use the default attribute if none is specified
-        let attr = attribute.unwrap_or_else(|| self.default_attribute());
+        let attr = attribute.unwrap_or(Self::DEFAULT_ATTRIBUTE);
 
         let indices = vec![
             network.get_node_index_by_name(self.meta.name.as_str(), Self::mrf_sub_name())?,
@@ -115,10 +117,6 @@ impl RiverGaugeNode {
         };
 
         Ok(metric)
-    }
-
-    pub fn default_attribute(&self) -> NodeAttribute {
-        NodeAttribute::Outflow
     }
 }
 

--- a/pywr-schema/src/nodes/river_gauge.rs
+++ b/pywr-schema/src/nodes/river_gauge.rs
@@ -110,6 +110,7 @@ impl RiverGaugeNode {
             },
             _ => {
                 return Err(SchemaError::NodeAttributeNotSupported {
+                    ty: "RiverGaugeNode".to_string(),
                     name: self.meta.name.clone(),
                     attr,
                 })

--- a/pywr-schema/src/nodes/river_gauge.rs
+++ b/pywr-schema/src/nodes/river_gauge.rs
@@ -1,7 +1,7 @@
 use crate::data_tables::LoadedTableCollection;
 use crate::error::{ConversionError, SchemaError};
 use crate::model::PywrMultiNetworkTransfer;
-use crate::nodes::NodeMeta;
+use crate::nodes::{NodeAttribute, NodeMeta};
 use crate::parameters::{DynamicFloatValue, TryIntoV2Parameter};
 use pywr_core::metric::Metric;
 use pywr_core::models::ModelDomain;
@@ -50,6 +50,7 @@ impl RiverGaugeNode {
     pub fn set_constraints(
         &self,
         network: &mut pywr_core::network::Network,
+        schema: &crate::model::PywrNetwork,
         domain: &ModelDomain,
         tables: &LoadedTableCollection,
         data_path: Option<&Path>,
@@ -57,12 +58,12 @@ impl RiverGaugeNode {
     ) -> Result<(), SchemaError> {
         // MRF applies as a maximum on the MRF node.
         if let Some(cost) = &self.mrf_cost {
-            let value = cost.load(network, domain, tables, data_path, inter_network_transfers)?;
+            let value = cost.load(network, schema, domain, tables, data_path, inter_network_transfers)?;
             network.set_node_cost(self.meta.name.as_str(), Self::mrf_sub_name(), value.into())?;
         }
 
         if let Some(mrf) = &self.mrf {
-            let value = mrf.load(network, domain, tables, data_path, inter_network_transfers)?;
+            let value = mrf.load(network, schema, domain, tables, data_path, inter_network_transfers)?;
             network.set_node_max_flow(self.meta.name.as_str(), Self::mrf_sub_name(), value.into())?;
         }
 
@@ -83,17 +84,41 @@ impl RiverGaugeNode {
         ]
     }
 
-    pub fn default_metric(&self, network: &pywr_core::network::Network) -> Result<Metric, SchemaError> {
+    pub fn create_metric(
+        &self,
+        network: &pywr_core::network::Network,
+        attribute: Option<NodeAttribute>,
+    ) -> Result<Metric, SchemaError> {
+        // Use the default attribute if none is specified
+        let attr = attribute.unwrap_or_else(|| self.default_attribute());
+
         let indices = vec![
             network.get_node_index_by_name(self.meta.name.as_str(), Self::mrf_sub_name())?,
             network.get_node_index_by_name(self.meta.name.as_str(), Self::bypass_sub_name())?,
         ];
 
-        Ok(Metric::MultiNodeInFlow {
-            indices,
-            name: self.meta.name.to_string(),
-            sub_name: Some("total".to_string()),
-        })
+        let metric = match attr {
+            NodeAttribute::Inflow => Metric::MultiNodeInFlow {
+                indices,
+                name: self.meta.name.to_string(),
+            },
+            NodeAttribute::Outflow => Metric::MultiNodeOutFlow {
+                indices,
+                name: self.meta.name.to_string(),
+            },
+            _ => {
+                return Err(SchemaError::NodeAttributeNotSupported {
+                    name: self.meta.name.clone(),
+                    attr,
+                })
+            }
+        };
+
+        Ok(metric)
+    }
+
+    pub fn default_attribute(&self) -> NodeAttribute {
+        NodeAttribute::Outflow
     }
 }
 

--- a/pywr-schema/src/nodes/river_split_with_gauge.rs
+++ b/pywr-schema/src/nodes/river_split_with_gauge.rs
@@ -42,6 +42,8 @@ pub struct RiverSplitWithGaugeNode {
 }
 
 impl RiverSplitWithGaugeNode {
+    const DEFAULT_ATTRIBUTE: NodeAttribute = NodeAttribute::Outflow;
+
     fn mrf_sub_name() -> Option<&'static str> {
         Some("mrf")
     }
@@ -160,7 +162,7 @@ impl RiverSplitWithGaugeNode {
         attribute: Option<NodeAttribute>,
     ) -> Result<Metric, SchemaError> {
         // Use the default attribute if none is specified
-        let attr = attribute.unwrap_or_else(|| self.default_attribute());
+        let attr = attribute.unwrap_or(Self::DEFAULT_ATTRIBUTE);
 
         // This gets the indices of all the link nodes
         // There's currently no way to isolate the flows to the individual splits
@@ -197,10 +199,6 @@ impl RiverSplitWithGaugeNode {
         };
 
         Ok(metric)
-    }
-
-    pub fn default_attribute(&self) -> NodeAttribute {
-        NodeAttribute::Outflow
     }
 }
 

--- a/pywr-schema/src/nodes/river_split_with_gauge.rs
+++ b/pywr-schema/src/nodes/river_split_with_gauge.rs
@@ -192,6 +192,7 @@ impl RiverSplitWithGaugeNode {
             },
             _ => {
                 return Err(SchemaError::NodeAttributeNotSupported {
+                    ty: "RiverSplitWithGaugeNode".to_string(),
                     name: self.meta.name.clone(),
                     attr,
                 })

--- a/pywr-schema/src/nodes/virtual_storage.rs
+++ b/pywr-schema/src/nodes/virtual_storage.rs
@@ -25,6 +25,8 @@ pub struct VirtualStorageNode {
 }
 
 impl VirtualStorageNode {
+    const DEFAULT_ATTRIBUTE: NodeAttribute = NodeAttribute::Volume;
+
     pub fn add_to_model(
         &self,
         network: &mut pywr_core::network::Network,
@@ -100,7 +102,7 @@ impl VirtualStorageNode {
         attribute: Option<NodeAttribute>,
     ) -> Result<Metric, SchemaError> {
         // Use the default attribute if none is specified
-        let attr = attribute.unwrap_or_else(|| self.default_attribute());
+        let attr = attribute.unwrap_or(Self::DEFAULT_ATTRIBUTE);
 
         let idx = network.get_virtual_storage_node_index_by_name(self.meta.name.as_str(), None)?;
 
@@ -120,10 +122,6 @@ impl VirtualStorageNode {
         };
 
         Ok(metric)
-    }
-
-    pub fn default_attribute(&self) -> NodeAttribute {
-        NodeAttribute::Volume
     }
 }
 

--- a/pywr-schema/src/nodes/virtual_storage.rs
+++ b/pywr-schema/src/nodes/virtual_storage.rs
@@ -115,6 +115,7 @@ impl VirtualStorageNode {
             }
             _ => {
                 return Err(SchemaError::NodeAttributeNotSupported {
+                    ty: "VirtualStorageNode".to_string(),
                     name: self.meta.name.clone(),
                     attr,
                 })

--- a/pywr-schema/src/nodes/virtual_storage.rs
+++ b/pywr-schema/src/nodes/virtual_storage.rs
@@ -1,8 +1,9 @@
 use crate::data_tables::LoadedTableCollection;
 use crate::error::{ConversionError, SchemaError};
 use crate::model::PywrMultiNetworkTransfer;
-use crate::nodes::NodeMeta;
+use crate::nodes::{NodeAttribute, NodeMeta};
 use crate::parameters::{DynamicFloatValue, TryIntoV2Parameter};
+use pywr_core::derived_metric::DerivedMetric;
 use pywr_core::metric::Metric;
 use pywr_core::models::ModelDomain;
 use pywr_core::node::{ConstraintValue, StorageInitialVolume};
@@ -27,6 +28,7 @@ impl VirtualStorageNode {
     pub fn add_to_model(
         &self,
         network: &mut pywr_core::network::Network,
+        schema: &crate::model::PywrNetwork,
         domain: &ModelDomain,
         tables: &LoadedTableCollection,
         data_path: Option<&Path>,
@@ -42,21 +44,21 @@ impl VirtualStorageNode {
 
         let cost = match &self.cost {
             Some(v) => v
-                .load(network, domain, tables, data_path, inter_network_transfers)?
+                .load(network, schema, domain, tables, data_path, inter_network_transfers)?
                 .into(),
             None => ConstraintValue::Scalar(0.0),
         };
 
         let min_volume = match &self.min_volume {
             Some(v) => v
-                .load(network, domain, tables, data_path, inter_network_transfers)?
+                .load(network, schema, domain, tables, data_path, inter_network_transfers)?
                 .into(),
             None => ConstraintValue::Scalar(0.0),
         };
 
         let max_volume = match &self.max_volume {
             Some(v) => v
-                .load(network, domain, tables, data_path, inter_network_transfers)?
+                .load(network, schema, domain, tables, data_path, inter_network_transfers)?
                 .into(),
             None => ConstraintValue::None,
         };
@@ -92,9 +94,36 @@ impl VirtualStorageNode {
         vec![]
     }
 
-    pub fn default_metric(&self, network: &pywr_core::network::Network) -> Result<Metric, SchemaError> {
+    pub fn create_metric(
+        &self,
+        network: &mut pywr_core::network::Network,
+        attribute: Option<NodeAttribute>,
+    ) -> Result<Metric, SchemaError> {
+        // Use the default attribute if none is specified
+        let attr = attribute.unwrap_or_else(|| self.default_attribute());
+
         let idx = network.get_virtual_storage_node_index_by_name(self.meta.name.as_str(), None)?;
-        Ok(Metric::VirtualStorageVolume(idx))
+
+        let metric = match attr {
+            NodeAttribute::Volume => Metric::VirtualStorageVolume(idx),
+            NodeAttribute::ProportionalVolume => {
+                let dm = DerivedMetric::VirtualStorageProportionalVolume(idx);
+                let derived_metric_idx = network.add_derived_metric(dm);
+                Metric::DerivedMetric(derived_metric_idx)
+            }
+            _ => {
+                return Err(SchemaError::NodeAttributeNotSupported {
+                    name: self.meta.name.clone(),
+                    attr,
+                })
+            }
+        };
+
+        Ok(metric)
+    }
+
+    pub fn default_attribute(&self) -> NodeAttribute {
+        NodeAttribute::Volume
     }
 }
 

--- a/pywr-schema/src/nodes/water_treatment_works.rs
+++ b/pywr-schema/src/nodes/water_treatment_works.rs
@@ -57,6 +57,8 @@ pub struct WaterTreatmentWorks {
 }
 
 impl WaterTreatmentWorks {
+    const DEFAULT_ATTRIBUTE: NodeAttribute = NodeAttribute::Outflow;
+
     fn loss_sub_name() -> Option<&'static str> {
         Some("loss")
     }
@@ -198,7 +200,7 @@ impl WaterTreatmentWorks {
         attribute: Option<NodeAttribute>,
     ) -> Result<Metric, SchemaError> {
         // Use the default attribute if none is specified
-        let attr = attribute.unwrap_or_else(|| self.default_attribute());
+        let attr = attribute.unwrap_or(Self::DEFAULT_ATTRIBUTE);
 
         let metric = match attr {
             NodeAttribute::Inflow => {
@@ -230,10 +232,6 @@ impl WaterTreatmentWorks {
         };
 
         Ok(metric)
-    }
-
-    pub fn default_attribute(&self) -> NodeAttribute {
-        NodeAttribute::Outflow
     }
 }
 

--- a/pywr-schema/src/nodes/water_treatment_works.rs
+++ b/pywr-schema/src/nodes/water_treatment_works.rs
@@ -225,6 +225,7 @@ impl WaterTreatmentWorks {
             }
             _ => {
                 return Err(SchemaError::NodeAttributeNotSupported {
+                    ty: "WaterTreatmentWorksNode".to_string(),
                     name: self.meta.name.clone(),
                     attr,
                 })

--- a/pywr-schema/src/nodes/water_treatment_works.rs
+++ b/pywr-schema/src/nodes/water_treatment_works.rs
@@ -1,7 +1,7 @@
 use crate::data_tables::LoadedTableCollection;
 use crate::error::SchemaError;
 use crate::model::PywrMultiNetworkTransfer;
-use crate::nodes::NodeMeta;
+use crate::nodes::{NodeAttribute, NodeMeta};
 use crate::parameters::DynamicFloatValue;
 use num::Zero;
 use pywr_core::aggregated_node::Factors;
@@ -103,30 +103,31 @@ impl WaterTreatmentWorks {
     pub fn set_constraints(
         &self,
         network: &mut pywr_core::network::Network,
+        schema: &crate::model::PywrNetwork,
         domain: &ModelDomain,
         tables: &LoadedTableCollection,
         data_path: Option<&Path>,
         inter_network_transfers: &[PywrMultiNetworkTransfer],
     ) -> Result<(), SchemaError> {
         if let Some(cost) = &self.cost {
-            let value = cost.load(network, domain, tables, data_path, inter_network_transfers)?;
+            let value = cost.load(network, schema, domain, tables, data_path, inter_network_transfers)?;
             network.set_node_cost(self.meta.name.as_str(), Self::net_sub_name(), value.into())?;
         }
 
         if let Some(max_flow) = &self.max_flow {
-            let value = max_flow.load(network, domain, tables, data_path, inter_network_transfers)?;
+            let value = max_flow.load(network, schema, domain, tables, data_path, inter_network_transfers)?;
             network.set_node_max_flow(self.meta.name.as_str(), Self::net_sub_name(), value.into())?;
         }
 
         if let Some(min_flow) = &self.min_flow {
-            let value = min_flow.load(network, domain, tables, data_path, inter_network_transfers)?;
+            let value = min_flow.load(network, schema, domain, tables, data_path, inter_network_transfers)?;
             network.set_node_min_flow(self.meta.name.as_str(), Self::net_sub_name(), value.into())?;
         }
 
         // soft min flow constraints; This typically applies a negative cost upto a maximum
         // defined by the `soft_min_flow`
         if let Some(cost) = &self.soft_min_flow_cost {
-            let value = cost.load(network, domain, tables, data_path, inter_network_transfers)?;
+            let value = cost.load(network, schema, domain, tables, data_path, inter_network_transfers)?;
             network.set_node_cost(
                 self.meta.name.as_str(),
                 Self::net_soft_min_flow_sub_name(),
@@ -134,7 +135,7 @@ impl WaterTreatmentWorks {
             )?;
         }
         if let Some(min_flow) = &self.soft_min_flow {
-            let value = min_flow.load(network, domain, tables, data_path, inter_network_transfers)?;
+            let value = min_flow.load(network, schema, domain, tables, data_path, inter_network_transfers)?;
             network.set_node_max_flow(
                 self.meta.name.as_str(),
                 Self::net_soft_min_flow_sub_name(),
@@ -145,7 +146,7 @@ impl WaterTreatmentWorks {
         if let Some(loss_factor) = &self.loss_factor {
             // Handle the case where we a given a zero loss factor
             // The aggregated node does not support zero loss factors so filter them here.
-            let lf = match loss_factor.load(network, domain, tables, data_path, inter_network_transfers)? {
+            let lf = match loss_factor.load(network, schema, domain, tables, data_path, inter_network_transfers)? {
                 Metric::Constant(f) => {
                     if f.is_zero() {
                         None
@@ -191,9 +192,48 @@ impl WaterTreatmentWorks {
         ]
     }
 
-    pub fn default_metric(&self, network: &pywr_core::network::Network) -> Result<Metric, SchemaError> {
-        let idx = network.get_node_index_by_name(self.meta.name.as_str(), Self::net_sub_name().as_deref())?;
-        Ok(Metric::NodeOutFlow(idx))
+    pub fn create_metric(
+        &self,
+        network: &pywr_core::network::Network,
+        attribute: Option<NodeAttribute>,
+    ) -> Result<Metric, SchemaError> {
+        // Use the default attribute if none is specified
+        let attr = attribute.unwrap_or_else(|| self.default_attribute());
+
+        let metric = match attr {
+            NodeAttribute::Inflow => {
+                let indices = vec![
+                    network.get_node_index_by_name(self.meta.name.as_str(), Self::net_sub_name())?,
+                    network.get_node_index_by_name(self.meta.name.as_str(), Self::loss_sub_name())?,
+                ];
+
+                Metric::MultiNodeInFlow {
+                    indices,
+                    name: self.meta.name.to_string(),
+                }
+            }
+            NodeAttribute::Outflow => {
+                let idx = network.get_node_index_by_name(self.meta.name.as_str(), Self::net_sub_name().as_deref())?;
+                Metric::NodeOutFlow(idx)
+            }
+            NodeAttribute::Loss => {
+                let idx = network.get_node_index_by_name(self.meta.name.as_str(), Self::loss_sub_name().as_deref())?;
+                // This is an output node that only supports inflow
+                Metric::NodeInFlow(idx)
+            }
+            _ => {
+                return Err(SchemaError::NodeAttributeNotSupported {
+                    name: self.meta.name.clone(),
+                    attr,
+                })
+            }
+        };
+
+        Ok(metric)
+    }
+
+    pub fn default_attribute(&self) -> NodeAttribute {
+        NodeAttribute::Outflow
     }
 }
 
@@ -238,7 +278,10 @@ mod tests {
                           },
                           0.0
                         ],
-                        "storage_node": "My reservoir"
+                        "storage_node": {
+                          "name": "My reservoir",
+                          "attribute": "ProportionalVolume"
+                        }
                     }
                   },
                   "soft_min_flow_cost": {

--- a/pywr-schema/src/parameters/asymmetric_switch.rs
+++ b/pywr-schema/src/parameters/asymmetric_switch.rs
@@ -29,6 +29,7 @@ impl AsymmetricSwitchIndexParameter {
     pub fn add_to_model(
         &self,
         network: &mut pywr_core::network::Network,
+        schema: &crate::model::PywrNetwork,
         domain: &ModelDomain,
         tables: &LoadedTableCollection,
         data_path: Option<&Path>,
@@ -36,10 +37,10 @@ impl AsymmetricSwitchIndexParameter {
     ) -> Result<IndexParameterIndex, SchemaError> {
         let on_index_parameter =
             self.on_index_parameter
-                .load(network, domain, tables, data_path, inter_network_transfers)?;
+                .load(network, schema, domain, tables, data_path, inter_network_transfers)?;
         let off_index_parameter =
             self.off_index_parameter
-                .load(network, domain, tables, data_path, inter_network_transfers)?;
+                .load(network, schema, domain, tables, data_path, inter_network_transfers)?;
 
         let p = pywr_core::parameters::AsymmetricSwitchIndexParameter::new(
             &self.meta.name,

--- a/pywr-schema/src/parameters/core.rs
+++ b/pywr-schema/src/parameters/core.rs
@@ -232,6 +232,7 @@ impl MaxParameter {
     pub fn add_to_model(
         &self,
         network: &mut pywr_core::network::Network,
+        schema: &crate::model::PywrNetwork,
         domain: &ModelDomain,
         tables: &LoadedTableCollection,
         data_path: Option<&Path>,
@@ -239,7 +240,7 @@ impl MaxParameter {
     ) -> Result<ParameterIndex, SchemaError> {
         let idx = self
             .parameter
-            .load(network, domain, tables, data_path, inter_network_transfers)?;
+            .load(network, schema, domain, tables, data_path, inter_network_transfers)?;
         let threshold = self.threshold.unwrap_or(0.0);
 
         let p = pywr_core::parameters::MaxParameter::new(&self.meta.name, idx, threshold);
@@ -306,6 +307,7 @@ impl DivisionParameter {
     pub fn add_to_model(
         &self,
         network: &mut pywr_core::network::Network,
+        schema: &crate::model::PywrNetwork,
         domain: &ModelDomain,
         tables: &LoadedTableCollection,
         data_path: Option<&Path>,
@@ -313,10 +315,10 @@ impl DivisionParameter {
     ) -> Result<ParameterIndex, SchemaError> {
         let n = self
             .numerator
-            .load(network, domain, tables, data_path, inter_network_transfers)?;
+            .load(network, schema, domain, tables, data_path, inter_network_transfers)?;
         let d = self
             .denominator
-            .load(network, domain, tables, data_path, inter_network_transfers)?;
+            .load(network, schema, domain, tables, data_path, inter_network_transfers)?;
 
         let p = pywr_core::parameters::DivisionParameter::new(&self.meta.name, n, d);
         Ok(network.add_parameter(Box::new(p))?)
@@ -380,6 +382,7 @@ impl MinParameter {
     pub fn add_to_model(
         &self,
         network: &mut pywr_core::network::Network,
+        schema: &crate::model::PywrNetwork,
         domain: &ModelDomain,
         tables: &LoadedTableCollection,
         data_path: Option<&Path>,
@@ -387,7 +390,7 @@ impl MinParameter {
     ) -> Result<ParameterIndex, SchemaError> {
         let idx = self
             .parameter
-            .load(network, domain, tables, data_path, inter_network_transfers)?;
+            .load(network, schema, domain, tables, data_path, inter_network_transfers)?;
         let threshold = self.threshold.unwrap_or(0.0);
 
         let p = pywr_core::parameters::MinParameter::new(&self.meta.name, idx, threshold);
@@ -436,6 +439,7 @@ impl NegativeParameter {
     pub fn add_to_model(
         &self,
         network: &mut pywr_core::network::Network,
+        schema: &crate::model::PywrNetwork,
         domain: &ModelDomain,
         tables: &LoadedTableCollection,
         data_path: Option<&Path>,
@@ -443,7 +447,7 @@ impl NegativeParameter {
     ) -> Result<ParameterIndex, SchemaError> {
         let idx = self
             .parameter
-            .load(network, domain, tables, data_path, inter_network_transfers)?;
+            .load(network, schema, domain, tables, data_path, inter_network_transfers)?;
 
         let p = pywr_core::parameters::NegativeParameter::new(&self.meta.name, idx);
         Ok(network.add_parameter(Box::new(p))?)

--- a/pywr-schema/src/parameters/delay.rs
+++ b/pywr-schema/src/parameters/delay.rs
@@ -34,6 +34,7 @@ impl DelayParameter {
     pub fn add_to_model(
         &self,
         network: &mut pywr_core::network::Network,
+        schema: &crate::model::PywrNetwork,
         domain: &ModelDomain,
         tables: &LoadedTableCollection,
         data_path: Option<&Path>,
@@ -41,7 +42,7 @@ impl DelayParameter {
     ) -> Result<ParameterIndex, SchemaError> {
         let metric = self
             .metric
-            .load(network, domain, tables, data_path, inter_network_transfers)?;
+            .load(network, schema, domain, tables, data_path, inter_network_transfers)?;
         let p = pywr_core::parameters::DelayParameter::new(&self.meta.name, metric, self.delay, self.initial_value);
         Ok(network.add_parameter(Box::new(p))?)
     }

--- a/pywr-schema/src/parameters/discount_factor.rs
+++ b/pywr-schema/src/parameters/discount_factor.rs
@@ -35,14 +35,15 @@ impl DiscountFactorParameter {
     pub fn add_to_model(
         &self,
         network: &mut pywr_core::network::Network,
+        schema: &crate::model::PywrNetwork,
         domain: &ModelDomain,
         tables: &LoadedTableCollection,
         data_path: Option<&Path>,
         inter_network_transfers: &[PywrMultiNetworkTransfer],
     ) -> Result<ParameterIndex, SchemaError> {
-        let discount_rate = self
-            .discount_rate
-            .load(network, domain, tables, data_path, inter_network_transfers)?;
+        let discount_rate =
+            self.discount_rate
+                .load(network, schema, domain, tables, data_path, inter_network_transfers)?;
         let p = pywr_core::parameters::DiscountFactorParameter::new(&self.meta.name, discount_rate, self.base_year);
         Ok(network.add_parameter(Box::new(p))?)
     }

--- a/pywr-schema/src/parameters/doc_examples/aggregated_1.json
+++ b/pywr-schema/src/parameters/doc_examples/aggregated_1.json
@@ -13,8 +13,9 @@
             "name": "my-other-parameter"
         },
         {
-            "type": "NodeVolume",
-            "name": "my-reservoir"
+            "type": "Node",
+            "name": "my-reservoir",
+            "attribute": "Volume"
         },
         {
             "type": "InlineParameter",

--- a/pywr-schema/src/parameters/indexed_array.rs
+++ b/pywr-schema/src/parameters/indexed_array.rs
@@ -37,19 +37,20 @@ impl IndexedArrayParameter {
     pub fn add_to_model(
         &self,
         network: &mut pywr_core::network::Network,
+        schema: &crate::model::PywrNetwork,
         domain: &ModelDomain,
         tables: &LoadedTableCollection,
         data_path: Option<&Path>,
         inter_network_transfers: &[PywrMultiNetworkTransfer],
     ) -> Result<ParameterIndex, SchemaError> {
-        let index_parameter = self
-            .index_parameter
-            .load(network, domain, tables, data_path, inter_network_transfers)?;
+        let index_parameter =
+            self.index_parameter
+                .load(network, schema, domain, tables, data_path, inter_network_transfers)?;
 
         let metrics = self
             .metrics
             .iter()
-            .map(|v| v.load(network, domain, tables, data_path, inter_network_transfers))
+            .map(|v| v.load(network, schema, domain, tables, data_path, inter_network_transfers))
             .collect::<Result<Vec<_>, _>>()?;
 
         let p = pywr_core::parameters::IndexedArrayParameter::new(&self.meta.name, index_parameter, &metrics);

--- a/pywr-schema/src/parameters/offset.rs
+++ b/pywr-schema/src/parameters/offset.rs
@@ -52,6 +52,7 @@ impl OffsetParameter {
     pub fn add_to_model(
         &self,
         network: &mut pywr_core::network::Network,
+        schema: &crate::model::PywrNetwork,
         domain: &ModelDomain,
         tables: &LoadedTableCollection,
         data_path: Option<&Path>,
@@ -71,7 +72,7 @@ impl OffsetParameter {
 
         let idx = self
             .metric
-            .load(network, domain, tables, data_path, inter_network_transfers)?;
+            .load(network, schema, domain, tables, data_path, inter_network_transfers)?;
 
         let p = pywr_core::parameters::OffsetParameter::new(&self.meta.name, idx, self.offset.load(tables)?, variable);
         Ok(network.add_parameter(Box::new(p))?)

--- a/pywr-schema/src/parameters/python.rs
+++ b/pywr-schema/src/parameters/python.rs
@@ -50,8 +50,9 @@ pub enum PythonModule {
 ///             "name": "another-parameter"
 ///         },
 ///         "volume": {
-///             "type": "NodeVolume",
-///             "name": "a-reservoir"
+///             "type": "Node",
+///             "name": "a-reservoir",
+///             "attribute": "Volume"
 ///         }
 ///     }
 /// }"#;

--- a/pywr-schema/src/parameters/python.rs
+++ b/pywr-schema/src/parameters/python.rs
@@ -125,6 +125,7 @@ impl PythonParameter {
     pub fn add_to_model(
         &self,
         network: &mut pywr_core::network::Network,
+        schema: &crate::model::PywrNetwork,
         domain: &ModelDomain,
         tables: &LoadedTableCollection,
         data_path: Option<&Path>,
@@ -170,7 +171,7 @@ impl PythonParameter {
                 .map(|(k, v)| {
                     Ok((
                         k.to_string(),
-                        v.load(network, domain, tables, data_path, inter_network_transfers)?,
+                        v.load(network, schema, domain, tables, data_path, inter_network_transfers)?,
                     ))
                 })
                 .collect::<Result<HashMap<_, _>, SchemaError>>()?,
@@ -183,7 +184,7 @@ impl PythonParameter {
                 .map(|(k, v)| {
                     Ok((
                         k.to_string(),
-                        v.load(network, domain, tables, data_path, inter_network_transfers)?,
+                        v.load(network, schema, domain, tables, data_path, inter_network_transfers)?,
                     ))
                 })
                 .collect::<Result<HashMap<_, _>, SchemaError>>()?,
@@ -204,6 +205,7 @@ impl PythonParameter {
 #[cfg(test)]
 mod tests {
     use crate::data_tables::LoadedTableCollection;
+    use crate::model::PywrNetwork;
     use crate::parameters::python::PythonParameter;
     use pywr_core::models::ModelDomain;
     use pywr_core::network::Network;
@@ -253,8 +255,11 @@ class MyParameter:
         // ... add it to an empty network
         // this should trigger loading the module and extracting the class
         let domain: ModelDomain = default_time_domain().into();
+        let schema = PywrNetwork::default();
         let mut network = Network::default();
         let tables = LoadedTableCollection::from_schema(None, None).unwrap();
-        param.add_to_model(&mut network, &domain, &tables, None, &[]).unwrap();
+        param
+            .add_to_model(&mut network, &schema, &domain, &tables, None, &[])
+            .unwrap();
     }
 }

--- a/pywr-schema/src/parameters/thresholds.rs
+++ b/pywr-schema/src/parameters/thresholds.rs
@@ -72,6 +72,7 @@ impl ParameterThresholdParameter {
     pub fn add_to_model(
         &self,
         network: &mut pywr_core::network::Network,
+        schema: &crate::model::PywrNetwork,
         domain: &ModelDomain,
         tables: &LoadedTableCollection,
         data_path: Option<&Path>,
@@ -79,10 +80,10 @@ impl ParameterThresholdParameter {
     ) -> Result<IndexParameterIndex, SchemaError> {
         let metric = self
             .parameter
-            .load(network, domain, tables, data_path, inter_network_transfers)?;
+            .load(network, schema, domain, tables, data_path, inter_network_transfers)?;
         let threshold = self
             .threshold
-            .load(network, domain, tables, data_path, inter_network_transfers)?;
+            .load(network, schema, domain, tables, data_path, inter_network_transfers)?;
 
         let p = pywr_core::parameters::ThresholdParameter::new(
             &self.meta.name,

--- a/pywr-schema/src/test_models/multi1/model.json
+++ b/pywr-schema/src/test_models/multi1/model.json
@@ -22,8 +22,9 @@
         {
           "from_network": "network1",
           "metric": {
-            "type": "NodeInFlow",
-            "name": "demand1"
+            "type": "Node",
+            "name": "demand1",
+            "attribute": "Inflow"
           },
           "name": "inflow"
         }

--- a/pywr-schema/src/test_models/multi2/model.json
+++ b/pywr-schema/src/test_models/multi2/model.json
@@ -32,8 +32,9 @@
         {
           "from_network": "network1",
           "metric": {
-            "type": "NodeInFlow",
-            "name": "demand1"
+            "type": "Node",
+            "name": "demand1",
+            "attribute": "Inflow"
           },
           "name": "inflow"
         }

--- a/pywr-schema/src/test_models/piecewise_storage2.json
+++ b/pywr-schema/src/test_models/piecewise_storage2.json
@@ -78,7 +78,10 @@
       {
         "name": "storage1-drought-index",
         "type": "ControlCurveIndex",
-        "storage_node": "storage1",
+        "storage_node": {
+          "name": "storage1",
+          "attribute": "ProportionalVolume"
+        },
         "control_curves": [
           {
             "type": "Parameter",


### PR DESCRIPTION
This is a refactor of NodeReference to specify a schema facing attribute (NodeAttribute). This idea is to remove the need for the user of the schema to understand the internals of complex nodes. Instead they will specify a node by its name in the schema and an associated NodeAttribute.

NodeAttribute is intended as a global enum of all possible values. However, each node may only support a subset of these attributes. I.e. some of the attributes do not make sense for certain node types.

This has largely worked. However, there is an ugly requirement in the control curves to specify the NodeReference struct where it was previously just a string.