### PR TITLE
chore: Remove Parameter::as_any_mut

### DIFF
--- a/pywr-core/src/parameters/aggregated.rs
+++ b/pywr-core/src/parameters/aggregated.rs
@@ -5,7 +5,6 @@ use crate::parameters::{Parameter, ParameterMeta};
 use crate::scenario::ScenarioIndex;
 use crate::state::{ParameterState, State};
 use crate::timestep::Timestep;
-use std::any::Any;
 use std::str::FromStr;
 
 pub enum AggFunc {
@@ -48,9 +47,6 @@ impl AggregatedParameter {
 }
 
 impl Parameter<f64> for AggregatedParameter {
-    fn as_any_mut(&mut self) -> &mut dyn Any {
-        self
-    }
     fn meta(&self) -> &ParameterMeta {
         &self.meta
     }

--- a/pywr-core/src/parameters/aggregated_index.rs
+++ b/pywr-core/src/parameters/aggregated_index.rs
@@ -6,7 +6,6 @@ use crate::parameters::{IndexValue, Parameter, ParameterMeta};
 use crate::scenario::ScenarioIndex;
 use crate::state::{ParameterState, State};
 use crate::timestep::Timestep;
-use std::any::Any;
 use std::str::FromStr;
 
 pub enum AggIndexFunc {
@@ -51,10 +50,6 @@ impl AggregatedIndexParameter {
 }
 
 impl Parameter<usize> for AggregatedIndexParameter {
-    fn as_any_mut(&mut self) -> &mut dyn Any {
-        self
-    }
-
     fn meta(&self) -> &ParameterMeta {
         &self.meta
     }

--- a/pywr-core/src/parameters/array.rs
+++ b/pywr-core/src/parameters/array.rs
@@ -5,7 +5,6 @@ use crate::state::{ParameterState, State};
 use crate::timestep::Timestep;
 use crate::PywrError;
 use ndarray::{Array1, Array2, Axis};
-use std::any::Any;
 
 pub struct Array1Parameter {
     meta: ParameterMeta,
@@ -24,9 +23,6 @@ impl Array1Parameter {
 }
 
 impl Parameter<f64> for Array1Parameter {
-    fn as_any_mut(&mut self) -> &mut dyn Any {
-        self
-    }
     fn meta(&self) -> &ParameterMeta {
         &self.meta
     }
@@ -67,9 +63,6 @@ impl Array2Parameter {
 }
 
 impl Parameter<f64> for Array2Parameter {
-    fn as_any_mut(&mut self) -> &mut dyn Any {
-        self
-    }
     fn meta(&self) -> &ParameterMeta {
         &self.meta
     }

--- a/pywr-core/src/parameters/asymmetric.rs
+++ b/pywr-core/src/parameters/asymmetric.rs
@@ -4,7 +4,6 @@ use crate::scenario::ScenarioIndex;
 use crate::state::{ParameterState, State};
 use crate::timestep::Timestep;
 use crate::PywrError;
-use std::any::Any;
 
 pub struct AsymmetricSwitchIndexParameter {
     meta: ParameterMeta,
@@ -23,10 +22,6 @@ impl AsymmetricSwitchIndexParameter {
 }
 
 impl Parameter<usize> for AsymmetricSwitchIndexParameter {
-    fn as_any_mut(&mut self) -> &mut dyn Any {
-        self
-    }
-
     fn meta(&self) -> &ParameterMeta {
         &self.meta
     }

--- a/pywr-core/src/parameters/constant.rs
+++ b/pywr-core/src/parameters/constant.rs
@@ -7,7 +7,6 @@ use crate::scenario::ScenarioIndex;
 use crate::state::{ParameterState, State};
 use crate::timestep::Timestep;
 use crate::PywrError;
-use std::any::Any;
 
 pub struct ConstantParameter {
     meta: ParameterMeta,
@@ -38,10 +37,6 @@ impl ConstantParameter {
 }
 
 impl Parameter<f64> for ConstantParameter {
-    fn as_any_mut(&mut self) -> &mut dyn Any {
-        self
-    }
-
     fn meta(&self) -> &ParameterMeta {
         &self.meta
     }

--- a/pywr-core/src/parameters/control_curves/apportion.rs
+++ b/pywr-core/src/parameters/control_curves/apportion.rs
@@ -5,7 +5,6 @@ use crate::scenario::ScenarioIndex;
 use crate::state::{MultiValue, ParameterState, State};
 use crate::timestep::Timestep;
 use crate::PywrError;
-use std::any::Any;
 use std::collections::HashMap;
 
 /// A parameter which divides a apportions a metric to an upper and lower amount based
@@ -33,10 +32,6 @@ impl ApportionParameter {
 }
 
 impl Parameter<MultiValue> for ApportionParameter {
-    fn as_any_mut(&mut self) -> &mut dyn Any {
-        self
-    }
-
     fn meta(&self) -> &ParameterMeta {
         &self.meta
     }

--- a/pywr-core/src/parameters/control_curves/index.rs
+++ b/pywr-core/src/parameters/control_curves/index.rs
@@ -5,7 +5,6 @@ use crate::scenario::ScenarioIndex;
 use crate::state::{ParameterState, State};
 use crate::timestep::Timestep;
 use crate::PywrError;
-use std::any::Any;
 
 pub struct ControlCurveIndexParameter {
     meta: ParameterMeta,
@@ -24,10 +23,6 @@ impl ControlCurveIndexParameter {
 }
 
 impl Parameter<usize> for ControlCurveIndexParameter {
-    fn as_any_mut(&mut self) -> &mut dyn Any {
-        self
-    }
-
     fn meta(&self) -> &ParameterMeta {
         &self.meta
     }

--- a/pywr-core/src/parameters/control_curves/interpolated.rs
+++ b/pywr-core/src/parameters/control_curves/interpolated.rs
@@ -6,7 +6,6 @@ use crate::scenario::ScenarioIndex;
 use crate::state::{ParameterState, State};
 use crate::timestep::Timestep;
 use crate::PywrError;
-use std::any::Any;
 
 pub struct ControlCurveInterpolatedParameter {
     meta: ParameterMeta,
@@ -27,9 +26,6 @@ impl ControlCurveInterpolatedParameter {
 }
 
 impl Parameter<f64> for ControlCurveInterpolatedParameter {
-    fn as_any_mut(&mut self) -> &mut dyn Any {
-        self
-    }
     fn meta(&self) -> &ParameterMeta {
         &self.meta
     }

--- a/pywr-core/src/parameters/control_curves/piecewise.rs
+++ b/pywr-core/src/parameters/control_curves/piecewise.rs
@@ -6,7 +6,6 @@ use crate::scenario::ScenarioIndex;
 use crate::state::{ParameterState, State};
 use crate::timestep::Timestep;
 use crate::PywrError;
-use std::any::Any;
 
 pub struct PiecewiseInterpolatedParameter {
     meta: ParameterMeta,
@@ -38,9 +37,6 @@ impl PiecewiseInterpolatedParameter {
 }
 
 impl Parameter<f64> for PiecewiseInterpolatedParameter {
-    fn as_any_mut(&mut self) -> &mut dyn Any {
-        self
-    }
     fn meta(&self) -> &ParameterMeta {
         &self.meta
     }

--- a/pywr-core/src/parameters/control_curves/simple.rs
+++ b/pywr-core/src/parameters/control_curves/simple.rs
@@ -5,7 +5,6 @@ use crate::scenario::ScenarioIndex;
 use crate::state::{ParameterState, State};
 use crate::timestep::Timestep;
 use crate::PywrError;
-use std::any::Any;
 
 pub struct ControlCurveParameter {
     meta: ParameterMeta,
@@ -26,9 +25,6 @@ impl ControlCurveParameter {
 }
 
 impl Parameter<f64> for ControlCurveParameter {
-    fn as_any_mut(&mut self) -> &mut dyn Any {
-        self
-    }
     fn meta(&self) -> &ParameterMeta {
         &self.meta
     }

--- a/pywr-core/src/parameters/control_curves/volume_between.rs
+++ b/pywr-core/src/parameters/control_curves/volume_between.rs
@@ -5,7 +5,6 @@ use crate::scenario::ScenarioIndex;
 use crate::state::{ParameterState, State};
 use crate::timestep::Timestep;
 use crate::PywrError;
-use std::any::Any;
 
 /// A parameter that returns the volume that is the proportion between two control curves
 pub struct VolumeBetweenControlCurvesParameter {
@@ -27,10 +26,6 @@ impl VolumeBetweenControlCurvesParameter {
 }
 
 impl Parameter<f64> for VolumeBetweenControlCurvesParameter {
-    fn as_any_mut(&mut self) -> &mut dyn Any {
-        self
-    }
-
     fn meta(&self) -> &ParameterMeta {
         &self.meta
     }

--- a/pywr-core/src/parameters/delay.rs
+++ b/pywr-core/src/parameters/delay.rs
@@ -5,7 +5,6 @@ use crate::scenario::ScenarioIndex;
 use crate::state::{ParameterState, State};
 use crate::timestep::Timestep;
 use crate::PywrError;
-use std::any::Any;
 use std::collections::VecDeque;
 
 pub struct DelayParameter {
@@ -27,9 +26,6 @@ impl DelayParameter {
 }
 
 impl Parameter<f64> for DelayParameter {
-    fn as_any_mut(&mut self) -> &mut dyn Any {
-        self
-    }
     fn meta(&self) -> &ParameterMeta {
         &self.meta
     }

--- a/pywr-core/src/parameters/discount_factor.rs
+++ b/pywr-core/src/parameters/discount_factor.rs
@@ -6,7 +6,6 @@ use crate::state::{ParameterState, State};
 use crate::timestep::Timestep;
 use crate::PywrError;
 use chrono::Datelike;
-use std::any::Any;
 
 pub struct DiscountFactorParameter {
     meta: ParameterMeta,
@@ -25,9 +24,6 @@ impl DiscountFactorParameter {
 }
 
 impl Parameter<f64> for DiscountFactorParameter {
-    fn as_any_mut(&mut self) -> &mut dyn Any {
-        self
-    }
     fn meta(&self) -> &ParameterMeta {
         &self.meta
     }

--- a/pywr-core/src/parameters/division.rs
+++ b/pywr-core/src/parameters/division.rs
@@ -6,7 +6,6 @@ use crate::scenario::ScenarioIndex;
 use crate::state::{ParameterState, State};
 use crate::timestep::Timestep;
 use crate::PywrError::InvalidMetricValue;
-use std::any::Any;
 
 pub struct DivisionParameter {
     meta: ParameterMeta,
@@ -25,9 +24,6 @@ impl DivisionParameter {
 }
 
 impl Parameter<f64> for DivisionParameter {
-    fn as_any_mut(&mut self) -> &mut dyn Any {
-        self
-    }
     fn meta(&self) -> &ParameterMeta {
         &self.meta
     }

--- a/pywr-core/src/parameters/indexed_array.rs
+++ b/pywr-core/src/parameters/indexed_array.rs
@@ -5,7 +5,6 @@ use crate::scenario::ScenarioIndex;
 use crate::state::{ParameterState, State};
 use crate::timestep::Timestep;
 use crate::PywrError;
-use std::any::Any;
 
 pub struct IndexedArrayParameter {
     meta: ParameterMeta,
@@ -24,9 +23,6 @@ impl IndexedArrayParameter {
 }
 
 impl Parameter<f64> for IndexedArrayParameter {
-    fn as_any_mut(&mut self) -> &mut dyn Any {
-        self
-    }
     fn meta(&self) -> &ParameterMeta {
         &self.meta
     }

--- a/pywr-core/src/parameters/interpolated.rs
+++ b/pywr-core/src/parameters/interpolated.rs
@@ -6,7 +6,6 @@ use crate::scenario::ScenarioIndex;
 use crate::state::{ParameterState, State};
 use crate::timestep::Timestep;
 use crate::PywrError;
-use std::any::Any;
 
 /// A parameter that interpolates a value to a function with given discrete data points.
 pub struct InterpolatedParameter {
@@ -28,9 +27,6 @@ impl InterpolatedParameter {
 }
 
 impl Parameter<f64> for InterpolatedParameter {
-    fn as_any_mut(&mut self) -> &mut dyn Any {
-        self
-    }
     fn meta(&self) -> &ParameterMeta {
         &self.meta
     }

--- a/pywr-core/src/parameters/max.rs
+++ b/pywr-core/src/parameters/max.rs
@@ -2,8 +2,6 @@ use crate::metric::Metric;
 use crate::network::Network;
 use crate::parameters::{Parameter, ParameterMeta};
 use crate::scenario::ScenarioIndex;
-use std::any::Any;
-
 use crate::state::{ParameterState, State};
 use crate::timestep::Timestep;
 use crate::PywrError;
@@ -25,9 +23,6 @@ impl MaxParameter {
 }
 
 impl Parameter<f64> for MaxParameter {
-    fn as_any_mut(&mut self) -> &mut dyn Any {
-        self
-    }
     fn meta(&self) -> &ParameterMeta {
         &self.meta
     }

--- a/pywr-core/src/parameters/min.rs
+++ b/pywr-core/src/parameters/min.rs
@@ -2,8 +2,6 @@ use crate::metric::Metric;
 use crate::network::Network;
 use crate::parameters::{Parameter, ParameterMeta};
 use crate::scenario::ScenarioIndex;
-use std::any::Any;
-
 use crate::state::{ParameterState, State};
 use crate::timestep::Timestep;
 use crate::PywrError;
@@ -25,9 +23,6 @@ impl MinParameter {
 }
 
 impl Parameter<f64> for MinParameter {
-    fn as_any_mut(&mut self) -> &mut dyn Any {
-        self
-    }
     fn meta(&self) -> &ParameterMeta {
         &self.meta
     }

--- a/pywr-core/src/parameters/mod.rs
+++ b/pywr-core/src/parameters/mod.rs
@@ -204,7 +204,6 @@ pub fn downcast_variable_config_ref<T: 'static>(variable_config: &dyn VariableCo
 ///
 /// The trait is generic over the type of the value produced.
 pub trait Parameter<T>: Send + Sync {
-    fn as_any_mut(&mut self) -> &mut dyn Any;
     fn meta(&self) -> &ParameterMeta;
     fn name(&self) -> &str {
         self.meta().name.as_str()

--- a/pywr-core/src/parameters/negative.rs
+++ b/pywr-core/src/parameters/negative.rs
@@ -5,7 +5,6 @@ use crate::scenario::ScenarioIndex;
 use crate::state::{ParameterState, State};
 use crate::timestep::Timestep;
 use crate::PywrError;
-use std::any::Any;
 
 pub struct NegativeParameter {
     meta: ParameterMeta,
@@ -22,9 +21,6 @@ impl NegativeParameter {
 }
 
 impl Parameter<f64> for NegativeParameter {
-    fn as_any_mut(&mut self) -> &mut dyn Any {
-        self
-    }
     fn meta(&self) -> &ParameterMeta {
         &self.meta
     }

--- a/pywr-core/src/parameters/offset.rs
+++ b/pywr-core/src/parameters/offset.rs
@@ -5,8 +5,6 @@ use crate::parameters::{
     Parameter, ParameterMeta, VariableConfig, VariableParameter,
 };
 use crate::scenario::ScenarioIndex;
-use std::any::Any;
-
 use crate::state::{ParameterState, State};
 use crate::timestep::Timestep;
 use crate::PywrError;
@@ -42,9 +40,6 @@ impl OffsetParameter {
 }
 
 impl Parameter<f64> for OffsetParameter {
-    fn as_any_mut(&mut self) -> &mut dyn Any {
-        self
-    }
     fn meta(&self) -> &ParameterMeta {
         &self.meta
     }

--- a/pywr-core/src/parameters/polynomial.rs
+++ b/pywr-core/src/parameters/polynomial.rs
@@ -5,7 +5,6 @@ use crate::scenario::ScenarioIndex;
 use crate::state::{ParameterState, State};
 use crate::timestep::Timestep;
 use crate::PywrError;
-use std::any::Any;
 
 pub struct Polynomial1DParameter {
     meta: ParameterMeta,
@@ -28,9 +27,6 @@ impl Polynomial1DParameter {
 }
 
 impl Parameter<f64> for Polynomial1DParameter {
-    fn as_any_mut(&mut self) -> &mut dyn Any {
-        self
-    }
     fn meta(&self) -> &ParameterMeta {
         &self.meta
     }

--- a/pywr-core/src/parameters/profiles/daily.rs
+++ b/pywr-core/src/parameters/profiles/daily.rs
@@ -5,7 +5,6 @@ use crate::state::{ParameterState, State};
 use crate::timestep::Timestep;
 use crate::PywrError;
 use chrono::Datelike;
-use std::any::Any;
 
 pub struct DailyProfileParameter {
     meta: ParameterMeta,
@@ -22,9 +21,6 @@ impl DailyProfileParameter {
 }
 
 impl Parameter<f64> for DailyProfileParameter {
-    fn as_any_mut(&mut self) -> &mut dyn Any {
-        self
-    }
     fn meta(&self) -> &ParameterMeta {
         &self.meta
     }

--- a/pywr-core/src/parameters/profiles/monthly.rs
+++ b/pywr-core/src/parameters/profiles/monthly.rs
@@ -1,11 +1,10 @@
 use crate::network::Network;
-use crate::parameters::{Parameter, ParameterIndex, ParameterMeta};
+use crate::parameters::{Parameter, ParameterMeta};
 use crate::scenario::ScenarioIndex;
 use crate::state::{ParameterState, State};
 use crate::timestep::Timestep;
 use crate::PywrError;
 use chrono::{Datelike, NaiveDateTime, Timelike};
-use std::any::Any;
 
 #[derive(Copy, Clone)]
 pub enum MonthlyInterpDay {
@@ -72,9 +71,6 @@ fn interpolate_last(date: &NaiveDateTime, first_value: f64, last_value: f64) -> 
 }
 
 impl Parameter<f64> for MonthlyProfileParameter {
-    fn as_any_mut(&mut self) -> &mut dyn Any {
-        self
-    }
     fn meta(&self) -> &ParameterMeta {
         &self.meta
     }
@@ -107,23 +103,5 @@ impl Parameter<f64> for MonthlyProfileParameter {
             None => self.values[timestep.date.month() as usize - 1],
         };
         Ok(v)
-    }
-}
-
-// TODO this is a proof-of-concept of a external "variable"
-#[allow(dead_code)]
-pub struct MonthlyProfileVariable {
-    index: ParameterIndex,
-}
-
-#[allow(dead_code)]
-impl MonthlyProfileVariable {
-    fn update(&self, model: &mut Network, new_values: &[f64]) {
-        let p = model.get_mut_parameter(&self.index).unwrap();
-
-        let profile = p.as_any_mut().downcast_mut::<MonthlyProfileParameter>().unwrap();
-
-        // This panics if the slices are different lengths!
-        profile.values.copy_from_slice(new_values);
     }
 }

--- a/pywr-core/src/parameters/profiles/rbf.rs
+++ b/pywr-core/src/parameters/profiles/rbf.rs
@@ -9,7 +9,6 @@ use crate::timestep::Timestep;
 use crate::PywrError;
 use chrono::Datelike;
 use nalgebra::DMatrix;
-use std::any::Any;
 
 pub struct RbfProfileVariableConfig {
     days_of_year_range: Option<u32>,
@@ -102,10 +101,6 @@ impl RbfProfileParameter {
 }
 
 impl Parameter<f64> for RbfProfileParameter {
-    fn as_any_mut(&mut self) -> &mut dyn Any {
-        self
-    }
-
     fn meta(&self) -> &ParameterMeta {
         &self.meta
     }

--- a/pywr-core/src/parameters/profiles/uniform_drawdown.rs
+++ b/pywr-core/src/parameters/profiles/uniform_drawdown.rs
@@ -5,7 +5,6 @@ use crate::state::{ParameterState, State};
 use crate::timestep::Timestep;
 use crate::PywrError;
 use chrono::{Datelike, NaiveDate};
-use std::any::Any;
 
 fn is_leap_year(year: i32) -> bool {
     (year % 4 == 0) & ((year % 100 != 0) | (year % 400 == 0))
@@ -33,9 +32,6 @@ impl UniformDrawdownProfileParameter {
 }
 
 impl Parameter<f64> for UniformDrawdownProfileParameter {
-    fn as_any_mut(&mut self) -> &mut dyn Any {
-        self
-    }
     fn meta(&self) -> &ParameterMeta {
         &self.meta
     }

--- a/pywr-core/src/parameters/profiles/weekly.rs
+++ b/pywr-core/src/parameters/profiles/weekly.rs
@@ -5,7 +5,6 @@ use crate::state::{ParameterState, State};
 use crate::timestep::Timestep;
 use crate::PywrError;
 use chrono::{Datelike, NaiveDate, NaiveDateTime, Timelike};
-use std::any::Any;
 use thiserror::Error;
 
 pub enum WeeklyInterpDay {
@@ -186,9 +185,6 @@ impl WeeklyProfileParameter {
 }
 
 impl Parameter<f64> for WeeklyProfileParameter {
-    fn as_any_mut(&mut self) -> &mut dyn Any {
-        self
-    }
     fn meta(&self) -> &ParameterMeta {
         &self.meta
     }

--- a/pywr-core/src/parameters/py.rs
+++ b/pywr-core/src/parameters/py.rs
@@ -6,7 +6,6 @@ use crate::scenario::ScenarioIndex;
 use crate::state::{MultiValue, ParameterState, State};
 use pyo3::prelude::*;
 use pyo3::types::{IntoPyDict, PyDict, PyFloat, PyLong, PyTuple};
-use std::any::Any;
 use std::collections::HashMap;
 
 pub struct PyParameter {
@@ -70,9 +69,6 @@ impl PyParameter {
 }
 
 impl Parameter<f64> for PyParameter {
-    fn as_any_mut(&mut self) -> &mut dyn Any {
-        self
-    }
     fn meta(&self) -> &ParameterMeta {
         &self.meta
     }
@@ -165,10 +161,6 @@ impl Parameter<f64> for PyParameter {
 }
 
 impl Parameter<MultiValue> for PyParameter {
-    fn as_any_mut(&mut self) -> &mut dyn Any {
-        self
-    }
-
     fn meta(&self) -> &ParameterMeta {
         &self.meta
     }

--- a/pywr-core/src/parameters/rhai.rs
+++ b/pywr-core/src/parameters/rhai.rs
@@ -6,7 +6,6 @@ use crate::scenario::ScenarioIndex;
 use crate::state::{ParameterState, State};
 use chrono::Datelike;
 use rhai::{Dynamic, Engine, Map, Scope, AST};
-use std::any::Any;
 use std::collections::HashMap;
 
 pub struct RhaiParameter {
@@ -56,9 +55,6 @@ impl RhaiParameter {
 }
 
 impl Parameter<f64> for RhaiParameter {
-    fn as_any_mut(&mut self) -> &mut dyn Any {
-        self
-    }
     fn meta(&self) -> &ParameterMeta {
         &self.meta
     }

--- a/pywr-core/src/parameters/threshold.rs
+++ b/pywr-core/src/parameters/threshold.rs
@@ -5,7 +5,6 @@ use crate::scenario::ScenarioIndex;
 use crate::state::{ParameterState, State};
 use crate::timestep::Timestep;
 use crate::PywrError;
-use std::any::Any;
 use std::str::FromStr;
 
 pub enum Predicate {
@@ -52,10 +51,6 @@ impl ThresholdParameter {
 }
 
 impl Parameter<usize> for ThresholdParameter {
-    fn as_any_mut(&mut self) -> &mut dyn Any {
-        self
-    }
-
     fn meta(&self) -> &ParameterMeta {
         &self.meta
     }

--- a/pywr-core/src/parameters/vector.rs
+++ b/pywr-core/src/parameters/vector.rs
@@ -4,7 +4,6 @@ use crate::scenario::ScenarioIndex;
 use crate::state::{ParameterState, State};
 use crate::timestep::Timestep;
 use crate::PywrError;
-use std::any::Any;
 
 pub struct VectorParameter {
     meta: ParameterMeta,
@@ -21,9 +20,6 @@ impl VectorParameter {
 }
 
 impl Parameter<f64> for VectorParameter {
-    fn as_any_mut(&mut self) -> &mut dyn Any {
-        self
-    }
     fn meta(&self) -> &ParameterMeta {
         &self.meta
     }


### PR DESCRIPTION
This method was only used by an experiment into the variable API. That API was implemented in a different many. Therefore, remove this unused API and the associated experimental (and dead) code.