### PR TITLE
fix: Clamp storage volumes to be within min & max volume ranges.

### DIFF
--- a/pywr-core/src/derived_metric.rs
+++ b/pywr-core/src/derived_metric.rs
@@ -78,7 +78,7 @@ impl DerivedMetric {
     pub fn compute(&self, network: &Network, state: &State) -> Result<f64, PywrError> {
         match self {
             Self::NodeProportionalVolume(idx) => {
-                let max_volume = network.get_node(idx)?.get_current_max_volume(state)?;
+                let max_volume = network.get_node(idx)?.get_max_volume(state)?;
                 Ok(state
                     .get_network_state()
                     .get_node_proportional_volume(idx, max_volume)?)
@@ -100,7 +100,7 @@ impl DerivedMetric {
                 let max_volume: f64 = node
                     .nodes
                     .iter()
-                    .map(|idx| network.get_node(idx)?.get_current_max_volume(state))
+                    .map(|idx| network.get_node(idx)?.get_max_volume(state))
                     .sum::<Result<_, _>>()?;
                 // TODO handle divide by zero
                 Ok(volume / max_volume)

--- a/pywr-core/src/node.rs
+++ b/pywr-core/src/node.rs
@@ -418,7 +418,7 @@ impl Node {
         }
     }
 
-    pub fn get_current_min_volume(&self, state: &State) -> Result<f64, PywrError> {
+    pub fn get_min_volume(&self, state: &State) -> Result<f64, PywrError> {
         match self {
             Self::Input(_) => Err(PywrError::StorageConstraintsUndefined),
             Self::Link(_) => Err(PywrError::StorageConstraintsUndefined),
@@ -439,7 +439,7 @@ impl Node {
         }
     }
 
-    pub fn get_current_max_volume(&self, state: &State) -> Result<f64, PywrError> {
+    pub fn get_max_volume(&self, state: &State) -> Result<f64, PywrError> {
         match self {
             Self::Input(_) => Err(PywrError::StorageConstraintsUndefined),
             Self::Link(_) => Err(PywrError::StorageConstraintsUndefined),
@@ -448,10 +448,11 @@ impl Node {
         }
     }
 
-    pub fn get_current_volume_bounds(&self, state: &State) -> Result<(f64, f64), PywrError> {
-        match (self.get_current_min_volume(state), self.get_current_max_volume(state)) {
+    /// Return the current min and max volumes as a tuple.
+    pub fn get_volume_bounds(&self, state: &State) -> Result<(f64, f64), PywrError> {
+        match (self.get_min_volume(state), self.get_max_volume(state)) {
             (Ok(min_vol), Ok(max_vol)) => Ok((min_vol, max_vol)),
-            _ => Err(PywrError::FlowConstraintsUndefined),
+            _ => Err(PywrError::StorageConstraintsUndefined),
         }
     }
 

--- a/pywr-core/src/solvers/builder.rs
+++ b/pywr-core/src/solvers/builder.rs
@@ -531,7 +531,7 @@ where
             .iter()
             .zip(network.virtual_storage_nodes().deref())
         {
-            let (avail, missing) = match node.get_current_available_volume_bounds(state) {
+            let (avail, missing) = match node.get_available_volume_bounds(state) {
                 Ok(bnds) => bnds,
                 Err(e) => return Err(e),
             };

--- a/pywr-core/src/solvers/cbc/mod.rs
+++ b/pywr-core/src/solvers/cbc/mod.rs
@@ -288,7 +288,7 @@ impl Solver for CbcSolver {
             let flow = if flow.abs() < 1e-10 { 0.0 } else { flow };
             network_state.add_flow(edge, timestep, flow)?;
         }
-        network_state.complete(model, timestep)?;
+        state.complete(model, timestep)?;
         timings.save_solution += start_save_solution.elapsed();
 
         Ok(timings)

--- a/pywr-core/src/solvers/clp/mod.rs
+++ b/pywr-core/src/solvers/clp/mod.rs
@@ -287,7 +287,7 @@ impl Solver for ClpSolver {
             let flow = solution[col];
             network_state.add_flow(edge, timestep, flow)?;
         }
-        network_state.complete(model, timestep)?;
+        state.complete(model, timestep)?;
         timings.save_solution += start_save_solution.elapsed();
 
         Ok(timings)

--- a/pywr-core/src/solvers/highs/mod.rs
+++ b/pywr-core/src/solvers/highs/mod.rs
@@ -288,7 +288,7 @@ impl Solver for HighsSolver {
             let flow = solution[col];
             network_state.add_flow(edge, timestep, flow)?;
         }
-        network_state.complete(network, timestep)?;
+        state.complete(network, timestep)?;
         timings.save_solution += start_save_solution.elapsed();
 
         Ok(timings)

--- a/pywr-core/src/state.rs
+++ b/pywr-core/src/state.rs
@@ -131,8 +131,22 @@ impl StorageState {
         self.volume / max_volume
     }
 
-    /// Ensure the volume is within the min and max volume range (inclusive).
+    /// Ensure the volume is within the min and max volume range (inclusive). If the volume
+    /// is more than 1E6 outside the min or max volume then this function will panic,
+    /// reporting a mass-balance message.
     fn clamp(&mut self, min_volume: f64, max_volume: f64) {
+        if (self.volume - min_volume) < -1e-6 {
+            panic!(
+                "Mass-balance error detected. Volume ({}) is smaller than minimum volume ({}).",
+                self.volume, min_volume
+            );
+        }
+        if (self.volume - max_volume) > 1e-6 {
+            panic!(
+                "Mass-balance error detected. Volume ({}) is greater than maximum volume ({}).",
+                self.volume, max_volume,
+            );
+        }
         self.volume = self.volume.clamp(min_volume, max_volume);
     }
 }

--- a/pywr-core/src/virtual_storage.rs
+++ b/pywr-core/src/virtual_storage.rs
@@ -272,7 +272,7 @@ impl VirtualStorage {
             .get_max_volume(&state.get_simple_parameter_values())
     }
 
-    pub fn get_current_available_volume_bounds(&self, state: &State) -> Result<(f64, f64), PywrError> {
+    pub fn get_available_volume_bounds(&self, state: &State) -> Result<(f64, f64), PywrError> {
         let min_vol = self.get_min_volume(state)?;
         let max_vol = self.get_max_volume(state)?;
 


### PR DESCRIPTION
This accounts for small floating point rounding errors and tolerances from LP results. In some cases the resulting volume will be a rounding error above or below the bounds.

This also replicates behaviour from v1.