### PR TITLE
Use NodeReference in VirtualStorage

### DIFF
--- a/pywr-schema/src/metric.rs
+++ b/pywr-schema/src/metric.rs
@@ -297,6 +297,15 @@ impl NodeReference {
     }
 }
 
+impl From<String> for NodeReference{
+    fn from (v: String) -> Self {
+        NodeReference {
+            name: v,
+            attribute: None
+        }
+    }
+}
+
 #[derive(serde::Deserialize, serde::Serialize, Debug, Clone, JsonSchema)]
 pub struct ParameterReference {
     /// The name of the parameter


### PR DESCRIPTION
Update virtual storage node names to use NodeReference rather than String. #164 