### PR TITLE
ci: CI performance improvements & disable debuginfo

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
 
 env:
+  CARGO_INCREMENTAL: 0
   CARGO_TERM_COLOR: always
   # Make sure CI fails on all warnings, including Clippy lints
   RUSTFLAGS: "-Dwarnings"
@@ -33,7 +34,7 @@ jobs:
       - name: Build
         run: cargo build --verbose --features highs,cbc --workspace --exclude ipm-simd --exclude pywr-python
       - name: Run tests
-        run: cargo test --features highs,cbc
+        run: cargo test --features highs,cbc --verbose --lib --bins -- --test-threads=1
       - name: Run mdbook tests
         run: mdbook test ./pywr-book
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -6,11 +6,10 @@ on:
   pull_request:
 
 env:
+  CARGO_INCREMENTAL: 0
   CARGO_TERM_COLOR: always
   # Make sure CI fails on all warnings, including Clippy lints
   RUSTFLAGS: "-Dwarnings"
-  ACTIONS_RUNNER_DEBUG: true
-  ACTIONS_STEP_DEBUG: true
 
 jobs:
   build:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,9 +25,14 @@ default-members = [
     # "pywr-python",
 ]
 
+[profile.dev]
+# Disabling debug info speeds up builds a bunch,
+# and we don't rely on it for debugging that much.
+debug = 0
 
 [profile.release]
-opt-level = 3 # fast and small wasm
+debug = 0 # Set this to 1 or 2 to get more useful backtraces in debugger.
+opt-level = 3
 # lto = true
 # strip = true
 # Turn this on for profiling


### PR DESCRIPTION
Limit the number of threads in the Linux CI. Disable debuginfo and incremental compilation to save space.