### PR TITLE
refactor: Rename ParameterThresholdParameter to ThresholdParameter.

### DIFF
--- a/pywr-schema/src/parameters/mod.rs
+++ b/pywr-schema/src/parameters/mod.rs
@@ -67,7 +67,7 @@ use schemars::JsonSchema;
 use std::path::{Path, PathBuf};
 use strum_macros::{Display, EnumDiscriminants, EnumString, IntoStaticStr, VariantNames};
 pub use tables::TablesArrayParameter;
-pub use thresholds::ParameterThresholdParameter;
+pub use thresholds::ThresholdParameter;
 
 #[derive(serde::Deserialize, serde::Serialize, Debug, Clone, JsonSchema, PywrVisitAll)]
 pub struct ParameterMeta {
@@ -174,7 +174,7 @@ pub enum Parameter {
     NegativeMin(NegativeMinParameter),
     HydropowerTarget(HydropowerTargetParameter),
     Polynomial1D(Polynomial1DParameter),
-    ParameterThreshold(ParameterThresholdParameter),
+    Threshold(ThresholdParameter),
     TablesArray(TablesArrayParameter),
     Python(PythonParameter),
     Delay(DelayParameter),
@@ -205,7 +205,7 @@ impl Parameter {
             Self::Min(p) => p.meta.name.as_str(),
             Self::Negative(p) => p.meta.name.as_str(),
             Self::Polynomial1D(p) => p.meta.name.as_str(),
-            Self::ParameterThreshold(p) => p.meta.name.as_str(),
+            Self::Threshold(p) => p.meta.name.as_str(),
             Self::TablesArray(p) => p.meta.name.as_str(),
             Self::Python(p) => p.meta.name.as_str(),
             Self::Division(p) => p.meta.name.as_str(),
@@ -259,7 +259,7 @@ impl Parameter {
             Self::Min(p) => pywr_core::parameters::ParameterType::Parameter(p.add_to_model(network, args)?),
             Self::Negative(p) => pywr_core::parameters::ParameterType::Parameter(p.add_to_model(network, args)?),
             Self::Polynomial1D(p) => pywr_core::parameters::ParameterType::Parameter(p.add_to_model(network)?),
-            Self::ParameterThreshold(p) => pywr_core::parameters::ParameterType::Index(p.add_to_model(network, args)?),
+            Self::Threshold(p) => pywr_core::parameters::ParameterType::Index(p.add_to_model(network, args)?),
             Self::TablesArray(p) => pywr_core::parameters::ParameterType::Parameter(p.add_to_model(network, args)?),
             Self::Python(p) => p.add_to_model(network, args)?,
             Self::Delay(p) => pywr_core::parameters::ParameterType::Parameter(p.add_to_model(network, args)?),
@@ -299,7 +299,7 @@ impl VisitMetrics for Parameter {
             Self::Min(p) => p.visit_metrics(visitor),
             Self::Negative(p) => p.visit_metrics(visitor),
             Self::Polynomial1D(p) => p.visit_metrics(visitor),
-            Self::ParameterThreshold(p) => p.visit_metrics(visitor),
+            Self::Threshold(p) => p.visit_metrics(visitor),
             Self::TablesArray(p) => p.visit_metrics(visitor),
             Self::Python(p) => p.visit_metrics(visitor),
             Self::Delay(p) => p.visit_metrics(visitor),
@@ -333,7 +333,7 @@ impl VisitMetrics for Parameter {
             Self::Min(p) => p.visit_metrics_mut(visitor),
             Self::Negative(p) => p.visit_metrics_mut(visitor),
             Self::Polynomial1D(p) => p.visit_metrics_mut(visitor),
-            Self::ParameterThreshold(p) => p.visit_metrics_mut(visitor),
+            Self::Threshold(p) => p.visit_metrics_mut(visitor),
             Self::TablesArray(p) => p.visit_metrics_mut(visitor),
             Self::Python(p) => p.visit_metrics_mut(visitor),
             Self::Delay(p) => p.visit_metrics_mut(visitor),
@@ -369,7 +369,7 @@ impl VisitPaths for Parameter {
             Self::Min(p) => p.visit_paths(visitor),
             Self::Negative(p) => p.visit_paths(visitor),
             Self::Polynomial1D(p) => p.visit_paths(visitor),
-            Self::ParameterThreshold(p) => p.visit_paths(visitor),
+            Self::Threshold(p) => p.visit_paths(visitor),
             Self::TablesArray(p) => p.visit_paths(visitor),
             Self::Python(p) => p.visit_paths(visitor),
             Self::Delay(p) => p.visit_paths(visitor),
@@ -403,7 +403,7 @@ impl VisitPaths for Parameter {
             Self::Min(p) => p.visit_paths_mut(visitor),
             Self::Negative(p) => p.visit_paths_mut(visitor),
             Self::Polynomial1D(p) => p.visit_paths_mut(visitor),
-            Self::ParameterThreshold(p) => p.visit_paths_mut(visitor),
+            Self::Threshold(p) => p.visit_paths_mut(visitor),
             Self::TablesArray(p) => p.visit_paths_mut(visitor),
             Self::Python(p) => p.visit_paths_mut(visitor),
             Self::Delay(p) => p.visit_paths_mut(visitor),
@@ -570,7 +570,7 @@ impl TryFromV1Parameter<ParameterV1> for ParameterOrTimeseries {
                     Parameter::Polynomial1D(p.try_into_v2_parameter(parent_node, unnamed_count)?).into()
                 }
                 CoreParameter::ParameterThreshold(p) => {
-                    Parameter::ParameterThreshold(p.try_into_v2_parameter(parent_node, unnamed_count)?).into()
+                    Parameter::Threshold(p.try_into_v2_parameter(parent_node, unnamed_count)?).into()
                 }
                 CoreParameter::TablesArray(p) => {
                     Parameter::TablesArray(p.try_into_v2_parameter(parent_node, unnamed_count)?).into()

--- a/pywr-schema/src/parameters/thresholds.rs
+++ b/pywr-schema/src/parameters/thresholds.rs
@@ -54,9 +54,9 @@ impl From<Predicate> for pywr_core::parameters::Predicate {
 
 #[derive(serde::Deserialize, serde::Serialize, Debug, Clone, JsonSchema, PywrVisitAll)]
 #[serde(deny_unknown_fields)]
-pub struct ParameterThresholdParameter {
+pub struct ThresholdParameter {
     pub meta: ParameterMeta,
-    pub parameter: Metric,
+    pub value: Metric,
     pub threshold: Metric,
     pub predicate: Predicate,
     #[serde(default)]
@@ -64,13 +64,13 @@ pub struct ParameterThresholdParameter {
 }
 
 #[cfg(feature = "core")]
-impl ParameterThresholdParameter {
+impl ThresholdParameter {
     pub fn add_to_model(
         &self,
         network: &mut pywr_core::network::Network,
         args: &LoadArgs,
     ) -> Result<ParameterIndex<usize>, SchemaError> {
-        let metric = self.parameter.load(network, args)?;
+        let metric = self.value.load(network, args)?;
         let threshold = self.threshold.load(network, args)?;
 
         let p = pywr_core::parameters::ThresholdParameter::new(
@@ -84,7 +84,7 @@ impl ParameterThresholdParameter {
     }
 }
 
-impl TryFromV1Parameter<ParameterThresholdParameterV1> for ParameterThresholdParameter {
+impl TryFromV1Parameter<ParameterThresholdParameterV1> for ThresholdParameter {
     type Error = ConversionError;
 
     fn try_from_v1_parameter(
@@ -94,14 +94,14 @@ impl TryFromV1Parameter<ParameterThresholdParameterV1> for ParameterThresholdPar
     ) -> Result<Self, Self::Error> {
         let meta: ParameterMeta = v1.meta.into_v2_parameter(parent_node, unnamed_count);
 
-        let parameter = v1.parameter.try_into_v2_parameter(Some(&meta.name), unnamed_count)?;
+        let value = v1.parameter.try_into_v2_parameter(Some(&meta.name), unnamed_count)?;
         let threshold = v1.threshold.try_into_v2_parameter(Some(&meta.name), unnamed_count)?;
 
         // TODO warn or something about the lack of using the values here!!
 
         let p = Self {
             meta,
-            parameter,
+            value,
             threshold,
             predicate: v1.predicate.into(),
             ratchet: false,


### PR DESCRIPTION
This implementation can use any metric for the value and threshold.

Fixes #146.