### PR TITLE
feat: Add StateBuilder for construction of State

### DIFF
--- a/pywr-core/src/parameters/py.rs
+++ b/pywr-core/src/parameters/py.rs
@@ -288,6 +288,7 @@ impl MultiValueParameter for PyParameter {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::state::StateBuilder;
     use crate::test_utils::default_timestepper;
     use crate::timestep::TimeDomain;
     use chrono::Datelike;
@@ -338,7 +339,7 @@ class MyParameter:
             },
         ];
 
-        let state = State::new(vec![], 0, vec![], 1, 0, 0, 0, 0);
+        let state = StateBuilder::new(vec![], 0).with_value_parameters(1).build();
 
         let mut internal_p_states: Vec<_> = scenario_indices
             .iter()
@@ -407,7 +408,7 @@ class MyParameter:
             },
         ];
 
-        let state = State::new(vec![], 0, vec![], 1, 0, 0, 0, 0);
+        let state = StateBuilder::new(vec![], 0).with_value_parameters(1).build();
 
         let mut internal_p_states: Vec<_> = scenario_indices
             .iter()

--- a/pywr-core/src/parameters/rhai.rs
+++ b/pywr-core/src/parameters/rhai.rs
@@ -120,6 +120,7 @@ impl Parameter for RhaiParameter {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::state::StateBuilder;
     use crate::test_utils::default_timestepper;
     use crate::timestep::TimeDomain;
     use float_cmp::assert_approx_eq;
@@ -165,7 +166,7 @@ mod tests {
             },
         ];
 
-        let state = State::new(vec![], 0, vec![], 1, 0, 0, 0, 0);
+        let state = StateBuilder::new(vec![], 0).with_value_parameters(1).build();
 
         let mut internal_p_states: Vec<_> = scenario_indices
             .iter()


### PR DESCRIPTION
`State::new` contained a lot of similarly typed arguments. This commit removes `State::new` and replaces it with a `StateBuilder` type that contains methods for adding optional arguments (which default to zero) and `.build()` for creating a `State`.