### PR TITLE
refactor: Make ParameterIndex generic

### DIFF
--- a/pywr-core/src/lib.rs
+++ b/pywr-core/src/lib.rs
@@ -5,8 +5,9 @@ extern crate core;
 use crate::derived_metric::DerivedMetricIndex;
 use crate::models::MultiNetworkTransferIndex;
 use crate::node::NodeIndex;
-use crate::parameters::{IndexParameterIndex, InterpolationError, MultiValueParameterIndex, ParameterIndex};
+use crate::parameters::{InterpolationError, ParameterIndex};
 use crate::recorders::{AggregationError, MetricSetIndex, RecorderIndex};
+use crate::state::MultiValue;
 use crate::virtual_storage::VirtualStorageIndex;
 use pyo3::exceptions::{PyException, PyRuntimeError};
 use pyo3::{create_exception, PyErr};
@@ -44,11 +45,11 @@ pub enum PywrError {
     #[error("virtual storage index {0} not found")]
     VirtualStorageIndexNotFound(VirtualStorageIndex),
     #[error("parameter index {0} not found")]
-    ParameterIndexNotFound(ParameterIndex),
+    ParameterIndexNotFound(ParameterIndex<f64>),
     #[error("index parameter index {0} not found")]
-    IndexParameterIndexNotFound(IndexParameterIndex),
+    IndexParameterIndexNotFound(ParameterIndex<usize>),
     #[error("multi1 value parameter index {0} not found")]
-    MultiValueParameterIndexNotFound(MultiValueParameterIndex),
+    MultiValueParameterIndexNotFound(ParameterIndex<MultiValue>),
     #[error("multi1 value parameter key {0} not found")]
     MultiValueParameterKeyNotFound(String),
     #[error("inter-network parameter state not initialised")]
@@ -72,9 +73,9 @@ pub enum PywrError {
     #[error("node name `{0}` already exists")]
     NodeNameAlreadyExists(String),
     #[error("parameter name `{0}` already exists at index {1}")]
-    ParameterNameAlreadyExists(String, ParameterIndex),
+    ParameterNameAlreadyExists(String, ParameterIndex<f64>),
     #[error("index parameter name `{0}` already exists at index {1}")]
-    IndexParameterNameAlreadyExists(String, IndexParameterIndex),
+    IndexParameterNameAlreadyExists(String, ParameterIndex<usize>),
     #[error("metric set name `{0}` already exists")]
     MetricSetNameAlreadyExists(String),
     #[error("recorder name `{0}` already exists at index {1}")]
@@ -158,7 +159,7 @@ pub enum PywrError {
     #[error("parameters do not provide an initial value")]
     ParameterNoInitialValue,
     #[error("parameter state not found for parameter index {0}")]
-    ParameterStateNotFound(ParameterIndex),
+    ParameterStateNotFound(ParameterIndex<f64>),
     #[error("Could not create timestep range due to following error: {0}")]
     TimestepRangeGenerationError(String),
     #[error("Could not create timesteps for frequency '{0}'")]

--- a/pywr-core/src/metric.rs
+++ b/pywr-core/src/metric.rs
@@ -5,8 +5,8 @@ use crate::edge::EdgeIndex;
 use crate::models::MultiNetworkTransferIndex;
 use crate::network::Network;
 use crate::node::NodeIndex;
-use crate::parameters::{IndexParameterIndex, MultiValueParameterIndex, ParameterIndex};
-use crate::state::State;
+use crate::parameters::ParameterIndex;
+use crate::state::{MultiValue, State};
 use crate::virtual_storage::VirtualStorageIndex;
 use crate::PywrError;
 #[derive(Clone, Debug, PartialEq)]
@@ -18,8 +18,8 @@ pub enum Metric {
     AggregatedNodeOutFlow(AggregatedNodeIndex),
     AggregatedNodeVolume(AggregatedStorageNodeIndex),
     EdgeFlow(EdgeIndex),
-    ParameterValue(ParameterIndex),
-    MultiParameterValue((MultiValueParameterIndex, String)),
+    ParameterValue(ParameterIndex<f64>),
+    MultiParameterValue((ParameterIndex<MultiValue>, String)),
     VirtualStorageVolume(VirtualStorageIndex),
     MultiNodeInFlow { indices: Vec<NodeIndex>, name: String },
     MultiNodeOutFlow { indices: Vec<NodeIndex>, name: String },
@@ -87,7 +87,7 @@ impl Metric {
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum IndexMetric {
-    IndexParameterValue(IndexParameterIndex),
+    IndexParameterValue(ParameterIndex<usize>),
     Constant(usize),
 }
 

--- a/pywr-schema/src/parameters/aggregated.rs
+++ b/pywr-schema/src/parameters/aggregated.rs
@@ -6,7 +6,7 @@ use crate::parameters::{
     TryIntoV2Parameter,
 };
 use pywr_core::models::ModelDomain;
-use pywr_core::parameters::{IndexParameterIndex, ParameterIndex};
+use pywr_core::parameters::ParameterIndex;
 use pywr_v1_schema::parameters::{
     AggFunc as AggFuncV1, AggregatedIndexParameter as AggregatedIndexParameterV1,
     AggregatedParameter as AggregatedParameterV1, IndexAggFunc as IndexAggFuncV1,
@@ -99,7 +99,7 @@ impl AggregatedParameter {
         tables: &LoadedTableCollection,
         data_path: Option<&Path>,
         inter_network_transfers: &[PywrMultiNetworkTransfer],
-    ) -> Result<ParameterIndex, SchemaError> {
+    ) -> Result<ParameterIndex<f64>, SchemaError> {
         let metrics = self
             .metrics
             .iter()
@@ -206,7 +206,7 @@ impl AggregatedIndexParameter {
         tables: &LoadedTableCollection,
         data_path: Option<&Path>,
         inter_network_transfers: &[PywrMultiNetworkTransfer],
-    ) -> Result<IndexParameterIndex, SchemaError> {
+    ) -> Result<ParameterIndex<usize>, SchemaError> {
         let parameters = self
             .parameters
             .iter()

--- a/pywr-schema/src/parameters/asymmetric_switch.rs
+++ b/pywr-schema/src/parameters/asymmetric_switch.rs
@@ -5,7 +5,7 @@ use crate::parameters::{
     DynamicFloatValueType, DynamicIndexValue, IntoV2Parameter, ParameterMeta, TryFromV1Parameter, TryIntoV2Parameter,
 };
 use pywr_core::models::ModelDomain;
-use pywr_core::parameters::IndexParameterIndex;
+use pywr_core::parameters::ParameterIndex;
 use pywr_v1_schema::parameters::AsymmetricSwitchIndexParameter as AsymmetricSwitchIndexParameterV1;
 use std::collections::HashMap;
 use std::path::Path;
@@ -34,7 +34,7 @@ impl AsymmetricSwitchIndexParameter {
         tables: &LoadedTableCollection,
         data_path: Option<&Path>,
         inter_network_transfers: &[PywrMultiNetworkTransfer],
-    ) -> Result<IndexParameterIndex, SchemaError> {
+    ) -> Result<ParameterIndex<usize>, SchemaError> {
         let on_index_parameter =
             self.on_index_parameter
                 .load(network, schema, domain, tables, data_path, inter_network_transfers)?;

--- a/pywr-schema/src/parameters/control_curves.rs
+++ b/pywr-schema/src/parameters/control_curves.rs
@@ -6,7 +6,7 @@ use crate::parameters::{
     DynamicFloatValue, IntoV2Parameter, NodeReference, ParameterMeta, TryFromV1Parameter, TryIntoV2Parameter,
 };
 use pywr_core::models::ModelDomain;
-use pywr_core::parameters::{IndexParameterIndex, ParameterIndex};
+use pywr_core::parameters::ParameterIndex;
 use pywr_v1_schema::parameters::{
     ControlCurveIndexParameter as ControlCurveIndexParameterV1,
     ControlCurveInterpolatedParameter as ControlCurveInterpolatedParameterV1,
@@ -33,7 +33,7 @@ impl ControlCurveInterpolatedParameter {
         tables: &LoadedTableCollection,
         data_path: Option<&Path>,
         inter_network_transfers: &[PywrMultiNetworkTransfer],
-    ) -> Result<ParameterIndex, SchemaError> {
+    ) -> Result<ParameterIndex<f64>, SchemaError> {
         let metric = self.storage_node.load(network, schema)?;
 
         let control_curves = self
@@ -136,7 +136,7 @@ impl ControlCurveIndexParameter {
         tables: &LoadedTableCollection,
         data_path: Option<&Path>,
         inter_network_transfers: &[PywrMultiNetworkTransfer],
-    ) -> Result<IndexParameterIndex, SchemaError> {
+    ) -> Result<ParameterIndex<usize>, SchemaError> {
         let metric = self.storage_node.load(network, schema)?;
 
         let control_curves = self
@@ -247,7 +247,7 @@ impl ControlCurveParameter {
         tables: &LoadedTableCollection,
         data_path: Option<&Path>,
         inter_network_transfers: &[PywrMultiNetworkTransfer],
-    ) -> Result<ParameterIndex, SchemaError> {
+    ) -> Result<ParameterIndex<f64>, SchemaError> {
         let metric = self.storage_node.load(network, schema)?;
 
         let control_curves = self
@@ -341,7 +341,7 @@ impl ControlCurvePiecewiseInterpolatedParameter {
         tables: &LoadedTableCollection,
         data_path: Option<&Path>,
         inter_network_transfers: &[PywrMultiNetworkTransfer],
-    ) -> Result<ParameterIndex, SchemaError> {
+    ) -> Result<ParameterIndex<f64>, SchemaError> {
         let metric = self.storage_node.load(network, schema)?;
 
         let control_curves = self

--- a/pywr-schema/src/parameters/core.rs
+++ b/pywr-schema/src/parameters/core.rs
@@ -170,7 +170,7 @@ impl ConstantParameter {
         &self,
         network: &mut pywr_core::network::Network,
         tables: &LoadedTableCollection,
-    ) -> Result<ParameterIndex, SchemaError> {
+    ) -> Result<ParameterIndex<f64>, SchemaError> {
         let p = pywr_core::parameters::ConstantParameter::new(&self.meta.name, self.value.load(tables)?);
         Ok(network.add_parameter(Box::new(p))?)
     }
@@ -226,7 +226,7 @@ impl MaxParameter {
         tables: &LoadedTableCollection,
         data_path: Option<&Path>,
         inter_network_transfers: &[PywrMultiNetworkTransfer],
-    ) -> Result<ParameterIndex, SchemaError> {
+    ) -> Result<ParameterIndex<f64>, SchemaError> {
         let idx = self
             .parameter
             .load(network, schema, domain, tables, data_path, inter_network_transfers)?;
@@ -301,7 +301,7 @@ impl DivisionParameter {
         tables: &LoadedTableCollection,
         data_path: Option<&Path>,
         inter_network_transfers: &[PywrMultiNetworkTransfer],
-    ) -> Result<ParameterIndex, SchemaError> {
+    ) -> Result<ParameterIndex<f64>, SchemaError> {
         let n = self
             .numerator
             .load(network, schema, domain, tables, data_path, inter_network_transfers)?;
@@ -376,7 +376,7 @@ impl MinParameter {
         tables: &LoadedTableCollection,
         data_path: Option<&Path>,
         inter_network_transfers: &[PywrMultiNetworkTransfer],
-    ) -> Result<ParameterIndex, SchemaError> {
+    ) -> Result<ParameterIndex<f64>, SchemaError> {
         let idx = self
             .parameter
             .load(network, schema, domain, tables, data_path, inter_network_transfers)?;
@@ -433,7 +433,7 @@ impl NegativeParameter {
         tables: &LoadedTableCollection,
         data_path: Option<&Path>,
         inter_network_transfers: &[PywrMultiNetworkTransfer],
-    ) -> Result<ParameterIndex, SchemaError> {
+    ) -> Result<ParameterIndex<f64>, SchemaError> {
         let idx = self
             .parameter
             .load(network, schema, domain, tables, data_path, inter_network_transfers)?;

--- a/pywr-schema/src/parameters/data_frame.rs
+++ b/pywr-schema/src/parameters/data_frame.rs
@@ -75,7 +75,7 @@ impl DataFrameParameter {
         network: &mut pywr_core::network::Network,
         domain: &ModelDomain,
         data_path: Option<&Path>,
-    ) -> Result<ParameterIndex, SchemaError> {
+    ) -> Result<ParameterIndex<f64>, SchemaError> {
         // Handle the case of an optional data path with a relative url.
         let pth = if let Some(dp) = data_path {
             if self.url.is_relative() {

--- a/pywr-schema/src/parameters/delay.rs
+++ b/pywr-schema/src/parameters/delay.rs
@@ -39,7 +39,7 @@ impl DelayParameter {
         tables: &LoadedTableCollection,
         data_path: Option<&Path>,
         inter_network_transfers: &[PywrMultiNetworkTransfer],
-    ) -> Result<ParameterIndex, SchemaError> {
+    ) -> Result<ParameterIndex<f64>, SchemaError> {
         let metric = self
             .metric
             .load(network, schema, domain, tables, data_path, inter_network_transfers)?;

--- a/pywr-schema/src/parameters/discount_factor.rs
+++ b/pywr-schema/src/parameters/discount_factor.rs
@@ -40,7 +40,7 @@ impl DiscountFactorParameter {
         tables: &LoadedTableCollection,
         data_path: Option<&Path>,
         inter_network_transfers: &[PywrMultiNetworkTransfer],
-    ) -> Result<ParameterIndex, SchemaError> {
+    ) -> Result<ParameterIndex<f64>, SchemaError> {
         let discount_rate =
             self.discount_rate
                 .load(network, schema, domain, tables, data_path, inter_network_transfers)?;

--- a/pywr-schema/src/parameters/indexed_array.rs
+++ b/pywr-schema/src/parameters/indexed_array.rs
@@ -42,7 +42,7 @@ impl IndexedArrayParameter {
         tables: &LoadedTableCollection,
         data_path: Option<&Path>,
         inter_network_transfers: &[PywrMultiNetworkTransfer],
-    ) -> Result<ParameterIndex, SchemaError> {
+    ) -> Result<ParameterIndex<f64>, SchemaError> {
         let index_parameter =
             self.index_parameter
                 .load(network, schema, domain, tables, data_path, inter_network_transfers)?;

--- a/pywr-schema/src/parameters/interpolated.rs
+++ b/pywr-schema/src/parameters/interpolated.rs
@@ -58,7 +58,7 @@ impl InterpolatedParameter {
         tables: &LoadedTableCollection,
         data_path: Option<&Path>,
         inter_network_transfers: &[PywrMultiNetworkTransfer],
-    ) -> Result<ParameterIndex, SchemaError> {
+    ) -> Result<ParameterIndex<f64>, SchemaError> {
         let x = self
             .x
             .load(network, schema, domain, tables, data_path, inter_network_transfers)?;

--- a/pywr-schema/src/parameters/mod.rs
+++ b/pywr-schema/src/parameters/mod.rs
@@ -53,7 +53,7 @@ use crate::parameters::interpolated::InterpolatedParameter;
 pub use offset::OffsetParameter;
 use pywr_core::metric::Metric;
 use pywr_core::models::{ModelDomain, MultiNetworkTransferIndex};
-use pywr_core::parameters::{IndexParameterIndex, IndexValue, ParameterType};
+use pywr_core::parameters::{IndexValue, ParameterIndex, ParameterType};
 use pywr_v1_schema::parameters::{
     CoreParameter, ExternalDataRef as ExternalDataRefV1, Parameter as ParameterV1, ParameterMeta as ParameterMetaV1,
     ParameterValue as ParameterValueV1, TableIndex as TableIndexV1, TableIndexEntry as TableIndexEntryV1,
@@ -718,7 +718,7 @@ impl ParameterIndexValue {
         tables: &LoadedTableCollection,
         data_path: Option<&Path>,
         inter_network_transfers: &[PywrMultiNetworkTransfer],
-    ) -> Result<IndexParameterIndex, SchemaError> {
+    ) -> Result<ParameterIndex<usize>, SchemaError> {
         match self {
             Self::Reference(name) => {
                 // This should be an existing parameter

--- a/pywr-schema/src/parameters/offset.rs
+++ b/pywr-schema/src/parameters/offset.rs
@@ -55,7 +55,7 @@ impl OffsetParameter {
         tables: &LoadedTableCollection,
         data_path: Option<&Path>,
         inter_network_transfers: &[PywrMultiNetworkTransfer],
-    ) -> Result<ParameterIndex, SchemaError> {
+    ) -> Result<ParameterIndex<f64>, SchemaError> {
         let idx = self
             .metric
             .load(network, schema, domain, tables, data_path, inter_network_transfers)?;

--- a/pywr-schema/src/parameters/polynomial.rs
+++ b/pywr-schema/src/parameters/polynomial.rs
@@ -23,7 +23,7 @@ impl Polynomial1DParameter {
         HashMap::new()
     }
 
-    pub fn add_to_model(&self, network: &mut pywr_core::network::Network) -> Result<ParameterIndex, SchemaError> {
+    pub fn add_to_model(&self, network: &mut pywr_core::network::Network) -> Result<ParameterIndex<f64>, SchemaError> {
         let metric =
             network.get_storage_node_metric(&self.storage_node, None, self.use_proportional_volume.unwrap_or(true))?;
 

--- a/pywr-schema/src/parameters/profiles.rs
+++ b/pywr-schema/src/parameters/profiles.rs
@@ -31,7 +31,7 @@ impl DailyProfileParameter {
         &self,
         network: &mut pywr_core::network::Network,
         tables: &LoadedTableCollection,
-    ) -> Result<ParameterIndex, SchemaError> {
+    ) -> Result<ParameterIndex<f64>, SchemaError> {
         let values = &self.values.load(tables)?[..366];
         let p = pywr_core::parameters::DailyProfileParameter::new(&self.meta.name, values.try_into().expect(""));
         Ok(network.add_parameter(Box::new(p))?)
@@ -101,7 +101,7 @@ impl MonthlyProfileParameter {
         &self,
         network: &mut pywr_core::network::Network,
         tables: &LoadedTableCollection,
-    ) -> Result<ParameterIndex, SchemaError> {
+    ) -> Result<ParameterIndex<f64>, SchemaError> {
         let values = &self.values.load(tables)?[..12];
         let p = pywr_core::parameters::MonthlyProfileParameter::new(
             &self.meta.name,
@@ -175,7 +175,7 @@ impl UniformDrawdownProfileParameter {
         &self,
         network: &mut pywr_core::network::Network,
         tables: &LoadedTableCollection,
-    ) -> Result<ParameterIndex, SchemaError> {
+    ) -> Result<ParameterIndex<f64>, SchemaError> {
         let reset_day = match &self.reset_day {
             Some(v) => v.load(tables)? as u32,
             None => 1,
@@ -363,7 +363,7 @@ impl RbfProfileParameter {
         HashMap::new()
     }
 
-    pub fn add_to_model(&self, network: &mut pywr_core::network::Network) -> Result<ParameterIndex, SchemaError> {
+    pub fn add_to_model(&self, network: &mut pywr_core::network::Network) -> Result<ParameterIndex<f64>, SchemaError> {
         let function = self.function.into_core_rbf(&self.points)?;
 
         let p = pywr_core::parameters::RbfProfileParameter::new(&self.meta.name, self.points.clone(), function);
@@ -545,7 +545,7 @@ impl WeeklyProfileParameter {
         &self,
         network: &mut pywr_core::network::Network,
         tables: &LoadedTableCollection,
-    ) -> Result<ParameterIndex, SchemaError> {
+    ) -> Result<ParameterIndex<f64>, SchemaError> {
         let p = pywr_core::parameters::WeeklyProfileParameter::new(
             &self.meta.name,
             WeeklyProfileValues::try_from(self.values.load(tables)?.as_slice()).map_err(

--- a/pywr-schema/src/parameters/tables.rs
+++ b/pywr-schema/src/parameters/tables.rs
@@ -33,7 +33,7 @@ impl TablesArrayParameter {
         network: &mut pywr_core::network::Network,
         domain: &ModelDomain,
         data_path: Option<&Path>,
-    ) -> Result<ParameterIndex, SchemaError> {
+    ) -> Result<ParameterIndex<f64>, SchemaError> {
         // 1. Load the file from the HDF5 file (NB this is not Pandas format).
 
         // Handle the case of an optional data path with a relative url.

--- a/pywr-schema/src/parameters/thresholds.rs
+++ b/pywr-schema/src/parameters/thresholds.rs
@@ -5,7 +5,7 @@ use crate::parameters::{
     DynamicFloatValue, DynamicFloatValueType, IntoV2Parameter, ParameterMeta, TryFromV1Parameter, TryIntoV2Parameter,
 };
 use pywr_core::models::ModelDomain;
-use pywr_core::parameters::IndexParameterIndex;
+use pywr_core::parameters::ParameterIndex;
 use pywr_v1_schema::parameters::{
     ParameterThresholdParameter as ParameterThresholdParameterV1, Predicate as PredicateV1,
 };
@@ -77,7 +77,7 @@ impl ParameterThresholdParameter {
         tables: &LoadedTableCollection,
         data_path: Option<&Path>,
         inter_network_transfers: &[PywrMultiNetworkTransfer],
-    ) -> Result<IndexParameterIndex, SchemaError> {
+    ) -> Result<ParameterIndex<usize>, SchemaError> {
         let metric = self
             .parameter
             .load(network, schema, domain, tables, data_path, inter_network_transfers)?;


### PR DESCRIPTION
This removes `IndexParameterIndex` (awful name!) and `MultiValueParameterIndex` in favour of a generic `ParameterIndex<T>.` Where `T` is the return type of the associated `Parameter<T>`. This ensures there is stronger type constraints to prevent using the wrong index in the wrong vec of parameters.