### PR TITLE
chore: Disable parallel feature in cc crate

### DIFF
--- a/clp-sys/Cargo.toml
+++ b/clp-sys/Cargo.toml
@@ -9,4 +9,4 @@ edition = "2018"
 [dependencies]
 
 [build-dependencies]
-cc = { version = "1.0", features = ["parallel"] }
+cc = { version = "1.0", features = [] }


### PR DESCRIPTION
This might be the cause of some CI failures by using too many resources.