### PR TITLE
feat: Implement deny_unknown_fields for many types.

### DIFF
--- a/pywr-python/tests/models/aggregated-node1/model.json
+++ b/pywr-python/tests/models/aggregated-node1/model.json
@@ -10,7 +10,9 @@
   "network": {
     "nodes": [
       {
-        "name": "input1",
+        "meta": {
+          "name": "input1"
+        },
         "type": "Input",
         "max_flow": {
           "type": "Timeseries",
@@ -22,7 +24,9 @@
         }
       },
       {
-        "name": "link1",
+        "meta": {
+          "name": "link1"
+        },
         "type": "Link",
         "max_flow": {
           "type": "Constant",
@@ -30,7 +34,9 @@
         }
       },
       {
-        "name": "link2",
+        "meta": {
+          "name": "link2"
+        },
         "type": "Link",
         "cost": {
           "type": "Constant",
@@ -38,7 +44,9 @@
         }
       },
       {
-        "name": "agg-node",
+        "meta": {
+          "name": "agg-node"
+        },
         "type": "Aggregated",
         "nodes": [
           "link1",
@@ -50,7 +58,9 @@
         }
       },
       {
-        "name": "output1",
+        "meta": {
+          "name": "output1"
+        },
         "type": "Output",
         "cost": {
           "type": "Constant",
@@ -82,14 +92,18 @@
     ],
     "parameters": [
       {
-        "name": "demand",
+        "meta": {
+          "name": "demand"
+        },
         "type": "Constant",
         "value": 10.0
       }
     ],
     "timeseries": [
       {
-        "name": "inflow",
+        "meta": {
+          "name": "inflow"
+        },
         "provider": {
           "type": "Polars",
           "url": "inflow.csv"

--- a/pywr-python/tests/models/piecewise-link1/model.json
+++ b/pywr-python/tests/models/piecewise-link1/model.json
@@ -10,7 +10,9 @@
   "network": {
     "nodes": [
       {
-        "name": "input1",
+        "meta": {
+          "name": "input1"
+        },
         "type": "Input",
         "max_flow": {
           "type": "Timeseries",
@@ -30,11 +32,15 @@
         }
       },
       {
-        "name": "link1",
+        "meta": {
+          "name": "link1"
+        },
         "type": "Link"
       },
       {
-        "name": "mrf1",
+        "meta": {
+          "name": "mrf1"
+        },
         "type": "PiecewiseLink",
         "steps": [
           {
@@ -52,11 +58,15 @@
         ]
       },
       {
-        "name": "term1",
+        "meta": {
+          "name": "term1"
+        },
         "type": "Output"
       },
       {
-        "name": "demand1",
+        "meta": {
+          "name": "demand1"
+        },
         "type": "Output",
         "cost": {
           "type": "Constant",
@@ -88,14 +98,18 @@
     ],
     "parameters": [
       {
-        "name": "demand",
+        "meta": {
+          "name": "demand"
+        },
         "type": "Constant",
         "value": 10.0
       }
     ],
     "timeseries": [
       {
-        "name": "inflow",
+        "meta": {
+          "name": "inflow"
+        },
         "provider": {
           "type": "Polars",
           "url": "inflow.csv"

--- a/pywr-python/tests/models/simple-custom-parameter/model.json
+++ b/pywr-python/tests/models/simple-custom-parameter/model.json
@@ -10,7 +10,9 @@
   "network": {
     "nodes": [
       {
-        "name": "input1",
+        "meta": {
+          "name": "input1"
+        },
         "type": "Input",
         "max_flow": {
           "type": "Timeseries",
@@ -22,11 +24,15 @@
         }
       },
       {
-        "name": "link1",
+        "meta": {
+          "name": "link1"
+        },
         "type": "Link"
       },
       {
-        "name": "output1",
+        "meta": {
+          "name": "output1"
+        },
         "type": "Output",
         "cost": {
           "type": "Constant",
@@ -50,9 +56,13 @@
     ],
     "parameters": [
       {
-        "name": "demand",
+        "meta": {
+          "name": "demand"
+        },
         "type": "Python",
-        "path": "custom.py",
+        "source": {
+          "path": "custom.py"
+        },
         "object": "CustomParameter",
         "args": [
           5.0
@@ -64,7 +74,9 @@
     ],
     "timeseries": [
       {
-        "name": "inflow",
+        "meta": {
+          "name": "inflow"
+        },
         "provider": {
           "type": "Polars",
           "url": "inflow.csv"

--- a/pywr-python/tests/models/simple-storage-timeseries/model.json
+++ b/pywr-python/tests/models/simple-storage-timeseries/model.json
@@ -10,7 +10,9 @@
   "network": {
     "nodes": [
       {
-        "name": "input1",
+        "meta": {
+          "name": "input1"
+        },
         "type": "Input",
         "max_flow": {
           "type": "Constant",
@@ -18,7 +20,9 @@
         }
       },
       {
-        "name": "storage1",
+        "meta": {
+          "name": "storage1"
+        },
         "type": "Storage",
         "cost": {
           "type": "Constant",
@@ -33,7 +37,9 @@
         }
       },
       {
-        "name": "output1",
+        "meta": {
+          "name": "output1"
+        },
         "type": "Output",
         "cost": {
           "type": "Constant",
@@ -57,7 +63,9 @@
     ],
     "parameters": [
       {
-        "name": "demand",
+        "meta": {
+          "name": "demand"
+        },
         "type": "Constant",
         "value": 10.0
       }

--- a/pywr-python/tests/models/simple-timeseries/model.json
+++ b/pywr-python/tests/models/simple-timeseries/model.json
@@ -10,7 +10,9 @@
   "network": {
     "nodes": [
       {
-        "name": "input1",
+        "meta": {
+          "name": "input1"
+        },
         "type": "Input",
         "max_flow": {
           "type": "Timeseries",
@@ -22,11 +24,15 @@
         }
       },
       {
-        "name": "link1",
+        "meta": {
+          "name": "link1"
+        },
         "type": "Link"
       },
       {
-        "name": "output1",
+        "meta": {
+          "name": "output1"
+        },
         "type": "Output",
         "cost": {
           "type": "Constant",
@@ -50,14 +56,18 @@
     ],
     "parameters": [
       {
-        "name": "demand",
+        "meta": {
+          "name": "demand"
+        },
         "type": "Constant",
         "value": 10.0
       }
     ],
     "timeseries": [
       {
-        "name": "inflow",
+        "meta": {
+          "name": "inflow"
+        },
         "provider": {
           "type": "Polars",
           "url": "inflow.csv"

--- a/pywr-schema/src/data_tables/mod.rs
+++ b/pywr-schema/src/data_tables/mod.rs
@@ -237,6 +237,7 @@ impl LoadedTableCollection {
 }
 
 #[derive(serde::Deserialize, serde::Serialize, Debug, Clone, JsonSchema, PywrVisitAll)]
+#[serde(deny_unknown_fields)]
 pub struct TableDataRef {
     pub table: String,
     pub column: Option<TableIndex>,

--- a/pywr-schema/src/metric.rs
+++ b/pywr-schema/src/metric.rs
@@ -237,6 +237,7 @@ pub enum TimeseriesColumns {
 }
 
 #[derive(serde::Deserialize, serde::Serialize, Debug, Clone, JsonSchema)]
+#[serde(deny_unknown_fields)]
 pub struct TimeseriesReference {
     name: String,
     columns: Option<TimeseriesColumns>,
@@ -253,6 +254,7 @@ impl TimeseriesReference {
 }
 
 #[derive(serde::Deserialize, serde::Serialize, Debug, Clone, JsonSchema, PywrVisitAll)]
+#[serde(deny_unknown_fields)]
 pub struct NodeReference {
     /// The name of the node
     pub name: String,
@@ -312,6 +314,7 @@ impl From<String> for NodeReference {
 }
 
 #[derive(serde::Deserialize, serde::Serialize, Debug, Clone, JsonSchema)]
+#[serde(deny_unknown_fields)]
 pub struct ParameterReference {
     /// The name of the parameter
     pub name: String,

--- a/pywr-schema/src/model.rs
+++ b/pywr-schema/src/model.rs
@@ -1115,6 +1115,7 @@ mod core_tests {
                         comment: None,
                     },
                     value: ConstantValue::Literal(10.0),
+                    variable: None,
                 }),
                 Parameter::Aggregated(AggregatedParameter {
                     meta: ParameterMeta {
@@ -1171,6 +1172,7 @@ mod core_tests {
                         comment: None,
                     },
                     value: ConstantValue::Literal(10.0),
+                    variable: None,
                 }),
                 Parameter::Constant(ConstantParameter {
                     meta: ParameterMeta {
@@ -1178,6 +1180,7 @@ mod core_tests {
                         comment: None,
                     },
                     value: ConstantValue::Literal(10.0),
+                    variable: None,
                 }),
             ]);
         }

--- a/pywr-schema/src/nodes/annual_virtual_storage.rs
+++ b/pywr-schema/src/nodes/annual_virtual_storage.rs
@@ -18,6 +18,7 @@ use pywr_v1_schema::nodes::AnnualVirtualStorageNode as AnnualVirtualStorageNodeV
 use schemars::JsonSchema;
 
 #[derive(serde::Deserialize, serde::Serialize, Clone, Debug, JsonSchema, PywrVisitAll)]
+#[serde(deny_unknown_fields)]
 pub struct AnnualReset {
     pub day: u8,
     pub month: u8,
@@ -35,8 +36,8 @@ impl Default for AnnualReset {
 }
 
 #[derive(serde::Deserialize, serde::Serialize, Clone, Default, Debug, JsonSchema, PywrVisitAll)]
+#[serde(deny_unknown_fields)]
 pub struct AnnualVirtualStorageNode {
-    #[serde(flatten)]
     pub meta: NodeMeta,
     pub nodes: Vec<String>,
     pub factors: Option<Vec<f64>>,

--- a/pywr-schema/src/nodes/core.rs
+++ b/pywr-schema/src/nodes/core.rs
@@ -20,8 +20,8 @@ use pywr_v1_schema::nodes::{
 use schemars::JsonSchema;
 
 #[derive(serde::Deserialize, serde::Serialize, Clone, Default, Debug, JsonSchema, PywrVisitAll)]
+#[serde(deny_unknown_fields)]
 pub struct InputNode {
-    #[serde(flatten)]
     pub meta: NodeMeta,
     pub max_flow: Option<Metric>,
     pub min_flow: Option<Metric>,
@@ -130,8 +130,8 @@ impl TryFrom<InputNodeV1> for InputNode {
 }
 
 #[derive(serde::Deserialize, serde::Serialize, Clone, Default, Debug, JsonSchema, PywrVisitAll)]
+#[serde(deny_unknown_fields)]
 pub struct LinkNode {
-    #[serde(flatten)]
     pub meta: NodeMeta,
     pub max_flow: Option<Metric>,
     pub min_flow: Option<Metric>,
@@ -240,8 +240,8 @@ impl TryFrom<LinkNodeV1> for LinkNode {
 }
 
 #[derive(serde::Deserialize, serde::Serialize, Clone, Default, Debug, JsonSchema, PywrVisitAll)]
+#[serde(deny_unknown_fields)]
 pub struct OutputNode {
-    #[serde(flatten)]
     pub meta: NodeMeta,
     pub max_flow: Option<Metric>,
     pub min_flow: Option<Metric>,
@@ -377,8 +377,8 @@ impl From<StorageInitialVolume> for CoreStorageInitialVolume {
 }
 
 #[derive(serde::Deserialize, serde::Serialize, Clone, Default, Debug, JsonSchema, PywrVisitAll)]
+#[serde(deny_unknown_fields)]
 pub struct StorageNode {
-    #[serde(flatten)]
     pub meta: NodeMeta,
     pub max_volume: Option<Metric>,
     pub min_volume: Option<Metric>,
@@ -576,8 +576,8 @@ impl TryFrom<ReservoirNodeV1> for StorageNode {
 ///
 )]
 #[derive(serde::Deserialize, serde::Serialize, Clone, Default, Debug, JsonSchema, PywrVisitAll)]
+#[serde(deny_unknown_fields)]
 pub struct CatchmentNode {
-    #[serde(flatten)]
     pub meta: NodeMeta,
     pub flow: Option<Metric>,
     pub cost: Option<Metric>,
@@ -672,15 +672,15 @@ impl TryFrom<CatchmentNodeV1> for CatchmentNode {
 }
 
 #[derive(serde::Deserialize, serde::Serialize, Clone, Debug, JsonSchema, PywrVisitAll)]
-#[serde(tag = "type")]
+#[serde(tag = "type", deny_unknown_fields)]
 pub enum Factors {
     Proportion { factors: Vec<Metric> },
     Ratio { factors: Vec<Metric> },
 }
 
 #[derive(serde::Deserialize, serde::Serialize, Clone, Default, Debug, JsonSchema, PywrVisitAll)]
+#[serde(deny_unknown_fields)]
 pub struct AggregatedNode {
-    #[serde(flatten)]
     pub meta: NodeMeta,
     pub nodes: Vec<String>,
     pub max_flow: Option<Metric>,
@@ -824,8 +824,8 @@ impl TryFrom<AggregatedNodeV1> for AggregatedNode {
 }
 
 #[derive(serde::Deserialize, serde::Serialize, Clone, Default, Debug, JsonSchema, PywrVisitAll)]
+#[serde(deny_unknown_fields)]
 pub struct AggregatedStorageNode {
-    #[serde(flatten)]
     pub meta: NodeMeta,
     pub storage_nodes: Vec<String>,
 }
@@ -920,8 +920,9 @@ mod tests {
     fn test_input() {
         let data = r#"
             {
-                "name": "supply1",
-                "type": "Input",
+                "meta": {
+                    "name": "supply1"
+                },
                 "max_flow": {
                     "type": "Constant",
                     "value": 15.0
@@ -938,9 +939,13 @@ mod tests {
     fn test_storage_initial_volume_absolute() {
         let data = r#"
             {
-                "name": "storage1",
-                "type": "Storage",
-                "volume": 15.0,
+                "meta": {
+                    "name": "storage1"
+                },
+                "max_volume": {
+                  "type": "Constant",
+                  "value": 10.0
+                },
                 "initial_volume": {
                     "Absolute": 12.0
                 }
@@ -956,9 +961,13 @@ mod tests {
     fn test_storage_initial_volume_proportional() {
         let data = r#"
             {
-                "name": "storage1",
-                "type": "Storage",
-                "volume": 15.0,
+                "meta": {
+                    "name": "storage1"
+                },
+                "max_volume": {
+                  "type": "Constant",
+                  "value": 15.0
+                },
                 "initial_volume": {
                     "Proportional": 0.5
                 }

--- a/pywr-schema/src/nodes/delay.rs
+++ b/pywr-schema/src/nodes/delay.rs
@@ -31,8 +31,8 @@ use schemars::JsonSchema;
 ///
 )]
 #[derive(serde::Deserialize, serde::Serialize, Clone, Default, Debug, JsonSchema, PywrVisitAll)]
+#[serde(deny_unknown_fields)]
 pub struct DelayNode {
-    #[serde(flatten)]
     pub meta: NodeMeta,
     pub delay: usize,
     pub initial_value: ConstantValue<f64>,

--- a/pywr-schema/src/nodes/loss_link.rs
+++ b/pywr-schema/src/nodes/loss_link.rs
@@ -18,7 +18,7 @@ use schemars::JsonSchema;
 /// net losses are applied as a proportion of the net flow. Please see the documentation for
 /// specific nodes (e.g. [`LossLinkNode`]) to understand how the loss factor is applied.
 #[derive(serde::Deserialize, serde::Serialize, Clone, Debug, JsonSchema, PywrVisitAll)]
-#[serde(tag = "type")]
+#[serde(tag = "type", deny_unknown_fields)]
 pub enum LossFactor {
     Gross { factor: Metric },
     Net { factor: Metric },
@@ -78,8 +78,8 @@ impl LossFactor {
 ///
 )]
 #[derive(serde::Deserialize, serde::Serialize, Clone, Default, Debug, JsonSchema, PywrVisitAll)]
+#[serde(deny_unknown_fields)]
 pub struct LossLinkNode {
-    #[serde(flatten)]
     pub meta: NodeMeta,
     pub loss_factor: Option<LossFactor>,
     pub min_net_flow: Option<Metric>,

--- a/pywr-schema/src/nodes/monthly_virtual_storage.rs
+++ b/pywr-schema/src/nodes/monthly_virtual_storage.rs
@@ -18,6 +18,7 @@ use pywr_v1_schema::nodes::MonthlyVirtualStorageNode as MonthlyVirtualStorageNod
 use schemars::JsonSchema;
 
 #[derive(serde::Deserialize, serde::Serialize, Clone, Debug, JsonSchema, PywrVisitAll)]
+#[serde(deny_unknown_fields)]
 pub struct NumberOfMonthsReset {
     pub months: u8,
 }
@@ -29,8 +30,8 @@ impl Default for NumberOfMonthsReset {
 }
 
 #[derive(serde::Deserialize, serde::Serialize, Clone, Default, Debug, JsonSchema, PywrVisitAll)]
+#[serde(deny_unknown_fields)]
 pub struct MonthlyVirtualStorageNode {
-    #[serde(flatten)]
     pub meta: NodeMeta,
     pub nodes: Vec<String>,
     pub factors: Option<Vec<f64>>,

--- a/pywr-schema/src/nodes/piecewise_link.rs
+++ b/pywr-schema/src/nodes/piecewise_link.rs
@@ -13,6 +13,7 @@ use pywr_v1_schema::nodes::PiecewiseLinkNode as PiecewiseLinkNodeV1;
 use schemars::JsonSchema;
 
 #[derive(serde::Deserialize, serde::Serialize, Clone, Debug, JsonSchema, PywrVisitAll)]
+#[serde(deny_unknown_fields)]
 pub struct PiecewiseLinkStep {
     pub max_flow: Option<Metric>,
     pub min_flow: Option<Metric>,
@@ -42,8 +43,8 @@ pub struct PiecewiseLinkStep {
 ///
 )]
 #[derive(serde::Deserialize, serde::Serialize, Clone, Default, Debug, JsonSchema, PywrVisitAll)]
+#[serde(deny_unknown_fields)]
 pub struct PiecewiseLinkNode {
-    #[serde(flatten)]
     pub meta: NodeMeta,
     pub steps: Vec<PiecewiseLinkStep>,
 }

--- a/pywr-schema/src/nodes/piecewise_storage.rs
+++ b/pywr-schema/src/nodes/piecewise_storage.rs
@@ -15,6 +15,7 @@ use pywr_schema_macros::PywrVisitAll;
 use schemars::JsonSchema;
 
 #[derive(serde::Deserialize, serde::Serialize, Clone, Debug, JsonSchema, PywrVisitAll)]
+#[serde(deny_unknown_fields)]
 pub struct PiecewiseStore {
     pub control_curve: Metric,
     pub cost: Option<Metric>,
@@ -47,8 +48,8 @@ pub struct PiecewiseStore {
 ///
 )]
 #[derive(serde::Deserialize, serde::Serialize, Clone, Default, Debug, JsonSchema, PywrVisitAll)]
+#[serde(deny_unknown_fields)]
 pub struct PiecewiseStorageNode {
-    #[serde(flatten)]
     pub meta: NodeMeta,
     pub max_volume: Metric,
     // TODO implement min volume

--- a/pywr-schema/src/nodes/river.rs
+++ b/pywr-schema/src/nodes/river.rs
@@ -9,8 +9,8 @@ use pywr_v1_schema::nodes::LinkNode as LinkNodeV1;
 use schemars::JsonSchema;
 
 #[derive(serde::Deserialize, serde::Serialize, Clone, Default, Debug, JsonSchema, PywrVisitAll)]
+#[serde(deny_unknown_fields)]
 pub struct RiverNode {
-    #[serde(flatten)]
     pub meta: NodeMeta,
 }
 

--- a/pywr-schema/src/nodes/river_gauge.rs
+++ b/pywr-schema/src/nodes/river_gauge.rs
@@ -28,8 +28,8 @@ use schemars::JsonSchema;
 ///
 )]
 #[derive(serde::Deserialize, serde::Serialize, Clone, Default, Debug, JsonSchema, PywrVisitAll)]
+#[serde(deny_unknown_fields)]
 pub struct RiverGaugeNode {
-    #[serde(flatten)]
     pub meta: NodeMeta,
     pub mrf: Option<Metric>,
     pub mrf_cost: Option<Metric>,

--- a/pywr-schema/src/nodes/river_split_with_gauge.rs
+++ b/pywr-schema/src/nodes/river_split_with_gauge.rs
@@ -35,8 +35,8 @@ use schemars::JsonSchema;
 ///
 )]
 #[derive(serde::Deserialize, serde::Serialize, Clone, Default, Debug, JsonSchema, PywrVisitAll)]
+#[serde(deny_unknown_fields)]
 pub struct RiverSplitWithGaugeNode {
-    #[serde(flatten)]
     pub meta: NodeMeta,
     pub mrf: Option<Metric>,
     pub mrf_cost: Option<Metric>,

--- a/pywr-schema/src/nodes/rolling_virtual_storage.rs
+++ b/pywr-schema/src/nodes/rolling_virtual_storage.rs
@@ -69,8 +69,8 @@ impl RollingWindow {
 /// licence on a water abstraction.
 ///
 #[derive(serde::Deserialize, serde::Serialize, Clone, Default, Debug, JsonSchema, PywrVisitAll)]
+#[serde(deny_unknown_fields)]
 pub struct RollingVirtualStorageNode {
-    #[serde(flatten)]
     pub meta: NodeMeta,
     pub nodes: Vec<String>,
     pub factors: Option<Vec<f64>>,

--- a/pywr-schema/src/nodes/turbine.rs
+++ b/pywr-schema/src/nodes/turbine.rs
@@ -26,8 +26,8 @@ pub enum TargetType {
 /// This turbine node can be used to set a flow constraint based on a hydropower production target.
 /// The turbine elevation, minimum head and efficiency can also be configured.
 #[derive(serde::Deserialize, serde::Serialize, Clone, Debug, JsonSchema, PywrVisitAll)]
+#[serde(deny_unknown_fields)]
 pub struct TurbineNode {
-    #[serde(flatten)]
     pub meta: NodeMeta,
     pub cost: Option<Metric>,
     /// Hydropower production target. If set the node's max flow is limited to the flow

--- a/pywr-schema/src/nodes/virtual_storage.rs
+++ b/pywr-schema/src/nodes/virtual_storage.rs
@@ -19,8 +19,8 @@ use pywr_v1_schema::nodes::VirtualStorageNode as VirtualStorageNodeV1;
 use schemars::JsonSchema;
 
 #[derive(serde::Deserialize, serde::Serialize, Clone, Default, Debug, JsonSchema, PywrVisitAll)]
+#[serde(deny_unknown_fields)]
 pub struct VirtualStorageNode {
-    #[serde(flatten)]
     pub meta: NodeMeta,
     pub nodes: Vec<NodeReference>,
     pub factors: Option<Vec<f64>>,

--- a/pywr-schema/src/nodes/water_treatment_works.rs
+++ b/pywr-schema/src/nodes/water_treatment_works.rs
@@ -36,9 +36,9 @@ use schemars::JsonSchema;
 ///
 )]
 #[derive(serde::Deserialize, serde::Serialize, Clone, Default, Debug, JsonSchema, PywrVisitAll)]
+#[serde(deny_unknown_fields)]
 pub struct WaterTreatmentWorks {
     /// Node metadata
-    #[serde(flatten)]
     pub meta: NodeMeta,
     /// The proportion of net flow that is lost to the loss node.
     pub loss_factor: Option<LossFactor>,

--- a/pywr-schema/src/parameters/aggregated.rs
+++ b/pywr-schema/src/parameters/aggregated.rs
@@ -72,8 +72,8 @@ impl From<AggFuncV1> for AggFunc {
 /// ```
 
 #[derive(serde::Deserialize, serde::Serialize, Debug, Clone, JsonSchema, PywrVisitAll)]
+#[serde(deny_unknown_fields)]
 pub struct AggregatedParameter {
-    #[serde(flatten)]
     pub meta: ParameterMeta,
     pub agg_func: AggFunc,
     pub metrics: Vec<Metric>,
@@ -167,8 +167,8 @@ impl From<IndexAggFuncV1> for IndexAggFunc {
 }
 
 #[derive(serde::Deserialize, serde::Serialize, Debug, Clone, JsonSchema, PywrVisitAll)]
+#[serde(deny_unknown_fields)]
 pub struct AggregatedIndexParameter {
-    #[serde(flatten)]
     pub meta: ParameterMeta,
     pub agg_func: IndexAggFunc,
     // TODO this should be `DynamicIntValues`
@@ -247,15 +247,19 @@ mod tests {
     fn test_aggregated() {
         let data = r#"
             {
-                "name": "my-agg-param",
-                "type": "aggregated",
+                "meta": {
+                    "name": "my-agg-param",
+                    "comment": "Take the minimum of two parameters"
+                },
                 "agg_func": "min",
-                "comment": "Take the minimum of two parameters",
                 "metrics": [
                   {
                     "type": "InlineParameter",
                     "definition": {
-                        "name": "First parameter",
+                        "meta": {
+                            "name": "First parameter",
+                            "comment": "A witty comment"
+                        },
                         "type": "ControlCurvePiecewiseInterpolated",
                         "storage_node": {
                           "name": "Reservoir",
@@ -265,7 +269,6 @@ mod tests {
                             {"type": "Parameter", "name": "reservoir_cc"},
                             {"type": "Constant", "value": 0.2}
                         ],
-                        "comment": "A witty comment",
                         "values": [
                             [-0.1, -1.0],
                             [-100, -200],
@@ -277,7 +280,10 @@ mod tests {
                   {
                     "type": "InlineParameter",
                     "definition": {
-                        "name": "Second parameter",
+                        "meta": {
+                            "name": "Second parameter",
+                            "comment": "A witty comment"
+                        },
                         "type": "ControlCurvePiecewiseInterpolated",
                         "storage_node": {
                           "name": "Reservoir",
@@ -287,7 +293,6 @@ mod tests {
                             {"type": "Parameter", "name": "reservoir_cc"},
                             {"type": "Constant", "value": 0.2}
                         ],
-                        "comment": "A witty comment",
                         "values": [
                             [-0.1, -1.0],
                             [-100, -200],

--- a/pywr-schema/src/parameters/asymmetric_switch.rs
+++ b/pywr-schema/src/parameters/asymmetric_switch.rs
@@ -11,8 +11,8 @@ use pywr_v1_schema::parameters::AsymmetricSwitchIndexParameter as AsymmetricSwit
 use schemars::JsonSchema;
 
 #[derive(serde::Deserialize, serde::Serialize, Debug, Clone, JsonSchema, PywrVisitAll)]
+#[serde(deny_unknown_fields)]
 pub struct AsymmetricSwitchIndexParameter {
-    #[serde(flatten)]
     pub meta: ParameterMeta,
     pub on_index_parameter: DynamicIndexValue,
     pub off_index_parameter: DynamicIndexValue,

--- a/pywr-schema/src/parameters/control_curves.rs
+++ b/pywr-schema/src/parameters/control_curves.rs
@@ -18,8 +18,8 @@ use pywr_v1_schema::parameters::{
 use schemars::JsonSchema;
 
 #[derive(serde::Deserialize, serde::Serialize, Debug, Clone, JsonSchema, PywrVisitAll)]
+#[serde(deny_unknown_fields)]
 pub struct ControlCurveInterpolatedParameter {
-    #[serde(flatten)]
     pub meta: ParameterMeta,
     pub control_curves: Vec<Metric>,
     pub storage_node: NodeReference,
@@ -119,8 +119,8 @@ impl TryFromV1Parameter<ControlCurveInterpolatedParameterV1> for ControlCurveInt
 }
 
 #[derive(serde::Deserialize, serde::Serialize, Debug, Clone, JsonSchema, PywrVisitAll)]
+#[serde(deny_unknown_fields)]
 pub struct ControlCurveIndexParameter {
-    #[serde(flatten)]
     pub meta: ParameterMeta,
     pub control_curves: Vec<Metric>,
     pub storage_node: NodeReference,
@@ -230,8 +230,8 @@ impl TryFromV1Parameter<ControlCurveParameterV1> for ControlCurveIndexParameter 
 }
 
 #[derive(serde::Deserialize, serde::Serialize, Debug, Clone, JsonSchema, PywrVisitAll)]
+#[serde(deny_unknown_fields)]
 pub struct ControlCurveParameter {
-    #[serde(flatten)]
     pub meta: ParameterMeta,
     pub control_curves: Vec<Metric>,
     pub storage_node: NodeReference,
@@ -324,8 +324,8 @@ impl TryFromV1Parameter<ControlCurveParameterV1> for ControlCurveParameter {
 }
 
 #[derive(serde::Deserialize, serde::Serialize, Debug, Clone, JsonSchema, PywrVisitAll)]
+#[serde(deny_unknown_fields)]
 pub struct ControlCurvePiecewiseInterpolatedParameter {
-    #[serde(flatten)]
     pub meta: ParameterMeta,
     pub control_curves: Vec<Metric>,
     pub storage_node: NodeReference,
@@ -416,8 +416,10 @@ mod tests {
     fn test_control_curve_piecewise_interpolated() {
         let data = r#"
             {
-                "name": "My control curve",
-                "type": "ControlCurvePiecewiseInterpolated",
+                "meta": {
+                    "name": "My control curve",
+                    "comment": "A witty comment"
+                },
                 "storage_node": {
                   "name": "Reservoir",
                   "attribute": "ProportionalVolume"
@@ -426,7 +428,6 @@ mod tests {
                     {"type": "Parameter", "name": "reservoir_cc"},
                     {"type": "Constant", "value": 0.2}
                 ],
-                "comment": "A witty comment",
                 "values": [
                     [-0.1, -1.0],
                     [-100, -200],

--- a/pywr-schema/src/parameters/core.rs
+++ b/pywr-schema/src/parameters/core.rs
@@ -22,8 +22,8 @@ use schemars::JsonSchema;
 /// algorithms to represent a, for example, binary-like variable in a continuous domain. Each
 /// activation function requires different data to parameterize the function's behaviour.
 ///
-#[derive(serde::Deserialize, serde::Serialize, Debug, Clone, Copy)]
-#[serde(tag = "type")]
+#[derive(serde::Deserialize, serde::Serialize, Debug, Clone, Copy, JsonSchema, PywrVisitAll)]
+#[serde(tag = "type", deny_unknown_fields)]
 pub enum ActivationFunction {
     /// A unit or null transformation.
     ///
@@ -121,7 +121,8 @@ impl From<ActivationFunction> for pywr_core::parameters::ActivationFunction {
 }
 
 /// Settings for a variable value.
-#[derive(serde::Deserialize, serde::Serialize, Debug, Clone)]
+#[derive(serde::Deserialize, serde::Serialize, Debug, Clone, JsonSchema, PywrVisitAll)]
+#[serde(deny_unknown_fields)]
 pub struct VariableSettings {
     /// Is this parameter an active variable?
     pub is_active: bool,
@@ -146,17 +147,18 @@ pub struct VariableSettings {
 /// ```
 ///
 #[derive(serde::Deserialize, serde::Serialize, Debug, Clone, JsonSchema, PywrVisitAll)]
+#[serde(deny_unknown_fields)]
 pub struct ConstantParameter {
     /// Meta-data.
-    ///
-    /// This field is flattened in the serialised format.
-    #[serde(flatten)]
     pub meta: ParameterMeta,
     /// The value the parameter should return.
     ///
     /// In the simple case this will be the value used by the network. However, if an activation
     /// function is specified this value will be the `x` value for that activation function.
     pub value: ConstantValue<f64>,
+    /// Optional settings for configuring how the value of this parameter can be varied. This
+    /// is used by, for example, external algorithms to optimise the value of the parameter.
+    pub variable: Option<VariableSettings>,
 }
 
 #[cfg(feature = "core")]
@@ -193,14 +195,15 @@ impl TryFromV1Parameter<ConstantParameterV1> for ConstantParameter {
         let p = Self {
             meta: v1.meta.into_v2_parameter(parent_node, unnamed_count),
             value,
+            variable: None, // TODO convert variable settings
         };
         Ok(p)
     }
 }
 
 #[derive(serde::Deserialize, serde::Serialize, Debug, Clone, JsonSchema, PywrVisitAll)]
+#[serde(deny_unknown_fields)]
 pub struct MaxParameter {
-    #[serde(flatten)]
     pub meta: ParameterMeta,
     pub parameter: Metric,
     pub threshold: Option<f64>,
@@ -255,8 +258,8 @@ impl TryFromV1Parameter<MaxParameterV1> for MaxParameter {
 #[doc = include_str!("doc_examples/division.json")]
 /// ```
 #[derive(serde::Deserialize, serde::Serialize, Debug, Clone, JsonSchema, PywrVisitAll)]
+#[serde(deny_unknown_fields)]
 pub struct DivisionParameter {
-    #[serde(flatten)]
     pub meta: ParameterMeta,
     pub numerator: Metric,
     pub denominator: Metric,
@@ -312,8 +315,8 @@ impl TryFromV1Parameter<DivisionParameterV1> for DivisionParameter {
 #[doc = include_str!("doc_examples/min.json")]
 /// ```
 #[derive(serde::Deserialize, serde::Serialize, Debug, Clone, JsonSchema, PywrVisitAll)]
+#[serde(deny_unknown_fields)]
 pub struct MinParameter {
-    #[serde(flatten)]
     pub meta: ParameterMeta,
     pub parameter: Metric,
     pub threshold: Option<f64>,
@@ -356,8 +359,8 @@ impl TryFromV1Parameter<MinParameterV1> for MinParameter {
 }
 
 #[derive(serde::Deserialize, serde::Serialize, Debug, Clone, JsonSchema, PywrVisitAll)]
+#[serde(deny_unknown_fields)]
 pub struct NegativeParameter {
-    #[serde(flatten)]
     pub meta: ParameterMeta,
     pub parameter: Metric,
 }
@@ -408,8 +411,8 @@ impl TryFromV1Parameter<NegativeParameterV1> for NegativeParameter {
 /// In January this parameter returns 2, in February 4.
 ///
 #[derive(serde::Deserialize, serde::Serialize, Debug, Clone, JsonSchema, PywrVisitAll)]
+#[serde(deny_unknown_fields)]
 pub struct NegativeMaxParameter {
-    #[serde(flatten)]
     pub meta: ParameterMeta,
     pub metric: Metric,
     pub threshold: Option<f64>,
@@ -464,8 +467,8 @@ impl TryFromV1Parameter<NegativeMaxParameterV1> for NegativeMaxParameter {
 /// In January this parameter returns 1, in February 2.
 ///
 #[derive(serde::Deserialize, serde::Serialize, Debug, Clone, JsonSchema, PywrVisitAll)]
+#[serde(deny_unknown_fields)]
 pub struct NegativeMinParameter {
-    #[serde(flatten)]
     pub meta: ParameterMeta,
     pub metric: Metric,
     pub threshold: Option<f64>,

--- a/pywr-schema/src/parameters/delay.rs
+++ b/pywr-schema/src/parameters/delay.rs
@@ -11,8 +11,8 @@ use schemars::JsonSchema;
 
 /// A parameter that delays a value from the network by a number of time-steps.
 #[derive(serde::Deserialize, serde::Serialize, Debug, Clone, JsonSchema, PywrVisitAll)]
+#[serde(deny_unknown_fields)]
 pub struct DelayParameter {
-    #[serde(flatten)]
     pub meta: ParameterMeta,
     pub metric: Metric,
     pub delay: usize,

--- a/pywr-schema/src/parameters/discount_factor.rs
+++ b/pywr-schema/src/parameters/discount_factor.rs
@@ -13,8 +13,8 @@ use schemars::JsonSchema;
 
 /// A parameter that returns the current discount factor for a given time-step.
 #[derive(serde::Deserialize, serde::Serialize, Debug, Clone, JsonSchema, PywrVisitAll)]
+#[serde(deny_unknown_fields)]
 pub struct DiscountFactorParameter {
-    #[serde(flatten)]
     pub meta: ParameterMeta,
     pub discount_rate: Metric,
     pub base_year: i32,

--- a/pywr-schema/src/parameters/doc_examples/aggregated_1.json
+++ b/pywr-schema/src/parameters/doc_examples/aggregated_1.json
@@ -1,5 +1,7 @@
 {
-  "name": "my-aggregated-value",
+  "meta": {
+    "name": "my-aggregated-value"
+  },
   "type": "Aggregated",
   "agg_func": "sum",
   "metrics": [
@@ -24,7 +26,9 @@
     {
       "type": "InlineParameter",
       "definition": {
-        "name": "my-monthly-profile",
+        "meta": {
+          "name": "my-monthly-profile"
+        },
         "type": "MonthlyProfile",
         "values": [
           1.0,

--- a/pywr-schema/src/parameters/doc_examples/constant_simple.json
+++ b/pywr-schema/src/parameters/doc_examples/constant_simple.json
@@ -1,5 +1,7 @@
 {
   "type": "Constant",
-  "name": "my-constant",
+  "meta": {
+    "name": "my-constant"
+  },
   "value": 10.0
 }

--- a/pywr-schema/src/parameters/doc_examples/constant_variable.json
+++ b/pywr-schema/src/parameters/doc_examples/constant_variable.json
@@ -1,6 +1,8 @@
 {
   "type": "Constant",
-  "name": "my-variable",
+  "meta": {
+    "name": "my-variable"
+  },
   "value": 5.0,
   "variable": {
     "is_active": true,

--- a/pywr-schema/src/parameters/doc_examples/division.json
+++ b/pywr-schema/src/parameters/doc_examples/division.json
@@ -1,10 +1,14 @@
 {
-  "name": "my-division",
+  "meta": {
+    "name": "my-division"
+  },
   "type": "Division",
   "numerator": {
     "type": "InlineParameter",
     "definition": {
-      "name": "my-monthly-profile",
+      "meta": {
+        "name": "my-monthly-profile"
+      },
       "type": "MonthlyProfile",
       "values": [
         1,

--- a/pywr-schema/src/parameters/doc_examples/hydropower.json
+++ b/pywr-schema/src/parameters/doc_examples/hydropower.json
@@ -1,5 +1,7 @@
 {
-  "name": "turbine-flow",
+  "meta": {
+    "name": "turbine-flow"
+  },
   "type": "HydropowerTarget",
   "target": {
     "type": "Constant",

--- a/pywr-schema/src/parameters/doc_examples/min.json
+++ b/pywr-schema/src/parameters/doc_examples/min.json
@@ -1,10 +1,14 @@
 {
-  "name": "my-min",
+  "meta": {
+    "name": "my-min"
+  },
   "type": "Min",
   "parameter": {
     "type": "InlineParameter",
     "definition": {
-      "name": "my-monthly-profile",
+      "meta": {
+        "name": "my-monthly-profile"
+      },
       "type": "MonthlyProfile",
       "values": [
         1,

--- a/pywr-schema/src/parameters/doc_examples/negative_max.json
+++ b/pywr-schema/src/parameters/doc_examples/negative_max.json
@@ -1,10 +1,14 @@
 {
-  "name": "my-negative-max",
+  "meta": {
+    "name": "my-negative-max"
+  },
   "type": "NegativeMax",
   "metric": {
     "type": "InlineParameter",
     "definition": {
-      "name": "my-monthly-profile",
+      "meta": {
+        "name": "my-monthly-profile"
+      },
       "type": "MonthlyProfile",
       "values": [
         -1,

--- a/pywr-schema/src/parameters/doc_examples/negative_min.json
+++ b/pywr-schema/src/parameters/doc_examples/negative_min.json
@@ -1,10 +1,14 @@
 {
-  "name": "my-negative-min",
+  "meta": {
+    "name": "my-negative-min"
+  },
   "type": "NegativeMin",
   "metric": {
     "type": "InlineParameter",
     "definition": {
-      "name": "my-monthly-profile",
+      "meta": {
+        "name": "my-monthly-profile"
+      },
       "type": "MonthlyProfile",
       "values": [
         -1,

--- a/pywr-schema/src/parameters/doc_examples/offset_simple.json
+++ b/pywr-schema/src/parameters/doc_examples/offset_simple.json
@@ -1,6 +1,8 @@
 {
   "type": "Offset",
-  "name": "my-offset",
+  "meta": {
+    "name": "my-offset"
+  },
   "offset": 3.14,
   "metric": {
     "type": "Parameter",

--- a/pywr-schema/src/parameters/doc_examples/offset_variable.json
+++ b/pywr-schema/src/parameters/doc_examples/offset_variable.json
@@ -1,6 +1,8 @@
 {
   "type": "Offset",
-  "name": "my-variable-offset",
+  "meta": {
+    "name": "my-variable-offset"
+  },
   "offset": 5.0,
   "metric": {
     "type": "Parameter",

--- a/pywr-schema/src/parameters/doc_examples/rbf_1.json
+++ b/pywr-schema/src/parameters/doc_examples/rbf_1.json
@@ -1,10 +1,25 @@
 {
-    "name": "my-interpolated-profile",
-    "type": "RbfProfile",
-    "points": [
-        [90, 0.5],
-        [180, 0.3],
-        [270, 0.7]
+  "meta": {
+    "name": "my-interpolated-profile"
+  },
+  "type": "RbfProfile",
+  "points": [
+    [
+      90,
+      0.5
     ],
-    "function": {"Gaussian": { "epsilon":  3.0 }}
+    [
+      180,
+      0.3
+    ],
+    [
+      270,
+      0.7
+    ]
+  ],
+  "function": {
+    "Gaussian": {
+      "epsilon": 3.0
+    }
+  }
 }

--- a/pywr-schema/src/parameters/doc_examples/rbf_2.json
+++ b/pywr-schema/src/parameters/doc_examples/rbf_2.json
@@ -1,16 +1,31 @@
 {
-    "name": "my-interpolated-profile",
-    "type": "RbfProfile",
-    "points": [
-        [90, 0.5],
-        [180, 0.3],
-        [270, 0.7]
+  "meta": {
+    "name": "my-interpolated-profile"
+  },
+  "type": "RbfProfile",
+  "points": [
+    [
+      90,
+      0.5
     ],
-    "function": {"Gaussian": { "epsilon":  3.0 }},
-    "variable": {
-        "is_active": true,
-        "days_of_year_range": 30,
-        "value_upper_bounds": 1.0,
-        "value_lower_bounds": 0.0
+    [
+      180,
+      0.3
+    ],
+    [
+      270,
+      0.7
+    ]
+  ],
+  "function": {
+    "Gaussian": {
+      "epsilon": 3.0
     }
+  },
+  "variable": {
+    "is_active": true,
+    "days_of_year_range": 30,
+    "value_upper_bounds": 1.0,
+    "value_lower_bounds": 0.0
+  }
 }

--- a/pywr-schema/src/parameters/hydropower.rs
+++ b/pywr-schema/src/parameters/hydropower.rs
@@ -38,8 +38,8 @@ use schemars::JsonSchema;
 /// ```json
 #[doc = include_str!("doc_examples/hydropower.json")]
 #[derive(serde::Deserialize, serde::Serialize, Debug, Clone, JsonSchema, PywrVisitAll)]
+#[serde(deny_unknown_fields)]
 pub struct HydropowerTargetParameter {
-    #[serde(flatten)]
     pub meta: ParameterMeta,
     /// Hydropower production target. This can be a constant, a value from a table, a
     /// parameter name or an inline parameter (see [`Metric`]). Units should be in

--- a/pywr-schema/src/parameters/indexed_array.rs
+++ b/pywr-schema/src/parameters/indexed_array.rs
@@ -12,8 +12,8 @@ use pywr_v1_schema::parameters::IndexedArrayParameter as IndexedArrayParameterV1
 use schemars::JsonSchema;
 
 #[derive(serde::Deserialize, serde::Serialize, Debug, Clone, JsonSchema, PywrVisitAll)]
+#[serde(deny_unknown_fields)]
 pub struct IndexedArrayParameter {
-    #[serde(flatten)]
     pub meta: ParameterMeta,
     #[serde(alias = "params")]
     pub metrics: Vec<Metric>,

--- a/pywr-schema/src/parameters/interpolated.rs
+++ b/pywr-schema/src/parameters/interpolated.rs
@@ -19,8 +19,8 @@ use schemars::JsonSchema;
 /// Internally this is implemented as a piecewise linear interpolation via
 /// [`pywr_core::parameters::InterpolatedParameter`].
 #[derive(serde::Deserialize, serde::Serialize, Debug, Clone, JsonSchema, PywrVisitAll)]
+#[serde(deny_unknown_fields)]
 pub struct InterpolatedParameter {
-    #[serde(flatten)]
     pub meta: ParameterMeta,
     pub x: Metric,
     pub xp: Vec<Metric>,

--- a/pywr-schema/src/parameters/mod.rs
+++ b/pywr-schema/src/parameters/mod.rs
@@ -44,7 +44,7 @@ pub use super::parameters::profiles::{
     DailyProfileParameter, MonthlyProfileParameter, RadialBasisFunction, RbfProfileParameter,
     RbfProfileVariableSettings, UniformDrawdownProfileParameter, WeeklyProfileParameter,
 };
-pub use super::parameters::python::{PythonModule, PythonParameter, PythonReturnType};
+pub use super::parameters::python::{PythonParameter, PythonReturnType, PythonSource};
 pub use super::parameters::tables::TablesArrayParameter;
 pub use super::parameters::thresholds::ParameterThresholdParameter;
 use crate::error::ConversionError;
@@ -647,6 +647,7 @@ impl TryFromV1Parameter<ParameterV1> for ParameterOrTimeseries {
                         comment: Some(comment),
                     },
                     value: ConstantValue::Literal(0.0),
+                    variable: None,
                 })
                 .into()
             }

--- a/pywr-schema/src/parameters/offset.rs
+++ b/pywr-schema/src/parameters/offset.rs
@@ -3,7 +3,7 @@ use crate::error::SchemaError;
 use crate::metric::Metric;
 #[cfg(feature = "core")]
 use crate::model::LoadArgs;
-use crate::parameters::{ConstantValue, ParameterMeta};
+use crate::parameters::{ConstantValue, ParameterMeta, VariableSettings};
 #[cfg(feature = "core")]
 use pywr_core::parameters::ParameterIndex;
 use pywr_schema_macros::PywrVisitAll;
@@ -24,11 +24,9 @@ use schemars::JsonSchema;
 /// ```
 ///
 #[derive(serde::Deserialize, serde::Serialize, Debug, Clone, JsonSchema, PywrVisitAll)]
+#[serde(deny_unknown_fields)]
 pub struct OffsetParameter {
     /// Meta-data.
-    ///
-    /// This field is flattened in the serialised format.
-    #[serde(flatten)]
     pub meta: ParameterMeta,
     /// The offset value applied to the metric.
     ///
@@ -37,6 +35,9 @@ pub struct OffsetParameter {
     pub offset: ConstantValue<f64>,
     /// The metric from which to apply the offset.
     pub metric: Metric,
+    /// Optional settings for configuring how the value of this parameter can be varied. This
+    /// is used by, for example, external algorithms to optimise the value of the parameter.
+    pub variable: Option<VariableSettings>,
 }
 
 #[cfg(feature = "core")]

--- a/pywr-schema/src/parameters/polynomial.rs
+++ b/pywr-schema/src/parameters/polynomial.rs
@@ -9,8 +9,8 @@ use pywr_v1_schema::parameters::Polynomial1DParameter as Polynomial1DParameterV1
 use schemars::JsonSchema;
 
 #[derive(serde::Deserialize, serde::Serialize, Debug, Clone, JsonSchema, PywrVisitAll)]
+#[serde(deny_unknown_fields)]
 pub struct Polynomial1DParameter {
-    #[serde(flatten)]
     pub meta: ParameterMeta,
     pub storage_node: String,
     pub coefficients: Vec<f64>,

--- a/pywr-schema/src/parameters/profiles.rs
+++ b/pywr-schema/src/parameters/profiles.rs
@@ -16,8 +16,8 @@ use pywr_v1_schema::parameters::{
 use schemars::JsonSchema;
 
 #[derive(serde::Deserialize, serde::Serialize, Debug, Clone, JsonSchema, PywrVisitAll)]
+#[serde(deny_unknown_fields)]
 pub struct DailyProfileParameter {
-    #[serde(flatten)]
     pub meta: ParameterMeta,
     pub values: ConstantFloatVec,
 }
@@ -87,8 +87,8 @@ impl From<MonthlyInterpDay> for pywr_core::parameters::MonthlyInterpDay {
 }
 
 #[derive(serde::Deserialize, serde::Serialize, Debug, Clone, JsonSchema, PywrVisitAll)]
+#[serde(deny_unknown_fields)]
 pub struct MonthlyProfileParameter {
-    #[serde(flatten)]
     pub meta: ParameterMeta,
     pub values: ConstantFloatVec,
     pub interp_day: Option<MonthlyInterpDay>,
@@ -158,8 +158,8 @@ impl TryFromV1Parameter<MonthlyProfileParameterV1> for MonthlyProfileParameter {
 }
 
 #[derive(serde::Deserialize, serde::Serialize, Debug, Clone, JsonSchema, PywrVisitAll)]
+#[serde(deny_unknown_fields)]
 pub struct UniformDrawdownProfileParameter {
-    #[serde(flatten)]
     pub meta: ParameterMeta,
     pub reset_day: Option<ConstantValue<usize>>,
     pub reset_month: Option<ConstantValue<usize>>,
@@ -219,6 +219,7 @@ impl TryFromV1Parameter<UniformDrawdownProfileParameterV1> for UniformDrawdownPr
 
 /// Distance functions for radial basis function interpolation.
 #[derive(serde::Deserialize, serde::Serialize, Debug, Copy, Clone, JsonSchema, PywrVisitAll)]
+#[serde(deny_unknown_fields)]
 pub enum RadialBasisFunction {
     Linear,
     Cubic,
@@ -298,7 +299,8 @@ fn estimate_epsilon(points: &[(u32, f64)]) -> Option<f64> {
 }
 
 /// Settings for a variable RBF profile.
-#[derive(serde::Deserialize, serde::Serialize, Debug, Clone, Copy)]
+#[derive(serde::Deserialize, serde::Serialize, Debug, Clone, Copy, JsonSchema, PywrVisitAll)]
+#[serde(deny_unknown_fields)]
 pub struct RbfProfileVariableSettings {
     /// Is this parameter an active variable?
     pub is_active: bool,
@@ -345,14 +347,17 @@ impl From<RbfProfileVariableSettings> for pywr_core::parameters::RbfProfileVaria
 /// ```
 ///
 #[derive(serde::Deserialize, serde::Serialize, Debug, Clone, JsonSchema, PywrVisitAll)]
+#[serde(deny_unknown_fields)]
 pub struct RbfProfileParameter {
-    #[serde(flatten)]
     pub meta: ParameterMeta,
     /// The points are the profile positions defined by an ordinal day of the year and a value.
     /// Radial basis function interpolation is used to create a daily profile from these points.
     pub points: Vec<(u32, f64)>,
     /// The distance function used for interpolation.
     pub function: RadialBasisFunction,
+    /// Optional settings for configuring how the value of this parameter can be varied. This
+    /// is used by, for example, external algorithms to optimise the value of the parameter.
+    pub variable: Option<RbfProfileVariableSettings>,
 }
 
 #[cfg(feature = "core")]
@@ -441,7 +446,12 @@ impl TryFromV1Parameter<RbfProfileParameterV1> for RbfProfileParameter {
             RadialBasisFunction::MultiQuadric { epsilon }
         };
 
-        let p = Self { meta, points, function };
+        let p = Self {
+            meta,
+            points,
+            function,
+            variable: None, // TODO convert variable settings
+        };
 
         Ok(p)
     }
@@ -525,8 +535,8 @@ impl From<WeeklyInterpDay> for pywr_core::parameters::WeeklyInterpDay {
 /// December).
 ///
 #[derive(serde::Deserialize, serde::Serialize, Debug, Clone, JsonSchema, PywrVisitAll)]
+#[serde(deny_unknown_fields)]
 pub struct WeeklyProfileParameter {
-    #[serde(flatten)]
     pub meta: ParameterMeta,
     pub values: ConstantFloatVec,
     pub interp_day: Option<WeeklyInterpDay>,

--- a/pywr-schema/src/parameters/tables.rs
+++ b/pywr-schema/src/parameters/tables.rs
@@ -15,8 +15,8 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 
 #[derive(serde::Deserialize, serde::Serialize, Debug, Clone, JsonSchema, PywrVisitAll)]
+#[serde(deny_unknown_fields)]
 pub struct TablesArrayParameter {
-    #[serde(flatten)]
     pub meta: ParameterMeta,
     pub node: String,
     #[serde(rename = "where")]

--- a/pywr-schema/src/parameters/thresholds.rs
+++ b/pywr-schema/src/parameters/thresholds.rs
@@ -53,8 +53,8 @@ impl From<Predicate> for pywr_core::parameters::Predicate {
 }
 
 #[derive(serde::Deserialize, serde::Serialize, Debug, Clone, JsonSchema, PywrVisitAll)]
+#[serde(deny_unknown_fields)]
 pub struct ParameterThresholdParameter {
-    #[serde(flatten)]
     pub meta: ParameterMeta,
     pub parameter: Metric,
     pub threshold: Metric,

--- a/pywr-schema/src/test_models/30-day-licence.json
+++ b/pywr-schema/src/test_models/30-day-licence.json
@@ -12,7 +12,9 @@
   "network": {
     "nodes": [
       {
-        "name": "supply1",
+        "meta": {
+          "name": "supply1"
+        },
         "type": "Input",
         "max_flow": {
           "type": "Constant",
@@ -20,11 +22,15 @@
         }
       },
       {
-        "name": "link1",
+        "meta": {
+          "name": "link1"
+        },
         "type": "Link"
       },
       {
-        "name": "demand1",
+        "meta": {
+          "name": "demand1"
+        },
         "type": "Output",
         "max_flow": {
           "type": "Parameter",
@@ -36,7 +42,9 @@
         }
       },
       {
-        "name": "licence",
+        "meta": {
+          "name": "licence"
+        },
         "type": "RollingVirtualStorage",
         "nodes": [
           "supply1"
@@ -63,7 +71,9 @@
     ],
     "parameters": [
       {
-        "name": "demand",
+        "meta": {
+          "name": "demand"
+        },
         "type": "Constant",
         "value": 10.0
       }

--- a/pywr-schema/src/test_models/csv1.json
+++ b/pywr-schema/src/test_models/csv1.json
@@ -12,7 +12,9 @@
   "network": {
     "nodes": [
       {
-        "name": "supply1",
+        "meta": {
+          "name": "supply1"
+        },
         "type": "Input",
         "max_flow": {
           "type": "Constant",
@@ -20,11 +22,15 @@
         }
       },
       {
-        "name": "link1",
+        "meta": {
+          "name": "link1"
+        },
         "type": "Link"
       },
       {
-        "name": "demand1",
+        "meta": {
+          "name": "demand1"
+        },
         "type": "Output",
         "max_flow": {
           "type": "Parameter",
@@ -48,7 +54,9 @@
     ],
     "parameters": [
       {
-        "name": "demand",
+        "meta": {
+          "name": "demand"
+        },
         "type": "Constant",
         "value": 10.0
       }

--- a/pywr-schema/src/test_models/csv2.json
+++ b/pywr-schema/src/test_models/csv2.json
@@ -12,7 +12,9 @@
   "network": {
     "nodes": [
       {
-        "name": "supply1",
+        "meta": {
+          "name": "supply1"
+        },
         "type": "Input",
         "max_flow": {
           "type": "Constant",
@@ -20,11 +22,15 @@
         }
       },
       {
-        "name": "link1",
+        "meta": {
+          "name": "link1"
+        },
         "type": "Link"
       },
       {
-        "name": "demand1",
+        "meta": {
+          "name": "demand1"
+        },
         "type": "Output",
         "max_flow": {
           "type": "Parameter",
@@ -48,7 +54,9 @@
     ],
     "parameters": [
       {
-        "name": "demand",
+        "meta": {
+          "name": "demand"
+        },
         "type": "Constant",
         "value": 10.0
       }

--- a/pywr-schema/src/test_models/csv3.json
+++ b/pywr-schema/src/test_models/csv3.json
@@ -12,7 +12,9 @@
   "network": {
     "nodes": [
       {
-        "name": "supply1",
+        "meta": {
+          "name": "supply1"
+        },
         "type": "Input",
         "max_flow": {
           "type": "Constant",
@@ -20,11 +22,15 @@
         }
       },
       {
-        "name": "link1",
+        "meta": {
+          "name": "link1"
+        },
         "type": "Link"
       },
       {
-        "name": "demand1",
+        "meta": {
+          "name": "demand1"
+        },
         "type": "Output",
         "max_flow": {
           "type": "Parameter",
@@ -48,7 +54,9 @@
     ],
     "parameters": [
       {
-        "name": "demand",
+        "meta": {
+          "name": "demand"
+        },
         "type": "Constant",
         "value": 10.0
       }

--- a/pywr-schema/src/test_models/delay1.json
+++ b/pywr-schema/src/test_models/delay1.json
@@ -12,7 +12,9 @@
   "network": {
     "nodes": [
       {
-        "name": "input1",
+        "meta": {
+          "name": "input1"
+        },
         "type": "Catchment",
         "flow": {
           "type": "Constant",
@@ -20,13 +22,17 @@
         }
       },
       {
-        "name": "link1",
+        "meta": {
+          "name": "link1"
+        },
         "type": "Delay",
         "delay": 3,
         "initial_value": 0.0
       },
       {
-        "name": "demand1",
+        "meta": {
+          "name": "demand1"
+        },
         "type": "Output",
         "max_flow": {
           "type": "Constant",

--- a/pywr-schema/src/test_models/hdf1.json
+++ b/pywr-schema/src/test_models/hdf1.json
@@ -12,7 +12,9 @@
   "network": {
     "nodes": [
       {
-        "name": "supply1",
+        "meta": {
+          "name": "supply1"
+        },
         "type": "Input",
         "max_flow": {
           "type": "Constant",
@@ -20,11 +22,15 @@
         }
       },
       {
-        "name": "link1",
+        "meta": {
+          "name": "link1"
+        },
         "type": "Link"
       },
       {
-        "name": "demand1",
+        "meta": {
+          "name": "demand1"
+        },
         "type": "Output",
         "max_flow": {
           "type": "Parameter",
@@ -48,7 +54,9 @@
     ],
     "parameters": [
       {
-        "name": "demand",
+        "meta": {
+          "name": "demand"
+        },
         "type": "Constant",
         "value": 10.0
       }

--- a/pywr-schema/src/test_models/loss_link1.json
+++ b/pywr-schema/src/test_models/loss_link1.json
@@ -12,11 +12,15 @@
   "network": {
     "nodes": [
       {
-        "name": "input1",
+        "meta": {
+          "name": "input1"
+        },
         "type": "Input"
       },
       {
-        "name": "loss1",
+        "meta": {
+          "name": "loss1"
+        },
         "type": "LossLink",
         "loss_factor": {
           "type": "Net",
@@ -27,7 +31,9 @@
         }
       },
       {
-        "name": "demand1",
+        "meta": {
+          "name": "demand1"
+        },
         "type": "Output",
         "max_flow": {
           "type": "Constant",
@@ -39,7 +45,9 @@
         }
       },
       {
-        "name": "loss2",
+        "meta": {
+          "name": "loss2"
+        },
         "type": "LossLink",
         "loss_factor": {
           "type": "Gross",
@@ -50,7 +58,9 @@
         }
       },
       {
-        "name": "demand2",
+        "meta": {
+          "name": "demand2"
+        },
         "type": "Output",
         "max_flow": {
           "type": "Constant",
@@ -62,11 +72,15 @@
         }
       },
       {
-        "name": "loss3",
+        "meta": {
+          "name": "loss3"
+        },
         "type": "LossLink"
       },
       {
-        "name": "demand3",
+        "meta": {
+          "name": "demand3"
+        },
         "type": "Output",
         "max_flow": {
           "type": "Constant",

--- a/pywr-schema/src/test_models/memory1.json
+++ b/pywr-schema/src/test_models/memory1.json
@@ -12,7 +12,9 @@
   "network": {
     "nodes": [
       {
-        "name": "supply1",
+        "meta": {
+          "name": "supply1"
+        },
         "type": "Input",
         "max_flow": {
           "type": "Constant",
@@ -20,11 +22,15 @@
         }
       },
       {
-        "name": "link1",
+        "meta": {
+          "name": "link1"
+        },
         "type": "Link"
       },
       {
-        "name": "demand1",
+        "meta": {
+          "name": "demand1"
+        },
         "type": "Output",
         "max_flow": {
           "type": "Parameter",
@@ -48,7 +54,9 @@
     ],
     "parameters": [
       {
-        "name": "demand",
+        "meta": {
+          "name": "demand"
+        },
         "type": "Constant",
         "value": 10.0
       }

--- a/pywr-schema/src/test_models/multi1/network1.json
+++ b/pywr-schema/src/test_models/multi1/network1.json
@@ -1,7 +1,9 @@
 {
   "nodes": [
     {
-      "name": "supply1",
+      "meta": {
+        "name": "supply1"
+      },
       "type": "Input",
       "max_flow": {
         "type": "Constant",
@@ -9,11 +11,15 @@
       }
     },
     {
-      "name": "link1",
+      "meta": {
+        "name": "link1"
+      },
       "type": "Link"
     },
     {
-      "name": "demand1",
+      "meta": {
+        "name": "demand1"
+      },
       "type": "Output",
       "max_flow": {
         "type": "Parameter",
@@ -37,7 +43,9 @@
   ],
   "parameters": [
     {
-      "name": "demand",
+      "meta": {
+        "name": "demand"
+      },
       "type": "Constant",
       "value": 10.0
     }

--- a/pywr-schema/src/test_models/multi1/network2.json
+++ b/pywr-schema/src/test_models/multi1/network2.json
@@ -1,7 +1,9 @@
 {
   "nodes": [
     {
-      "name": "supply2",
+      "meta": {
+        "name": "supply2"
+      },
       "type": "Input",
       "max_flow": {
         "type": "InterNetworkTransfer",
@@ -9,11 +11,15 @@
       }
     },
     {
-      "name": "link2",
+      "meta": {
+        "name": "link2"
+      },
       "type": "Link"
     },
     {
-      "name": "demand2",
+      "meta": {
+        "name": "demand2"
+      },
       "type": "Output",
       "max_flow": {
         "type": "Parameter",
@@ -37,7 +43,9 @@
   ],
   "parameters": [
     {
-      "name": "demand",
+      "meta": {
+        "name": "demand"
+      },
       "type": "Constant",
       "value": 20.0
     }

--- a/pywr-schema/src/test_models/multi2/network1.json
+++ b/pywr-schema/src/test_models/multi2/network1.json
@@ -1,7 +1,9 @@
 {
   "nodes": [
     {
-      "name": "supply1",
+      "meta": {
+        "name": "supply1"
+      },
       "type": "Input",
       "max_flow": {
         "type": "InterNetworkTransfer",
@@ -9,11 +11,15 @@
       }
     },
     {
-      "name": "link1",
+      "meta": {
+        "name": "link1"
+      },
       "type": "Link"
     },
     {
-      "name": "demand1",
+      "meta": {
+        "name": "demand1"
+      },
       "type": "Output",
       "max_flow": {
         "type": "Parameter",
@@ -37,7 +43,9 @@
   ],
   "parameters": [
     {
-      "name": "demand",
+      "meta": {
+        "name": "demand"
+      },
       "type": "Constant",
       "value": 10.0
     }

--- a/pywr-schema/src/test_models/multi2/network2.json
+++ b/pywr-schema/src/test_models/multi2/network2.json
@@ -1,7 +1,9 @@
 {
   "nodes": [
     {
-      "name": "supply2",
+      "meta": {
+        "name": "supply2"
+      },
       "type": "Input",
       "max_flow": {
         "type": "InterNetworkTransfer",
@@ -9,11 +11,15 @@
       }
     },
     {
-      "name": "link2",
+      "meta": {
+        "name": "link2"
+      },
       "type": "Link"
     },
     {
-      "name": "demand2",
+      "meta": {
+        "name": "demand2"
+      },
       "type": "Output",
       "max_flow": {
         "type": "Parameter",
@@ -37,7 +43,9 @@
   ],
   "parameters": [
     {
-      "name": "demand",
+      "meta": {
+        "name": "demand"
+      },
       "type": "Constant",
       "value": 20.0
     }

--- a/pywr-schema/src/test_models/piecewise_link1.json
+++ b/pywr-schema/src/test_models/piecewise_link1.json
@@ -12,7 +12,9 @@
   "network": {
     "nodes": [
       {
-        "name": "input1",
+        "meta": {
+          "name": "input1"
+        },
         "type": "Input",
         "max_flow": {
           "type": "Constant",
@@ -20,7 +22,9 @@
         }
       },
       {
-        "name": "link1",
+        "meta": {
+          "name": "link1"
+        },
         "type": "PiecewiseLink",
         "steps": [
           {
@@ -52,7 +56,9 @@
         ]
       },
       {
-        "name": "demand1",
+        "meta": {
+          "name": "demand1"
+        },
         "type": "Output",
         "max_flow": {
           "type": "Constant",

--- a/pywr-schema/src/test_models/piecewise_storage1.json
+++ b/pywr-schema/src/test_models/piecewise_storage1.json
@@ -12,7 +12,9 @@
   "network": {
     "nodes": [
       {
-        "name": "input1",
+        "meta": {
+          "name": "input1"
+        },
         "type": "Input",
         "max_flow": {
           "type": "Constant",
@@ -24,7 +26,9 @@
         }
       },
       {
-        "name": "storage1",
+        "meta": {
+          "name": "storage1"
+        },
         "type": "PiecewiseStorage",
         "max_volume": {
           "type": "Constant",
@@ -54,7 +58,9 @@
         ]
       },
       {
-        "name": "demand1",
+        "meta": {
+          "name": "demand1"
+        },
         "type": "Output",
         "max_flow": {
           "type": "Constant",

--- a/pywr-schema/src/test_models/piecewise_storage2.json
+++ b/pywr-schema/src/test_models/piecewise_storage2.json
@@ -12,7 +12,9 @@
   "network": {
     "nodes": [
       {
-        "name": "input1",
+        "meta": {
+          "name": "input1"
+        },
         "type": "Input",
         "max_flow": {
           "type": "Constant",
@@ -24,7 +26,9 @@
         }
       },
       {
-        "name": "storage1",
+        "meta": {
+          "name": "storage1"
+        },
         "type": "PiecewiseStorage",
         "max_volume": {
           "type": "Constant",
@@ -50,7 +54,9 @@
               "type": "InlineParameter",
               "definition": {
                 "type": "MonthlyProfile",
-                "name": "storage1-control-curve",
+                "meta": {
+                  "name": "storage1-control-curve"
+                },
                 "values": [
                   0.75,
                   0.75,
@@ -71,7 +77,9 @@
         ]
       },
       {
-        "name": "demand1",
+        "meta": {
+          "name": "demand1"
+        },
         "type": "Output",
         "max_flow": {
           "type": "Constant",
@@ -95,12 +103,16 @@
     ],
     "parameters": [
       {
-        "name": "storage1-drought-curve",
+        "meta": {
+          "name": "storage1-drought-curve"
+        },
         "type": "Constant",
         "value": 0.5
       },
       {
-        "name": "storage1-drought-index",
+        "meta": {
+          "name": "storage1-drought-index"
+        },
         "type": "ControlCurveIndex",
         "storage_node": {
           "name": "storage1",

--- a/pywr-schema/src/test_models/river_gauge1.json
+++ b/pywr-schema/src/test_models/river_gauge1.json
@@ -12,7 +12,9 @@
   "network": {
     "nodes": [
       {
-        "name": "catchment1",
+        "meta": {
+          "name": "catchment1"
+        },
         "type": "Catchment",
         "flow": {
           "type": "Constant",
@@ -20,7 +22,9 @@
         }
       },
       {
-        "name": "gauge1",
+        "meta": {
+          "name": "gauge1"
+        },
         "type": "RiverGauge",
         "mrf": {
           "type": "Constant",
@@ -32,11 +36,15 @@
         }
       },
       {
-        "name": "term1",
+        "meta": {
+          "name": "term1"
+        },
         "type": "Output"
       },
       {
-        "name": "demand1",
+        "meta": {
+          "name": "demand1"
+        },
         "type": "Output",
         "max_flow": {
           "type": "Constant",

--- a/pywr-schema/src/test_models/river_split_with_gauge1.json
+++ b/pywr-schema/src/test_models/river_split_with_gauge1.json
@@ -12,7 +12,9 @@
   "network": {
     "nodes": [
       {
-        "name": "catchment1",
+        "meta": {
+          "name": "catchment1"
+        },
         "type": "Catchment",
         "flow": {
           "type": "Constant",
@@ -20,7 +22,9 @@
         }
       },
       {
-        "name": "gauge1",
+        "meta": {
+          "name": "gauge1"
+        },
         "type": "RiverGauge",
         "mrf": {
           "type": "Constant",
@@ -32,11 +36,15 @@
         }
       },
       {
-        "name": "term1",
+        "meta": {
+          "name": "term1"
+        },
         "type": "Output"
       },
       {
-        "name": "demand1",
+        "meta": {
+          "name": "demand1"
+        },
         "type": "Output",
         "max_flow": {
           "type": "Constant",

--- a/pywr-schema/src/test_models/simple1.json
+++ b/pywr-schema/src/test_models/simple1.json
@@ -12,7 +12,9 @@
   "network": {
     "nodes": [
       {
-        "name": "supply1",
+        "meta": {
+          "name": "supply1"
+        },
         "type": "Input",
         "max_flow": {
           "type": "Constant",
@@ -20,11 +22,15 @@
         }
       },
       {
-        "name": "link1",
+        "meta": {
+          "name": "link1"
+        },
         "type": "Link"
       },
       {
-        "name": "demand1",
+        "meta": {
+          "name": "demand1"
+        },
         "type": "Output",
         "max_flow": {
           "type": "Parameter",
@@ -48,7 +54,9 @@
     ],
     "parameters": [
       {
-        "name": "demand",
+        "meta": {
+          "name": "demand"
+        },
         "type": "Constant",
         "value": 10.0
       }

--- a/pywr-schema/src/test_models/storage_max_volumes.json
+++ b/pywr-schema/src/test_models/storage_max_volumes.json
@@ -12,7 +12,9 @@
   "network": {
     "nodes": [
       {
-        "name": "supply1",
+        "meta": {
+          "name": "supply1"
+        },
         "type": "Input",
         "max_flow": {
           "type": "Constant",
@@ -20,7 +22,9 @@
         }
       },
       {
-        "name": "storage1",
+        "meta": {
+          "name": "storage1"
+        },
         "type": "Storage",
         "initial_volume": {
           "Proportional": 0.5
@@ -31,7 +35,9 @@
         }
       },
       {
-        "name": "storage2",
+        "meta": {
+          "name": "storage2"
+        },
         "type": "Storage",
         "initial_volume": {
           "Proportional": 0.5
@@ -42,7 +48,9 @@
         }
       },
       {
-        "name": "storage3",
+        "meta": {
+          "name": "storage3"
+        },
         "type": "Storage",
         "initial_volume": {
           "Proportional": 0.5
@@ -53,7 +61,9 @@
         }
       },
       {
-        "name": "output1",
+        "meta": {
+          "name": "output1"
+        },
         "type": "Output"
       }
     ],
@@ -85,17 +95,23 @@
     ],
     "parameters": [
       {
-        "name": "ten",
+        "meta": {
+          "name": "ten"
+        },
         "type": "Constant",
         "value": 10.0
       },
       {
-        "name": "five",
+        "meta": {
+          "name": "five"
+        },
         "type": "Constant",
         "value": 5.0
       },
       {
-        "name": "fifteen",
+        "meta": {
+          "name": "fifteen"
+        },
         "type": "Aggregated",
         "agg_func": "sum",
         "metrics": [

--- a/pywr-schema/src/test_models/timeseries.json
+++ b/pywr-schema/src/test_models/timeseries.json
@@ -10,7 +10,9 @@
   "network": {
     "nodes": [
       {
-        "name": "input2",
+        "meta": {
+          "name": "input2"
+        },
         "type": "Input",
         "max_flow": {
           "type": "Parameter",
@@ -18,7 +20,9 @@
         }
       },
       {
-        "name": "input1",
+        "meta": {
+          "name": "input1"
+        },
         "type": "Input",
         "max_flow": {
           "type": "Timeseries",
@@ -30,11 +34,15 @@
         }
       },
       {
-        "name": "link1",
+        "meta": {
+          "name": "link1"
+        },
         "type": "Link"
       },
       {
-        "name": "output1",
+        "meta": {
+          "name": "output1"
+        },
         "type": "Output",
         "cost": {
           "type": "Constant",
@@ -62,12 +70,16 @@
     ],
     "parameters": [
       {
-        "name": "demand",
+        "meta": {
+          "name": "demand"
+        },
         "type": "Constant",
         "value": 100.0
       },
       {
-        "name": "factored_flow",
+        "meta": {
+          "name": "factored_flow"
+        },
         "type": "Aggregated",
         "agg_func": "product",
         "metrics": [
@@ -84,7 +96,9 @@
     ],
     "timeseries": [
       {
-        "name": "inflow",
+        "meta": {
+          "name": "inflow"
+        },
         "provider": {
           "type": "Polars",
           "time_col": "date",

--- a/pywr-schema/src/test_models/v1/timeseries-converted.json
+++ b/pywr-schema/src/test_models/v1/timeseries-converted.json
@@ -14,7 +14,6 @@
     "nodes": [
       {
         "type": "Input",
-        "name": "input1",
         "max_flow": {
           "type": "Timeseries",
           "name": "inflow",
@@ -23,34 +22,43 @@
             "name": "inflow1"
           }
         },
+        "meta": {
+          "name": "input1"
+        },
         "min_flow": null,
         "cost": null
       },
       {
         "type": "Input",
-        "name": "input2",
         "max_flow": {
           "type": "Parameter",
           "name": "factored_flow",
           "key": null
+        },
+        "meta": {
+          "name": "input2"
         },
         "min_flow": null,
         "cost": null
       },
       {
         "type": "Link",
-        "name": "link1",
         "max_flow": null,
+        "meta": {
+          "name": "link1"
+        },
         "min_flow": null,
         "cost": null
       },
       {
         "type": "Output",
-        "name": "output1",
         "max_flow": {
           "type": "Parameter",
           "name": "demand",
           "key": null
+        },
+        "meta": {
+          "name": "output1"
         },
         "min_flow": null,
         "cost": {
@@ -76,12 +84,17 @@
     "parameters": [
       {
         "type": "Constant",
-        "name": "demand",
-        "value": 100.0
+        "meta": {
+          "name": "demand"
+        },
+        "value": 100.0,
+        "variable": null
       },
       {
         "type": "Aggregated",
-        "name": "factored_flow",
+        "meta": {
+          "name": "factored_flow"
+        },
         "agg_func": "product",
         "metrics": [
           {
@@ -102,7 +115,9 @@
     "tables": null,
     "timeseries": [
       {
-        "name": "inflow",
+        "meta": {
+          "name": "inflow"
+        },
         "provider": {
           "type": "Polars",
           "infer_schema_length": null,

--- a/pywr-schema/src/test_models/wtw1.json
+++ b/pywr-schema/src/test_models/wtw1.json
@@ -12,11 +12,15 @@
   "network": {
     "nodes": [
       {
-        "name": "input1",
+        "meta": {
+          "name": "input1"
+        },
         "type": "Input"
       },
       {
-        "name": "wtw1",
+        "meta": {
+          "name": "wtw1"
+        },
         "type": "WaterTreatmentWorks",
         "max_flow": {
           "type": "Constant",
@@ -31,7 +35,9 @@
         }
       },
       {
-        "name": "demand1",
+        "meta": {
+          "name": "demand1"
+        },
         "type": "Output",
         "max_flow": {
           "type": "Constant",
@@ -43,7 +49,9 @@
         }
       },
       {
-        "name": "wtw2",
+        "meta": {
+          "name": "wtw2"
+        },
         "type": "WaterTreatmentWorks",
         "max_flow": {
           "type": "Constant",
@@ -51,7 +59,9 @@
         }
       },
       {
-        "name": "demand2",
+        "meta": {
+          "name": "demand2"
+        },
         "type": "Output",
         "max_flow": {
           "type": "Constant",

--- a/pywr-schema/src/timeseries/mod.rs
+++ b/pywr-schema/src/timeseries/mod.rs
@@ -62,8 +62,8 @@ enum TimeseriesProvider {
 }
 
 #[derive(serde::Deserialize, serde::Serialize, Debug, Clone, JsonSchema)]
+#[serde(deny_unknown_fields)]
 pub struct Timeseries {
-    #[serde(flatten)]
     meta: ParameterMeta,
     provider: TimeseriesProvider,
 }


### PR DESCRIPTION
Enforce `deny_unknown_fields` in parameters and node schemas. This will help finding schema errors and avoid silently ignoring incorrect or misnamed fields. This has required not flattening the meta objects in the JSON schema. Therefore, the schema has changed with the meta data now nested in a "meta" field. The meta objects do not implement `deny_unknown_fields` which allows this object to contain open ended data that might be useful for other tools.

Fixes #165.