### PR TITLE
feat: Replace DynamicIndexValue with IndexMetric 

### DIFF
--- a/pywr-core/src/network.rs
+++ b/pywr-core/src/network.rs
@@ -1363,6 +1363,14 @@ impl Network {
         self.parameters.add_simple_f64(parameter)
     }
 
+    /// Add a [`parameters::SimpleParameter`] to the network
+    pub fn add_simple_index_parameter(
+        &mut self,
+        parameter: Box<dyn parameters::SimpleParameter<usize>>,
+    ) -> Result<ParameterIndex<usize>, PywrError> {
+        self.parameters.add_simple_usize(parameter)
+    }
+
     /// Add a [`parameters::ConstParameter`] to the network
     pub fn add_const_parameter(
         &mut self,

--- a/pywr-core/src/parameters/control_curves/piecewise.rs
+++ b/pywr-core/src/parameters/control_curves/piecewise.rs
@@ -87,7 +87,7 @@ mod test {
         // Create an artificial volume series to use for the interpolation test
         let volume = Array1Parameter::new("test-x".into(), Array1::linspace(1.0, 0.0, 21), None);
 
-        let volume_idx = model.network_mut().add_parameter(Box::new(volume)).unwrap();
+        let volume_idx = model.network_mut().add_simple_parameter(Box::new(volume)).unwrap();
 
         let parameter = PiecewiseInterpolatedParameter::new(
             "test-parameter".into(),

--- a/pywr-core/src/parameters/delay.rs
+++ b/pywr-core/src/parameters/delay.rs
@@ -176,7 +176,7 @@ mod test {
         let volumes = Array1::linspace(1.0, 0.0, 21);
         let volume = Array1Parameter::new("test-x".into(), volumes.clone(), None);
 
-        let volume_idx = model.network_mut().add_parameter(Box::new(volume)).unwrap();
+        let volume_idx = model.network_mut().add_simple_parameter(Box::new(volume)).unwrap();
 
         const DELAY: usize = 3; // 3 time-step delay
         let parameter = DelayParameter::new(

--- a/pywr-core/src/parameters/discount_factor.rs
+++ b/pywr-core/src/parameters/discount_factor.rs
@@ -68,7 +68,7 @@ mod test {
         let volumes = Array1::linspace(1.0, 0.0, 21);
         let volume = Array1Parameter::new("test-x".into(), volumes.clone(), None);
 
-        let _volume_idx = network.add_parameter(Box::new(volume)).unwrap();
+        let _volume_idx = network.add_simple_parameter(Box::new(volume)).unwrap();
 
         let parameter = DiscountFactorParameter::new(
             "test-parameter".into(),

--- a/pywr-core/src/parameters/mod.rs
+++ b/pywr-core/src/parameters/mod.rs
@@ -1008,7 +1008,7 @@ impl ParameterCollection {
         }
 
         match parameter.try_into_simple() {
-            Some(simple) => self.add_simple_usize(simple).map(|idx| idx.into()),
+            Some(simple) => self.add_simple_usize(simple),
             None => {
                 let index = GeneralParameterIndex::new(self.general_usize.len());
                 self.general_usize.push(parameter);
@@ -1020,17 +1020,22 @@ impl ParameterCollection {
     pub fn add_simple_usize(
         &mut self,
         parameter: Box<dyn SimpleParameter<usize>>,
-    ) -> Result<SimpleParameterIndex<usize>, PywrError> {
+    ) -> Result<ParameterIndex<usize>, PywrError> {
         if self.has_name(parameter.name()) {
             return Err(PywrError::ParameterNameAlreadyExists(parameter.meta().name.to_string()));
         }
 
-        let index = SimpleParameterIndex::new(self.simple_usize.len());
+        match parameter.try_into_const() {
+            Some(constant) => self.add_const_usize(constant),
+            None => {
+                let index = SimpleParameterIndex::new(self.simple_f64.len());
 
-        self.simple_usize.push(parameter);
-        self.simple_resolve_order.push(SimpleParameterType::Index(index));
+                self.simple_usize.push(parameter);
+                self.simple_resolve_order.push(SimpleParameterType::Index(index));
 
-        Ok(index)
+                Ok(index.into())
+            }
+        }
     }
 
     pub fn add_const_usize(

--- a/pywr-core/src/state.rs
+++ b/pywr-core/src/state.rs
@@ -416,7 +416,7 @@ pub struct ParameterValuesRef<'a> {
     multi_values: &'a [MultiValue],
 }
 
-impl<'a> ParameterValuesRef<'a> {
+impl ParameterValuesRef<'_> {
     fn get_value(&self, idx: usize) -> Option<&f64> {
         self.values.get(idx)
     }
@@ -428,6 +428,10 @@ impl<'a> ParameterValuesRef<'a> {
     fn get_multi_value(&self, idx: usize, key: &str) -> Option<&f64> {
         self.multi_values.get(idx).and_then(|s| s.get_value(key))
     }
+
+    fn get_multi_index(&self, idx: usize, key: &str) -> Option<&usize> {
+        self.multi_values.get(idx).and_then(|s| s.get_index(key))
+    }
 }
 
 pub struct SimpleParameterValues<'a> {
@@ -435,7 +439,7 @@ pub struct SimpleParameterValues<'a> {
     simple: ParameterValuesRef<'a>,
 }
 
-impl<'a> SimpleParameterValues<'a> {
+impl SimpleParameterValues<'_> {
     pub fn get_simple_parameter_f64(&self, idx: SimpleParameterIndex<f64>) -> Result<f64, PywrError> {
         self.simple
             .get_value(*idx.deref())
@@ -461,6 +465,17 @@ impl<'a> SimpleParameterValues<'a> {
             .copied()
     }
 
+    pub fn get_simple_multi_parameter_usize(
+        &self,
+        idx: SimpleParameterIndex<MultiValue>,
+        key: &str,
+    ) -> Result<usize, PywrError> {
+        self.simple
+            .get_multi_index(*idx.deref(), key)
+            .ok_or(PywrError::SimpleMultiValueParameterIndexNotFound(idx))
+            .copied()
+    }
+
     pub fn get_constant_values(&self) -> &ConstParameterValues {
         &self.constant
     }
@@ -470,7 +485,7 @@ pub struct ConstParameterValues<'a> {
     constant: ParameterValuesRef<'a>,
 }
 
-impl<'a> ConstParameterValues<'a> {
+impl ConstParameterValues<'_> {
     pub fn get_const_parameter_f64(&self, idx: ConstParameterIndex<f64>) -> Result<f64, PywrError> {
         self.constant
             .get_value(*idx.deref())
@@ -492,6 +507,17 @@ impl<'a> ConstParameterValues<'a> {
     ) -> Result<f64, PywrError> {
         self.constant
             .get_multi_value(*idx.deref(), key)
+            .ok_or(PywrError::ConstMultiValueParameterIndexNotFound(idx))
+            .copied()
+    }
+
+    pub fn get_const_multi_parameter_usize(
+        &self,
+        idx: ConstParameterIndex<MultiValue>,
+        key: &str,
+    ) -> Result<usize, PywrError> {
+        self.constant
+            .get_multi_index(*idx.deref(), key)
             .ok_or(PywrError::ConstMultiValueParameterIndexNotFound(idx))
             .copied()
     }

--- a/pywr-core/src/test_utils.rs
+++ b/pywr-core/src/test_utils.rs
@@ -64,7 +64,7 @@ pub fn simple_network(network: &mut Network, inflow_scenario_index: usize, num_i
     let inflow = Array::from_shape_fn((366, num_inflow_scenarios), |(i, j)| 1.0 + i as f64 + j as f64);
     let inflow = Array2Parameter::new("inflow".into(), inflow, inflow_scenario_index, None);
 
-    let inflow = network.add_parameter(Box::new(inflow)).unwrap();
+    let inflow = network.add_simple_parameter(Box::new(inflow)).unwrap();
 
     let input_node = network.get_mut_node_by_name("input", None).unwrap();
     input_node.set_max_flow_constraint(Some(inflow.into())).unwrap();
@@ -287,7 +287,7 @@ fn make_simple_system<R: Rng>(
         inflow_scenario_group_index,
         None,
     );
-    let idx = network.add_parameter(Box::new(inflow))?;
+    let idx = network.add_simple_parameter(Box::new(inflow))?;
 
     network.set_node_max_flow("input", Some(suffix), Some(idx.into()))?;
 

--- a/pywr-core/src/timestep.rs
+++ b/pywr-core/src/timestep.rs
@@ -96,7 +96,7 @@ impl PywrDuration {
     }
 }
 
-type TimestepIndex = usize;
+pub type TimestepIndex = usize;
 
 #[pyclass]
 #[derive(Debug, Copy, Clone)]

--- a/pywr-schema/src/data_tables/mod.rs
+++ b/pywr-schema/src/data_tables/mod.rs
@@ -255,7 +255,7 @@ impl LoadedTableCollection {
     }
 }
 
-#[derive(serde::Deserialize, serde::Serialize, Debug, Clone, JsonSchema, PywrVisitAll)]
+#[derive(serde::Deserialize, serde::Serialize, Debug, Clone, JsonSchema, PywrVisitAll, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct TableDataRef {
     pub table: String,

--- a/pywr-schema/src/edge.rs
+++ b/pywr-schema/src/edge.rs
@@ -7,7 +7,7 @@ use pywr_core::{edge::EdgeIndex, metric::MetricF64, node::NodeIndex};
 use schemars::JsonSchema;
 use std::fmt::{Display, Formatter};
 
-#[derive(serde::Deserialize, serde::Serialize, Clone, JsonSchema, Debug)]
+#[derive(serde::Deserialize, serde::Serialize, Clone, JsonSchema, Debug, PartialEq)]
 pub struct Edge {
     pub from_node: String,
     pub to_node: String,

--- a/pywr-schema/src/error.rs
+++ b/pywr-schema/src/error.rs
@@ -17,8 +17,10 @@ pub enum SchemaError {
         name: String,
         attr: NodeAttribute,
     },
-    #[error("parameter {0} not found")]
+    #[error("Parameter `{0}` not found")]
     ParameterNotFound(String),
+    #[error("Expected an index parameter, but found a regular parameter: {0}")]
+    IndexParameterExpected(String),
     #[error("Loading a local parameter reference (name: {0}) requires a parent name space.")]
     LocalParameterReferenceRequiresParent(String),
     #[error("network {0} not found")]
@@ -44,8 +46,6 @@ pub enum SchemaError {
     HDF5Error(String),
     #[error("Missing metric set: {0}")]
     MissingMetricSet(String),
-    #[error("unexpected parameter type: {0}")]
-    UnexpectedParameterType(String),
     #[error("mismatch in the length of data provided. expected: {expected}, found: {found}")]
     DataLengthMismatch { expected: usize, found: usize },
     #[error("Failed to estimate epsilon for use in the radial basis function.")]

--- a/pywr-schema/src/metric.rs
+++ b/pywr-schema/src/metric.rs
@@ -17,7 +17,10 @@ use crate::v1::{ConversionData, TryFromV1, TryIntoV2};
 use crate::ConversionError;
 #[cfg(feature = "core")]
 use pywr_core::{
-    metric::MetricF64, models::MultiNetworkTransferIndex, parameters::ParameterName, recorders::OutputMetric,
+    metric::{MetricF64, MetricUsize},
+    models::MultiNetworkTransferIndex,
+    parameters::ParameterName,
+    recorders::OutputMetric,
 };
 use pywr_schema_macros::PywrVisitAll;
 use pywr_v1_schema::parameters::ParameterValue as ParameterValueV1;
@@ -25,23 +28,33 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use strum_macros::Display;
 
-/// Output metrics that can be recorded from a model run.
+/// A floating point value representing different model metrics.
+///
+/// Metrics can be used in various places in a model to create dynamic behaviour. For example,
+/// parameter can use an arbitrary [`Metric`] for its calculation giving the user the ability
+/// to configure the source of that value. Therefore, metrics are the primary way in which
+/// dynamic behaviour is created.
+///
+/// See also [`IndexMetric`] for integer values.
 #[derive(Deserialize, Serialize, Clone, Debug, Display, JsonSchema)]
 #[serde(tag = "type")]
 pub enum Metric {
-    Constant {
-        value: f64,
-    },
+    /// A constant floating point value.
+    Constant { value: f64 },
+    /// A reference to a constant value in a table.
     Table(TableDataRef),
     /// An attribute of a node.
     Node(NodeReference),
+    /// An attribute of an edge.
     Edge(EdgeReference),
+    /// A reference to a value from a timeseries.
     Timeseries(TimeseriesReference),
+    /// A reference to a global parameter.
     Parameter(ParameterReference),
+    /// A reference to a local parameter.
     LocalParameter(ParameterReference),
-    InterNetworkTransfer {
-        name: String,
-    },
+    /// A reference to an inter-network transfer by name.
+    InterNetworkTransfer { name: String },
 }
 
 impl Default for Metric {
@@ -65,9 +78,9 @@ impl Metric {
         parent: Option<&str>,
     ) -> Result<MetricF64, SchemaError> {
         match self {
-            Self::Node(node_ref) => node_ref.load(network, args),
+            Self::Node(node_ref) => node_ref.load_f64(network, args),
             // Global parameter with no parent
-            Self::Parameter(parameter_ref) => parameter_ref.load(network, None),
+            Self::Parameter(parameter_ref) => parameter_ref.load_f64(network, None),
             // Local parameter loaded from parent's namespace
             Self::LocalParameter(parameter_ref) => {
                 if parent.is_none() {
@@ -76,7 +89,7 @@ impl Metric {
                     ));
                 }
 
-                parameter_ref.load(network, parent)
+                parameter_ref.load_f64(network, parent)
             }
             Self::Constant { value } => Ok((*value).into()),
             Self::Table(table_ref) => {
@@ -93,13 +106,13 @@ impl Metric {
                 let param_idx = match &ts_ref.columns {
                     Some(TimeseriesColumns::Scenario(scenario)) => {
                         args.timeseries
-                            .load_df(network, ts_ref.name.as_ref(), args.domain, scenario.as_str())?
+                            .load_df_f64(network, ts_ref.name.as_ref(), args.domain, scenario.as_str())?
                     }
                     Some(TimeseriesColumns::Column(col)) => {
                         args.timeseries
-                            .load_column(network, ts_ref.name.as_ref(), col.as_str())?
+                            .load_column_f64(network, ts_ref.name.as_ref(), col.as_str())?
                     }
-                    None => args.timeseries.load_single_column(network, ts_ref.name.as_ref())?,
+                    None => args.timeseries.load_single_column_f64(network, ts_ref.name.as_ref())?,
                 };
                 Ok(param_idx.into())
             }
@@ -234,8 +247,13 @@ impl NodeReference {
         Self { name, attribute }
     }
 
+    /// Load a node reference into a [`MetricF64`].
     #[cfg(feature = "core")]
-    pub fn load(&self, network: &mut pywr_core::network::Network, args: &LoadArgs) -> Result<MetricF64, SchemaError> {
+    pub fn load_f64(
+        &self,
+        network: &mut pywr_core::network::Network,
+        args: &LoadArgs,
+    ) -> Result<MetricF64, SchemaError> {
         // This is the associated node in the schema
         let node = args
             .schema
@@ -243,6 +261,22 @@ impl NodeReference {
             .ok_or_else(|| SchemaError::NodeNotFound(self.name.clone()))?;
 
         node.create_metric(network, self.attribute, args)
+    }
+
+    /// Load a node reference into a [`MetricUsize`].
+    #[cfg(feature = "core")]
+    pub fn load_usize(
+        &self,
+        _network: &mut pywr_core::network::Network,
+        args: &LoadArgs,
+    ) -> Result<MetricUsize, SchemaError> {
+        // This is the associated node in the schema
+        let _node = args
+            .schema
+            .get_node_by_name(&self.name)
+            .ok_or_else(|| SchemaError::NodeNotFound(self.name.clone()))?;
+
+        todo!("Support usize attributes on nodes.")
     }
 
     /// Return the attribute of the node. If the attribute is not specified then the default
@@ -345,7 +379,7 @@ impl ParameterReference {
     /// from the `network`. If `parent` is the optional parameter name space from which to load
     /// the parameter.
     #[cfg(feature = "core")]
-    pub fn load(
+    pub fn load_f64(
         &self,
         network: &mut pywr_core::network::Network,
         parent: Option<&str>,
@@ -369,6 +403,34 @@ impl ParameterReference {
         }
     }
 
+    /// Load a parameter reference into a [`MetricUsize`] by attempting to retrieve the parameter
+    /// from the `network`. If `parent` is the optional parameter name space from which to load
+    /// the parameter.
+    #[cfg(feature = "core")]
+    pub fn load_usize(
+        &self,
+        network: &mut pywr_core::network::Network,
+        parent: Option<&str>,
+    ) -> Result<MetricUsize, SchemaError> {
+        let name = ParameterName::new(&self.name, parent);
+
+        match &self.key {
+            Some(key) => {
+                // Key given; this should be a multi-valued parameter
+                Ok((network.get_multi_valued_parameter_index_by_name(&name)?, key.clone()).into())
+            }
+            None => {
+                if let Ok(idx) = network.get_index_parameter_index_by_name(&name) {
+                    Ok(idx.into())
+                } else if network.get_parameter_index_by_name(&name).is_ok() {
+                    // Inform the user we found the parameter, but it was the wrong type
+                    Err(SchemaError::IndexParameterExpected(self.name.to_string()))
+                } else {
+                    Err(SchemaError::ParameterNotFound(self.name.to_string()))
+                }
+            }
+        }
+    }
     #[cfg(feature = "core")]
     pub fn parameter_type(&self, args: &LoadArgs) -> Result<ParameterType, SchemaError> {
         let parameter = args
@@ -392,5 +454,132 @@ impl EdgeReference {
     pub fn load(&self, network: &mut pywr_core::network::Network, args: &LoadArgs) -> Result<MetricF64, SchemaError> {
         // This is the associated node in the schema
         self.edge.create_metric(network, args)
+    }
+}
+
+/// An unsigned integer value representing different model metrics.
+///
+/// This struct is the integer equivalent of [`Metric`] and is used in places where an integer
+/// value is required. See [`Metric`] for more information.
+#[derive(serde::Deserialize, serde::Serialize, Debug, Clone, JsonSchema, Display)]
+#[serde(untagged)]
+pub enum IndexMetric {
+    Constant {
+        value: usize,
+    },
+    Table(TableDataRef),
+    /// An attribute of a node.
+    Node(NodeReference),
+    Timeseries(TimeseriesReference),
+    Parameter(ParameterReference),
+    LocalParameter(ParameterReference),
+    InterNetworkTransfer {
+        name: String,
+    },
+}
+
+impl IndexMetric {
+    pub fn from_usize(v: usize) -> Self {
+        Self::Constant { value: v }
+    }
+}
+
+#[cfg(feature = "core")]
+impl IndexMetric {
+    pub fn load(
+        &self,
+        network: &mut pywr_core::network::Network,
+        args: &LoadArgs,
+        parent: Option<&str>,
+    ) -> Result<MetricUsize, SchemaError> {
+        match self {
+            Self::Node(node_ref) => node_ref.load_usize(network, args),
+            // Global parameter with no parent
+            Self::Parameter(parameter_ref) => parameter_ref.load_usize(network, None),
+            // Local parameter loaded from parent's namespace
+            Self::LocalParameter(parameter_ref) => {
+                if parent.is_none() {
+                    return Err(SchemaError::LocalParameterReferenceRequiresParent(
+                        parameter_ref.name.clone(),
+                    ));
+                }
+
+                parameter_ref.load_usize(network, parent)
+            }
+            Self::Constant { value } => Ok((*value).into()),
+            Self::Table(table_ref) => {
+                let value = args
+                    .tables
+                    .get_scalar_usize(table_ref)
+                    .map_err(|error| SchemaError::TableRefLoad {
+                        table_ref: table_ref.clone(),
+                        error,
+                    })?;
+                Ok(value.into())
+            }
+            Self::Timeseries(ts_ref) => {
+                let param_idx = match &ts_ref.columns {
+                    Some(TimeseriesColumns::Scenario(scenario)) => {
+                        args.timeseries
+                            .load_df_usize(network, ts_ref.name.as_ref(), args.domain, scenario.as_str())?
+                    }
+                    Some(TimeseriesColumns::Column(col)) => {
+                        args.timeseries
+                            .load_column_usize(network, ts_ref.name.as_ref(), col.as_str())?
+                    }
+                    None => args
+                        .timeseries
+                        .load_single_column_usize(network, ts_ref.name.as_ref())?,
+                };
+                Ok(param_idx.into())
+            }
+            Self::InterNetworkTransfer { name } => {
+                // Find the matching inter model transfer
+                match args.inter_network_transfers.iter().position(|t| &t.name == name) {
+                    Some(idx) => Ok(MetricUsize::InterNetworkTransfer(MultiNetworkTransferIndex(idx))),
+                    None => Err(SchemaError::InterNetworkTransferNotFound(name.to_string())),
+                }
+            }
+        }
+    }
+}
+
+impl TryFromV1<ParameterValueV1> for IndexMetric {
+    type Error = ConversionError;
+
+    fn try_from_v1(
+        v1: ParameterValueV1,
+        parent_node: Option<&str>,
+        conversion_data: &mut ConversionData,
+    ) -> Result<Self, Self::Error> {
+        let p = match v1 {
+            // There was no such thing as s constant index in Pywr v1
+            // TODO this could print a warning and do a cast to usize instead.
+            ParameterValueV1::Constant(_) => return Err(ConversionError::FloatToIndex),
+            ParameterValueV1::Reference(p_name) => Self::Parameter(ParameterReference {
+                name: p_name,
+                key: None,
+            }),
+            ParameterValueV1::Table(tbl) => Self::Table(tbl.try_into()?),
+            ParameterValueV1::Inline(param) => {
+                // Inline parameters are converted to either a parameter or a timeseries
+                // The actual component is extracted into the conversion data leaving a reference
+                // to the component in the metric.
+                let definition: ParameterOrTimeseriesRef = (*param).try_into_v2(parent_node, conversion_data)?;
+                match definition {
+                    ParameterOrTimeseriesRef::Parameter(p) => {
+                        let reference = ParameterReference {
+                            name: p.name().to_string(),
+                            key: None,
+                        };
+                        conversion_data.parameters.push(*p);
+
+                        Self::Parameter(reference)
+                    }
+                    ParameterOrTimeseriesRef::Timeseries(t) => Self::Timeseries(t),
+                }
+            }
+        };
+        Ok(p)
     }
 }

--- a/pywr-schema/src/nodes/mod.rs
+++ b/pywr-schema/src/nodes/mod.rs
@@ -89,7 +89,7 @@ impl From<NodeMetaV1> for NodeMeta {
 /// All possible attributes that could be produced by a node.
 ///
 ///
-#[derive(serde::Deserialize, serde::Serialize, Debug, Clone, Copy, Display, JsonSchema, PywrVisitAll)]
+#[derive(serde::Deserialize, serde::Serialize, Debug, Clone, Copy, Display, JsonSchema, PywrVisitAll, PartialEq)]
 pub enum NodeAttribute {
     Inflow,
     Outflow,

--- a/pywr-schema/src/parameters/aggregated.rs
+++ b/pywr-schema/src/parameters/aggregated.rs
@@ -1,10 +1,10 @@
 use crate::error::ConversionError;
 #[cfg(feature = "core")]
 use crate::error::SchemaError;
-use crate::metric::Metric;
+use crate::metric::{IndexMetric, Metric};
 #[cfg(feature = "core")]
 use crate::model::LoadArgs;
-use crate::parameters::{ConversionData, DynamicIndexValue, ParameterMeta};
+use crate::parameters::{ConversionData, ParameterMeta};
 use crate::v1::{IntoV2, TryFromV1, TryIntoV2};
 #[cfg(feature = "core")]
 use pywr_core::parameters::ParameterIndex;
@@ -173,7 +173,7 @@ pub struct AggregatedIndexParameter {
     pub meta: ParameterMeta,
     pub agg_func: IndexAggFunc,
     // TODO this should be `DynamicIntValues`
-    pub parameters: Vec<DynamicIndexValue>,
+    pub parameters: Vec<IndexMetric>,
 }
 
 impl AggregatedIndexParameter {
@@ -201,7 +201,7 @@ impl AggregatedIndexParameter {
         let parameters = self
             .parameters
             .iter()
-            .map(|v| v.load(network, args))
+            .map(|v| v.load(network, args, None))
             .collect::<Result<Vec<_>, _>>()?;
 
         let p = pywr_core::parameters::AggregatedIndexParameter::new(

--- a/pywr-schema/src/parameters/asymmetric_switch.rs
+++ b/pywr-schema/src/parameters/asymmetric_switch.rs
@@ -1,9 +1,10 @@
 use crate::error::ConversionError;
 #[cfg(feature = "core")]
 use crate::error::SchemaError;
+use crate::metric::IndexMetric;
 #[cfg(feature = "core")]
 use crate::model::LoadArgs;
-use crate::parameters::{ConversionData, DynamicIndexValue, ParameterMeta};
+use crate::parameters::{ConversionData, ParameterMeta};
 use crate::v1::{IntoV2, TryFromV1, TryIntoV2};
 #[cfg(feature = "core")]
 use pywr_core::parameters::ParameterIndex;
@@ -15,8 +16,8 @@ use schemars::JsonSchema;
 #[serde(deny_unknown_fields)]
 pub struct AsymmetricSwitchIndexParameter {
     pub meta: ParameterMeta,
-    pub on_index_parameter: DynamicIndexValue,
-    pub off_index_parameter: DynamicIndexValue,
+    pub on_index_parameter: IndexMetric,
+    pub off_index_parameter: IndexMetric,
 }
 
 #[cfg(feature = "core")]
@@ -26,8 +27,8 @@ impl AsymmetricSwitchIndexParameter {
         network: &mut pywr_core::network::Network,
         args: &LoadArgs,
     ) -> Result<ParameterIndex<usize>, SchemaError> {
-        let on_index_parameter = self.on_index_parameter.load(network, args)?;
-        let off_index_parameter = self.off_index_parameter.load(network, args)?;
+        let on_index_parameter = self.on_index_parameter.load(network, args, None)?;
+        let off_index_parameter = self.off_index_parameter.load(network, args, None)?;
 
         let p = pywr_core::parameters::AsymmetricSwitchIndexParameter::new(
             self.meta.name.as_str().into(),

--- a/pywr-schema/src/parameters/control_curves.rs
+++ b/pywr-schema/src/parameters/control_curves.rs
@@ -34,7 +34,7 @@ impl ControlCurveInterpolatedParameter {
         network: &mut pywr_core::network::Network,
         args: &LoadArgs,
     ) -> Result<ParameterIndex<f64>, SchemaError> {
-        let metric = self.storage_node.load(network, args)?;
+        let metric = self.storage_node.load_f64(network, args)?;
 
         let control_curves = self
             .control_curves
@@ -134,7 +134,7 @@ impl ControlCurveIndexParameter {
         network: &mut pywr_core::network::Network,
         args: &LoadArgs,
     ) -> Result<ParameterIndex<usize>, SchemaError> {
-        let metric = self.storage_node.load(network, args)?;
+        let metric = self.storage_node.load_f64(network, args)?;
 
         let control_curves = self
             .control_curves
@@ -246,7 +246,7 @@ impl ControlCurveParameter {
         network: &mut pywr_core::network::Network,
         args: &LoadArgs,
     ) -> Result<ParameterIndex<f64>, SchemaError> {
-        let metric = self.storage_node.load(network, args)?;
+        let metric = self.storage_node.load_f64(network, args)?;
 
         let control_curves = self
             .control_curves
@@ -342,7 +342,7 @@ impl ControlCurvePiecewiseInterpolatedParameter {
         network: &mut pywr_core::network::Network,
         args: &LoadArgs,
     ) -> Result<ParameterIndex<f64>, SchemaError> {
-        let metric = self.storage_node.load(network, args)?;
+        let metric = self.storage_node.load_f64(network, args)?;
 
         let control_curves = self
             .control_curves

--- a/pywr-schema/src/parameters/indexed_array.rs
+++ b/pywr-schema/src/parameters/indexed_array.rs
@@ -1,10 +1,10 @@
 use crate::error::ConversionError;
 #[cfg(feature = "core")]
 use crate::error::SchemaError;
-use crate::metric::Metric;
+use crate::metric::{IndexMetric, Metric};
 #[cfg(feature = "core")]
 use crate::model::LoadArgs;
-use crate::parameters::{ConversionData, DynamicIndexValue, ParameterMeta};
+use crate::parameters::{ConversionData, ParameterMeta};
 use crate::v1::{IntoV2, TryFromV1, TryIntoV2};
 #[cfg(feature = "core")]
 use pywr_core::parameters::ParameterIndex;
@@ -18,7 +18,7 @@ pub struct IndexedArrayParameter {
     pub meta: ParameterMeta,
     #[serde(alias = "params")]
     pub metrics: Vec<Metric>,
-    pub index_parameter: DynamicIndexValue,
+    pub index_parameter: IndexMetric,
 }
 
 #[cfg(feature = "core")]
@@ -28,7 +28,7 @@ impl IndexedArrayParameter {
         network: &mut pywr_core::network::Network,
         args: &LoadArgs,
     ) -> Result<ParameterIndex<f64>, SchemaError> {
-        let index_parameter = self.index_parameter.load(network, args)?;
+        let index_parameter = self.index_parameter.load(network, args, None)?;
 
         let metrics = self
             .metrics

--- a/pywr-schema/src/parameters/mod.rs
+++ b/pywr-schema/src/parameters/mod.rs
@@ -638,7 +638,7 @@ impl ConstantFloatVec {
     }
 }
 
-#[derive(serde::Deserialize, serde::Serialize, Debug, Clone, JsonSchema, PywrVisitAll, Display)]
+#[derive(serde::Deserialize, serde::Serialize, Debug, Clone, JsonSchema, PywrVisitAll, Display, PartialEq)]
 #[serde(untagged)]
 pub enum TableIndex {
     Single(String),

--- a/pywr-schema/src/parameters/python.rs
+++ b/pywr-schema/src/parameters/python.rs
@@ -2,10 +2,10 @@
 use crate::data_tables::make_path;
 #[cfg(feature = "core")]
 use crate::error::SchemaError;
-use crate::metric::Metric;
+use crate::metric::{IndexMetric, Metric};
 #[cfg(feature = "core")]
 use crate::model::LoadArgs;
-use crate::parameters::{DynamicFloatValueType, DynamicIndexValue, ParameterMeta};
+use crate::parameters::{DynamicFloatValueType, ParameterMeta};
 use crate::visit::{VisitMetrics, VisitPaths};
 #[cfg(feature = "core")]
 use pyo3::prelude::{PyAnyMethods, PyModule};
@@ -103,7 +103,7 @@ pub struct PythonParameter {
     pub metrics: Option<HashMap<String, Metric>>,
     /// Index values to pass to the calculation method of the initialised object (i.e.
     /// indices that the Python calculation is dependent on).
-    pub indices: Option<HashMap<String, DynamicIndexValue>>,
+    pub indices: Option<HashMap<String, IndexMetric>>,
 }
 
 #[cfg(feature = "core")]
@@ -242,7 +242,7 @@ impl PythonParameter {
         let indices = match &self.indices {
             Some(indices) => indices
                 .iter()
-                .map(|(k, v)| Ok((k.to_string(), v.load(network, args)?)))
+                .map(|(k, v)| Ok((k.to_string(), v.load(network, args, None)?)))
                 .collect::<Result<HashMap<_, _>, SchemaError>>()?,
             None => HashMap::new(),
         };

--- a/pywr-schema/src/parameters/tables.rs
+++ b/pywr-schema/src/parameters/tables.rs
@@ -75,7 +75,7 @@ impl TablesArrayParameter {
                 scenario_group_index,
                 self.timestep_offset,
             );
-            Ok(network.add_parameter(Box::new(p))?)
+            Ok(network.add_simple_parameter(Box::new(p))?)
         } else {
             let array = array.slice_move(s![.., 0]);
             let p = pywr_core::parameters::Array1Parameter::new(
@@ -83,7 +83,7 @@ impl TablesArrayParameter {
                 array,
                 self.timestep_offset,
             );
-            Ok(network.add_parameter(Box::new(p))?)
+            Ok(network.add_simple_parameter(Box::new(p))?)
         }
     }
 }

--- a/pywr-schema/src/timeseries/mod.rs
+++ b/pywr-schema/src/timeseries/mod.rs
@@ -13,7 +13,11 @@ pub use pandas::PandasDataset;
 #[cfg(feature = "core")]
 use polars::error::PolarsError;
 #[cfg(feature = "core")]
-use polars::prelude::{DataFrame, DataType::Float64, Float64Type, IndexOrder};
+use polars::prelude::{
+    DataFrame,
+    DataType::{Float64, UInt64},
+    Float64Type, IndexOrder, UInt64Type,
+};
 pub use polars_dataset::PolarsDataset;
 #[cfg(feature = "core")]
 use pywr_core::{
@@ -129,7 +133,7 @@ impl LoadedTimeseriesCollection {
         Ok(Self { timeseries })
     }
 
-    pub fn load_column(
+    pub fn load_column_f64(
         &self,
         network: &mut pywr_core::network::Network,
         name: &str,
@@ -149,14 +153,41 @@ impl LoadedTimeseriesCollection {
             Err(e) => match e {
                 PywrError::ParameterNotFound(_) => {
                     let p = Array1Parameter::new(name, array, None);
-                    Ok(network.add_parameter(Box::new(p))?)
+                    Ok(network.add_simple_parameter(Box::new(p))?)
                 }
                 _ => Err(TimeseriesError::PywrCore(e)),
             },
         }
     }
 
-    pub fn load_single_column(
+    pub fn load_column_usize(
+        &self,
+        network: &mut pywr_core::network::Network,
+        name: &str,
+        col: &str,
+    ) -> Result<ParameterIndex<usize>, TimeseriesError> {
+        let df = self
+            .timeseries
+            .get(name)
+            .ok_or(TimeseriesError::TimeseriesNotFound(name.to_string()))?;
+        let series = df.column(col)?;
+
+        let array = series.cast(&UInt64)?.u64()?.to_ndarray()?.to_owned();
+        let name = ParameterName::new(col, Some(name));
+
+        match network.get_index_parameter_index_by_name(&name) {
+            Ok(idx) => Ok(idx),
+            Err(e) => match e {
+                PywrError::ParameterNotFound(_) => {
+                    let p = Array1Parameter::new(name, array, None);
+                    Ok(network.add_simple_index_parameter(Box::new(p))?)
+                }
+                _ => Err(TimeseriesError::PywrCore(e)),
+            },
+        }
+    }
+
+    pub fn load_single_column_f64(
         &self,
         network: &mut pywr_core::network::Network,
         name: &str,
@@ -187,14 +218,53 @@ impl LoadedTimeseriesCollection {
             Err(e) => match e {
                 PywrError::ParameterNotFound(_) => {
                     let p = Array1Parameter::new(name, array, None);
-                    Ok(network.add_parameter(Box::new(p))?)
+                    Ok(network.add_simple_parameter(Box::new(p))?)
                 }
                 _ => Err(TimeseriesError::PywrCore(e)),
             },
         }
     }
 
-    pub fn load_df(
+    pub fn load_single_column_usize(
+        &self,
+        network: &mut pywr_core::network::Network,
+        name: &str,
+    ) -> Result<ParameterIndex<usize>, TimeseriesError> {
+        let df = self
+            .timeseries
+            .get(name)
+            .ok_or(TimeseriesError::TimeseriesNotFound(name.to_string()))?;
+
+        let cols = df.get_column_names();
+
+        if cols.len() > 1 {
+            return Err(TimeseriesError::TimeseriesColumnOrScenarioRequired(name.to_string()));
+        };
+
+        let col = cols.first().ok_or(TimeseriesError::ColumnNotFound {
+            col: "".to_string(),
+            name: name.to_string(),
+        })?;
+
+        let series = df.column(col)?;
+
+        let array = series.cast(&UInt64)?.u64()?.to_ndarray()?.to_owned();
+        let name = ParameterName::new(col, Some(name));
+
+        match network.get_index_parameter_index_by_name(&name) {
+            Ok(idx) => Ok(idx),
+            Err(e) => match e {
+                PywrError::ParameterNotFound(_) => {
+                    let p = Array1Parameter::new(name, array, None);
+                    Ok(network.add_simple_index_parameter(Box::new(p))?)
+                }
+                _ => Err(TimeseriesError::PywrCore(e)),
+            },
+        }
+    }
+
+    /// Load a timeseries dataframe as a 2D array F64 parameter.
+    pub fn load_df_f64(
         &self,
         network: &mut pywr_core::network::Network,
         name: &str,
@@ -219,7 +289,40 @@ impl LoadedTimeseriesCollection {
             Err(e) => match e {
                 PywrError::ParameterNotFound(_) => {
                     let p = Array2Parameter::new(name, array, scenario_group_index, None);
-                    Ok(network.add_parameter(Box::new(p))?)
+                    Ok(network.add_simple_parameter(Box::new(p))?)
+                }
+                _ => Err(TimeseriesError::PywrCore(e)),
+            },
+        }
+    }
+
+    /// Load a timeseries dataframe as a 2D array Usize parameter.
+    pub fn load_df_usize(
+        &self,
+        network: &mut pywr_core::network::Network,
+        name: &str,
+        domain: &ModelDomain,
+        scenario: &str,
+    ) -> Result<ParameterIndex<usize>, TimeseriesError> {
+        let scenario_group_index = domain
+            .scenarios()
+            .group_index(scenario)
+            .ok_or(TimeseriesError::ScenarioGroupNotFound(scenario.to_string()))?;
+
+        let df = self
+            .timeseries
+            .get(name)
+            .ok_or(TimeseriesError::TimeseriesNotFound(name.to_string()))?;
+
+        let array: Array2<u64> = df.to_ndarray::<UInt64Type>(IndexOrder::default()).unwrap();
+        let name = ParameterName::new(scenario, Some(name));
+
+        match network.get_index_parameter_index_by_name(&name) {
+            Ok(idx) => Ok(idx),
+            Err(e) => match e {
+                PywrError::ParameterNotFound(_) => {
+                    let p = Array2Parameter::new(name, array, scenario_group_index, None);
+                    Ok(network.add_simple_index_parameter(Box::new(p))?)
                 }
                 _ => Err(TimeseriesError::PywrCore(e)),
             },

--- a/pywr-schema/src/timeseries/mod.rs
+++ b/pywr-schema/src/timeseries/mod.rs
@@ -399,14 +399,14 @@ impl LoadedTimeseriesCollection {
 //     ts.into_values().collect::<Vec<Timeseries>>()
 // }
 
-#[derive(serde::Deserialize, serde::Serialize, Debug, Clone, JsonSchema, strum_macros::Display)]
+#[derive(serde::Deserialize, serde::Serialize, Debug, Clone, JsonSchema, strum_macros::Display, PartialEq)]
 #[serde(tag = "type", content = "name")]
 pub enum TimeseriesColumns {
     Scenario(String),
     Column(String),
 }
 
-#[derive(serde::Deserialize, serde::Serialize, Debug, Clone, JsonSchema)]
+#[derive(serde::Deserialize, serde::Serialize, Debug, Clone, JsonSchema, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct TimeseriesReference {
     pub name: String,

--- a/pywr-schema/src/visit.rs
+++ b/pywr-schema/src/visit.rs
@@ -1,4 +1,4 @@
-use crate::metric::Metric;
+use crate::metric::{IndexMetric, Metric};
 use std::collections::HashMap;
 use std::num::NonZeroUsize;
 use std::path::{Path, PathBuf};
@@ -24,6 +24,12 @@ impl VisitMetrics for Metric {
     fn visit_metrics_mut<F: FnMut(&mut Metric)>(&mut self, visitor: &mut F) {
         visitor(self);
     }
+}
+
+impl VisitMetrics for IndexMetric {
+    fn visit_metrics<F: FnMut(&Metric)>(&self, _visitor: &mut F) {}
+
+    fn visit_metrics_mut<F: FnMut(&mut Metric)>(&mut self, _visitor: &mut F) {}
 }
 
 impl<T> VisitMetrics for Option<T>
@@ -125,6 +131,7 @@ pub trait VisitPaths {
 }
 
 impl VisitPaths for Metric {}
+impl VisitPaths for IndexMetric {}
 
 impl<T> VisitPaths for Option<T>
 where


### PR DESCRIPTION
`IndexMetric` mirrors `Metric`, but for integers.

Also adds support for:
- Integer arrays in core.
- `MultiValue<usize>` parameter return type.

Fixes #291 