### PR TITLE
chore: Use main version of hdf5 crate.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,5 @@ pyo3-polars = "0.11.1"
 pyo3 = { version = "0.20.2" }
 tracing = "0.1"
 csv = "1.1"
-hdf5 = { version="0.8.1" }
-hdf5-sys = { version="0.8.1", features=["static"] }
+hdf5 = { git="https://github.com/aldanor/hdf5-rust.git", package = "hdf5", features=["static", "zlib"] }
 pywr-v1-schema = { git = "https://github.com/pywr/pywr-schema/", tag="v0.9.0", package = "pywr-schema" }

--- a/pywr-core/Cargo.toml
+++ b/pywr-core/Cargo.toml
@@ -20,7 +20,6 @@ ndarray = {  workspace = true }
 num = {  workspace = true }
 float-cmp = "0.9.0"
 hdf5 = {  workspace = true }
-hdf5-sys = {  workspace = true }
 csv = {  workspace = true }
 clp-sys = { path = "../clp-sys" }
 ipm-ocl = { path = "../ipm-ocl", optional = true }


### PR DESCRIPTION
This is not ideal, but the current release is very old and difficult to build sometimes.

This also re-enables the zlib feature for handling compressed files.