### PR TITLE
build: Build Python 3.9 ABI3 wheels.

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -58,7 +58,9 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: [ '3.9', '3.10', '3.11', '3.12' ]
+        # We produce abi3-py39 wheels for Python 3.9 later.
+        # If this is changed, then the PyO3 feature in the pywr-python/Cargo.toml file must also be updated.
+        python-version: [ '3.9' ]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -89,7 +91,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.9', '3.10', '3.11', '3.12' ]
+        # We produce abi3-py39 wheels for Python 3.9 later.
+        # If this is changed, then the PyO3 feature in the pywr-python/Cargo.toml file must also be updated.
+        python-version: [ '3.9' ]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/pywr-python/Cargo.toml
+++ b/pywr-python/Cargo.toml
@@ -14,15 +14,17 @@ categories = ["science", "simulation"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-pyo3 = {  workspace = true, features = ["extension-module", "macros"] }
-pyo3-polars = {  workspace = true }
-pyo3-log = {  workspace = true }
+# The Github workflow is configured to use the minimum version corresponding to the `abi3-pyXX` feature enabled here.
+# Please remember to update the workflow if changing the ABI version.
+pyo3 = { workspace = true, features = ["extension-module", "macros", "abi3-py39", "chrono"] }
+pyo3-polars = { workspace = true }
+pyo3-log = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 chrono = { workspace = true }
 
-pywr-core = { path="../pywr-core" }
-pywr-schema = { path="../pywr-schema" }
+pywr-core = { path = "../pywr-core" }
+pywr-schema = { path = "../pywr-schema" }
 
 
 [lib]

--- a/pywr-python/src/lib.rs
+++ b/pywr-python/src/lib.rs
@@ -1,7 +1,8 @@
-use chrono::NaiveDate;
+use chrono::NaiveDateTime;
 use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
-use pyo3::types::{PyDateAccess, PyDateTime, PyDict, PyTimeAccess, PyType};
+use pyo3::types::{PyDict, PyType};
+
 /// Python API
 ///
 /// The following structures provide a Python API to access the core model structures.
@@ -63,25 +64,9 @@ pub struct Schema {
 #[pymethods]
 impl Schema {
     #[new]
-    fn new(title: &str, start: &Bound<'_, PyDateTime>, end: &Bound<'_, PyDateTime>) -> Self {
-        // SAFETY: We know that the date & month are valid because it is a Python date.
-        let start = DateType::DateTime(
-            NaiveDate::from_ymd_opt(start.get_year(), start.get_month() as u32, start.get_day() as u32)
-                .unwrap()
-                .and_hms_opt(
-                    start.get_hour() as u32,
-                    start.get_minute() as u32,
-                    start.get_second() as u32,
-                )
-                .unwrap(),
-        );
-
-        let end = DateType::DateTime(
-            NaiveDate::from_ymd_opt(end.get_year(), end.get_month() as u32, end.get_day() as u32)
-                .unwrap()
-                .and_hms_opt(end.get_hour() as u32, end.get_minute() as u32, end.get_second() as u32)
-                .unwrap(),
-        );
+    fn new(title: &str, start: NaiveDateTime, end: NaiveDateTime) -> Self {
+        let start = DateType::DateTime(start);
+        let end = DateType::DateTime(end);
 
         Self {
             schema: pywr_schema::PywrModel::new(title, &start, &end),


### PR DESCRIPTION
Enable the "abi3-py39" feature in PyO3. This will now build ABI3 compatible wheels for Python 3.9 and above. Doing this reduces the need for separate builds for each Python version, and therefore reduces the number of CI jobs.