### PR TITLE
feat: Support aggregation order in MemoryOutput.

### DIFF
--- a/pywr-core/src/recorders/mod.rs
+++ b/pywr-core/src/recorders/mod.rs
@@ -16,7 +16,7 @@ pub use aggregator::{AggregationFrequency, AggregationFunction, Aggregator};
 pub use csv::{CsvLongFmtOutput, CsvLongFmtRecord, CsvWideFmtOutput};
 use float_cmp::{approx_eq, ApproxEq, F64Margin};
 pub use hdf::HDF5Recorder;
-pub use memory::{Aggregation, AggregationError, MemoryRecorder};
+pub use memory::{Aggregation, AggregationError, AggregationOrder, MemoryRecorder};
 pub use metric_set::{MetricSet, MetricSetIndex, MetricSetState, OutputMetric};
 use ndarray::prelude::*;
 use ndarray::Array2;


### PR DESCRIPTION
This addresses a todo regarding allowing the user to specify the aggregation order for the "aggregated value" of the memory output.

It also fixes two Clippy warnings about unused functions.