### PR TITLE
refactor: Make the Parameter trait generic over the calculated value type

### DIFF
--- a/pywr-core/src/parameters/aggregated.rs
+++ b/pywr-core/src/parameters/aggregated.rs
@@ -47,7 +47,7 @@ impl AggregatedParameter {
     }
 }
 
-impl Parameter for AggregatedParameter {
+impl Parameter<f64> for AggregatedParameter {
     fn as_any_mut(&mut self) -> &mut dyn Any {
         self
     }

--- a/pywr-core/src/parameters/aggregated_index.rs
+++ b/pywr-core/src/parameters/aggregated_index.rs
@@ -2,10 +2,11 @@
 ///
 use super::PywrError;
 use crate::network::Network;
-use crate::parameters::{IndexParameter, IndexValue, ParameterMeta};
+use crate::parameters::{IndexValue, Parameter, ParameterMeta};
 use crate::scenario::ScenarioIndex;
 use crate::state::{ParameterState, State};
 use crate::timestep::Timestep;
+use std::any::Any;
 use std::str::FromStr;
 
 pub enum AggIndexFunc {
@@ -49,7 +50,11 @@ impl AggregatedIndexParameter {
     }
 }
 
-impl IndexParameter for AggregatedIndexParameter {
+impl Parameter<usize> for AggregatedIndexParameter {
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+
     fn meta(&self) -> &ParameterMeta {
         &self.meta
     }

--- a/pywr-core/src/parameters/array.rs
+++ b/pywr-core/src/parameters/array.rs
@@ -23,7 +23,7 @@ impl Array1Parameter {
     }
 }
 
-impl Parameter for Array1Parameter {
+impl Parameter<f64> for Array1Parameter {
     fn as_any_mut(&mut self) -> &mut dyn Any {
         self
     }
@@ -66,7 +66,7 @@ impl Array2Parameter {
     }
 }
 
-impl Parameter for Array2Parameter {
+impl Parameter<f64> for Array2Parameter {
     fn as_any_mut(&mut self) -> &mut dyn Any {
         self
     }

--- a/pywr-core/src/parameters/asymmetric.rs
+++ b/pywr-core/src/parameters/asymmetric.rs
@@ -1,9 +1,10 @@
 use crate::network::Network;
-use crate::parameters::{downcast_internal_state_mut, IndexParameter, IndexValue, ParameterMeta};
+use crate::parameters::{downcast_internal_state_mut, IndexValue, Parameter, ParameterMeta};
 use crate::scenario::ScenarioIndex;
 use crate::state::{ParameterState, State};
 use crate::timestep::Timestep;
 use crate::PywrError;
+use std::any::Any;
 
 pub struct AsymmetricSwitchIndexParameter {
     meta: ParameterMeta,
@@ -21,7 +22,11 @@ impl AsymmetricSwitchIndexParameter {
     }
 }
 
-impl IndexParameter for AsymmetricSwitchIndexParameter {
+impl Parameter<usize> for AsymmetricSwitchIndexParameter {
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+
     fn meta(&self) -> &ParameterMeta {
         &self.meta
     }

--- a/pywr-core/src/parameters/constant.rs
+++ b/pywr-core/src/parameters/constant.rs
@@ -37,7 +37,7 @@ impl ConstantParameter {
     }
 }
 
-impl Parameter for ConstantParameter {
+impl Parameter<f64> for ConstantParameter {
     fn as_any_mut(&mut self) -> &mut dyn Any {
         self
     }

--- a/pywr-core/src/parameters/control_curves/apportion.rs
+++ b/pywr-core/src/parameters/control_curves/apportion.rs
@@ -1,10 +1,11 @@
 use crate::metric::Metric;
 use crate::network::Network;
-use crate::parameters::{MultiValueParameter, ParameterMeta};
+use crate::parameters::{Parameter, ParameterMeta};
 use crate::scenario::ScenarioIndex;
 use crate::state::{MultiValue, ParameterState, State};
 use crate::timestep::Timestep;
 use crate::PywrError;
+use std::any::Any;
 use std::collections::HashMap;
 
 /// A parameter which divides a apportions a metric to an upper and lower amount based
@@ -31,7 +32,11 @@ impl ApportionParameter {
     }
 }
 
-impl MultiValueParameter for ApportionParameter {
+impl Parameter<MultiValue> for ApportionParameter {
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+
     fn meta(&self) -> &ParameterMeta {
         &self.meta
     }

--- a/pywr-core/src/parameters/control_curves/index.rs
+++ b/pywr-core/src/parameters/control_curves/index.rs
@@ -1,10 +1,11 @@
 use crate::metric::Metric;
 use crate::network::Network;
-use crate::parameters::{IndexParameter, ParameterMeta};
+use crate::parameters::{Parameter, ParameterMeta};
 use crate::scenario::ScenarioIndex;
 use crate::state::{ParameterState, State};
 use crate::timestep::Timestep;
 use crate::PywrError;
+use std::any::Any;
 
 pub struct ControlCurveIndexParameter {
     meta: ParameterMeta,
@@ -22,7 +23,11 @@ impl ControlCurveIndexParameter {
     }
 }
 
-impl IndexParameter for ControlCurveIndexParameter {
+impl Parameter<usize> for ControlCurveIndexParameter {
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+
     fn meta(&self) -> &ParameterMeta {
         &self.meta
     }

--- a/pywr-core/src/parameters/control_curves/interpolated.rs
+++ b/pywr-core/src/parameters/control_curves/interpolated.rs
@@ -26,7 +26,7 @@ impl ControlCurveInterpolatedParameter {
     }
 }
 
-impl Parameter for ControlCurveInterpolatedParameter {
+impl Parameter<f64> for ControlCurveInterpolatedParameter {
     fn as_any_mut(&mut self) -> &mut dyn Any {
         self
     }

--- a/pywr-core/src/parameters/control_curves/piecewise.rs
+++ b/pywr-core/src/parameters/control_curves/piecewise.rs
@@ -37,7 +37,7 @@ impl PiecewiseInterpolatedParameter {
     }
 }
 
-impl Parameter for PiecewiseInterpolatedParameter {
+impl Parameter<f64> for PiecewiseInterpolatedParameter {
     fn as_any_mut(&mut self) -> &mut dyn Any {
         self
     }

--- a/pywr-core/src/parameters/control_curves/simple.rs
+++ b/pywr-core/src/parameters/control_curves/simple.rs
@@ -25,7 +25,7 @@ impl ControlCurveParameter {
     }
 }
 
-impl Parameter for ControlCurveParameter {
+impl Parameter<f64> for ControlCurveParameter {
     fn as_any_mut(&mut self) -> &mut dyn Any {
         self
     }

--- a/pywr-core/src/parameters/control_curves/volume_between.rs
+++ b/pywr-core/src/parameters/control_curves/volume_between.rs
@@ -26,7 +26,7 @@ impl VolumeBetweenControlCurvesParameter {
     }
 }
 
-impl Parameter for VolumeBetweenControlCurvesParameter {
+impl Parameter<f64> for VolumeBetweenControlCurvesParameter {
     fn as_any_mut(&mut self) -> &mut dyn Any {
         self
     }

--- a/pywr-core/src/parameters/delay.rs
+++ b/pywr-core/src/parameters/delay.rs
@@ -26,7 +26,7 @@ impl DelayParameter {
     }
 }
 
-impl Parameter for DelayParameter {
+impl Parameter<f64> for DelayParameter {
     fn as_any_mut(&mut self) -> &mut dyn Any {
         self
     }

--- a/pywr-core/src/parameters/discount_factor.rs
+++ b/pywr-core/src/parameters/discount_factor.rs
@@ -24,7 +24,7 @@ impl DiscountFactorParameter {
     }
 }
 
-impl Parameter for DiscountFactorParameter {
+impl Parameter<f64> for DiscountFactorParameter {
     fn as_any_mut(&mut self) -> &mut dyn Any {
         self
     }

--- a/pywr-core/src/parameters/division.rs
+++ b/pywr-core/src/parameters/division.rs
@@ -24,7 +24,7 @@ impl DivisionParameter {
     }
 }
 
-impl Parameter for DivisionParameter {
+impl Parameter<f64> for DivisionParameter {
     fn as_any_mut(&mut self) -> &mut dyn Any {
         self
     }

--- a/pywr-core/src/parameters/indexed_array.rs
+++ b/pywr-core/src/parameters/indexed_array.rs
@@ -23,7 +23,7 @@ impl IndexedArrayParameter {
     }
 }
 
-impl Parameter for IndexedArrayParameter {
+impl Parameter<f64> for IndexedArrayParameter {
     fn as_any_mut(&mut self) -> &mut dyn Any {
         self
     }

--- a/pywr-core/src/parameters/interpolated.rs
+++ b/pywr-core/src/parameters/interpolated.rs
@@ -27,7 +27,7 @@ impl InterpolatedParameter {
     }
 }
 
-impl Parameter for InterpolatedParameter {
+impl Parameter<f64> for InterpolatedParameter {
     fn as_any_mut(&mut self) -> &mut dyn Any {
         self
     }

--- a/pywr-core/src/parameters/max.rs
+++ b/pywr-core/src/parameters/max.rs
@@ -24,7 +24,7 @@ impl MaxParameter {
     }
 }
 
-impl Parameter for MaxParameter {
+impl Parameter<f64> for MaxParameter {
     fn as_any_mut(&mut self) -> &mut dyn Any {
         self
     }

--- a/pywr-core/src/parameters/min.rs
+++ b/pywr-core/src/parameters/min.rs
@@ -24,7 +24,7 @@ impl MinParameter {
     }
 }
 
-impl Parameter for MinParameter {
+impl Parameter<f64> for MinParameter {
     fn as_any_mut(&mut self) -> &mut dyn Any {
         self
     }

--- a/pywr-core/src/parameters/negative.rs
+++ b/pywr-core/src/parameters/negative.rs
@@ -21,7 +21,7 @@ impl NegativeParameter {
     }
 }
 
-impl Parameter for NegativeParameter {
+impl Parameter<f64> for NegativeParameter {
     fn as_any_mut(&mut self) -> &mut dyn Any {
         self
     }

--- a/pywr-core/src/parameters/offset.rs
+++ b/pywr-core/src/parameters/offset.rs
@@ -41,7 +41,7 @@ impl OffsetParameter {
     }
 }
 
-impl Parameter for OffsetParameter {
+impl Parameter<f64> for OffsetParameter {
     fn as_any_mut(&mut self) -> &mut dyn Any {
         self
     }

--- a/pywr-core/src/parameters/polynomial.rs
+++ b/pywr-core/src/parameters/polynomial.rs
@@ -27,7 +27,7 @@ impl Polynomial1DParameter {
     }
 }
 
-impl Parameter for Polynomial1DParameter {
+impl Parameter<f64> for Polynomial1DParameter {
     fn as_any_mut(&mut self) -> &mut dyn Any {
         self
     }

--- a/pywr-core/src/parameters/profiles/daily.rs
+++ b/pywr-core/src/parameters/profiles/daily.rs
@@ -21,7 +21,7 @@ impl DailyProfileParameter {
     }
 }
 
-impl Parameter for DailyProfileParameter {
+impl Parameter<f64> for DailyProfileParameter {
     fn as_any_mut(&mut self) -> &mut dyn Any {
         self
     }

--- a/pywr-core/src/parameters/profiles/monthly.rs
+++ b/pywr-core/src/parameters/profiles/monthly.rs
@@ -67,7 +67,7 @@ fn interpolate_last(date: &NaiveDateTime, first_value: f64, last_value: f64) -> 
     }
 }
 
-impl Parameter for MonthlyProfileParameter {
+impl Parameter<f64> for MonthlyProfileParameter {
     fn as_any_mut(&mut self) -> &mut dyn Any {
         self
     }

--- a/pywr-core/src/parameters/profiles/rbf.rs
+++ b/pywr-core/src/parameters/profiles/rbf.rs
@@ -101,7 +101,7 @@ impl RbfProfileParameter {
     }
 }
 
-impl Parameter for RbfProfileParameter {
+impl Parameter<f64> for RbfProfileParameter {
     fn as_any_mut(&mut self) -> &mut dyn Any {
         self
     }

--- a/pywr-core/src/parameters/profiles/uniform_drawdown.rs
+++ b/pywr-core/src/parameters/profiles/uniform_drawdown.rs
@@ -32,7 +32,7 @@ impl UniformDrawdownProfileParameter {
     }
 }
 
-impl Parameter for UniformDrawdownProfileParameter {
+impl Parameter<f64> for UniformDrawdownProfileParameter {
     fn as_any_mut(&mut self) -> &mut dyn Any {
         self
     }

--- a/pywr-core/src/parameters/profiles/weekly.rs
+++ b/pywr-core/src/parameters/profiles/weekly.rs
@@ -180,7 +180,7 @@ impl WeeklyProfileParameter {
     }
 }
 
-impl Parameter for WeeklyProfileParameter {
+impl Parameter<f64> for WeeklyProfileParameter {
     fn as_any_mut(&mut self) -> &mut dyn Any {
         self
     }

--- a/pywr-core/src/parameters/rhai.rs
+++ b/pywr-core/src/parameters/rhai.rs
@@ -55,7 +55,7 @@ impl RhaiParameter {
     }
 }
 
-impl Parameter for RhaiParameter {
+impl Parameter<f64> for RhaiParameter {
     fn as_any_mut(&mut self) -> &mut dyn Any {
         self
     }

--- a/pywr-core/src/parameters/threshold.rs
+++ b/pywr-core/src/parameters/threshold.rs
@@ -1,10 +1,11 @@
 use crate::metric::Metric;
 use crate::network::Network;
-use crate::parameters::{downcast_internal_state_mut, IndexParameter, ParameterMeta};
+use crate::parameters::{downcast_internal_state_mut, Parameter, ParameterMeta};
 use crate::scenario::ScenarioIndex;
 use crate::state::{ParameterState, State};
 use crate::timestep::Timestep;
 use crate::PywrError;
+use std::any::Any;
 use std::str::FromStr;
 
 pub enum Predicate {
@@ -50,7 +51,11 @@ impl ThresholdParameter {
     }
 }
 
-impl IndexParameter for ThresholdParameter {
+impl Parameter<usize> for ThresholdParameter {
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+
     fn meta(&self) -> &ParameterMeta {
         &self.meta
     }

--- a/pywr-core/src/parameters/vector.rs
+++ b/pywr-core/src/parameters/vector.rs
@@ -20,7 +20,7 @@ impl VectorParameter {
     }
 }
 
-impl Parameter for VectorParameter {
+impl Parameter<f64> for VectorParameter {
     fn as_any_mut(&mut self) -> &mut dyn Any {
         self
     }

--- a/pywr-core/src/test_utils.rs
+++ b/pywr-core/src/test_utils.rs
@@ -158,7 +158,7 @@ pub fn simple_storage_model() -> Model {
 /// See [`AssertionRecorder`] for more information.
 pub fn run_and_assert_parameter(
     model: &mut Model,
-    parameter: Box<dyn Parameter>,
+    parameter: Box<dyn Parameter<f64>>,
     expected_values: Array2<f64>,
     ulps: Option<i64>,
     epsilon: Option<f64>,


### PR DESCRIPTION
This allows removing `IndexParameter` and `MultiValueParameter` traits, reducing code duplication.