### PR TITLE
feat: Use u64 instead of usize for index parameters.

### DIFF
--- a/pywr-core/src/aggregated_node.rs
+++ b/pywr-core/src/aggregated_node.rs
@@ -77,16 +77,16 @@ impl Factors {
 #[derive(Debug, PartialEq)]
 pub struct Exclusivity {
     // The minimum number of nodes that must be active
-    min_active: usize,
+    min_active: u64,
     // The maximum number of nodes that can be active
-    max_active: usize,
+    max_active: u64,
 }
 
 impl Exclusivity {
-    pub fn min_active(&self) -> usize {
+    pub fn min_active(&self) -> u64 {
         self.min_active
     }
-    pub fn max_active(&self) -> usize {
+    pub fn max_active(&self) -> u64 {
         self.max_active
     }
 }
@@ -108,7 +108,7 @@ impl Relationship {
         Relationship::Factored(Factors::Proportion(factors.to_vec()))
     }
 
-    pub fn new_exclusive(min_active: usize, max_active: usize) -> Self {
+    pub fn new_exclusive(min_active: u64, max_active: u64) -> Self {
         Relationship::Exclusive(Exclusivity { min_active, max_active })
     }
 }

--- a/pywr-core/src/lib.rs
+++ b/pywr-core/src/lib.rs
@@ -50,25 +50,25 @@ pub enum PywrError {
     #[error("parameter index {0} not found")]
     ParameterIndexNotFound(ParameterIndex<f64>),
     #[error("index parameter index {0} not found")]
-    IndexParameterIndexNotFound(ParameterIndex<usize>),
+    IndexParameterIndexNotFound(ParameterIndex<u64>),
     #[error("multi-value parameter index {0} not found")]
     MultiValueParameterIndexNotFound(ParameterIndex<MultiValue>),
     #[error("parameter index {0} not found")]
     GeneralParameterIndexNotFound(GeneralParameterIndex<f64>),
     #[error("index parameter index {0} not found")]
-    GeneralIndexParameterIndexNotFound(GeneralParameterIndex<usize>),
+    GeneralIndexParameterIndexNotFound(GeneralParameterIndex<u64>),
     #[error("multi-value parameter index {0} not found")]
     GeneralMultiValueParameterIndexNotFound(GeneralParameterIndex<MultiValue>),
     #[error("parameter index {0} not found")]
     SimpleParameterIndexNotFound(SimpleParameterIndex<f64>),
     #[error("index parameter index {0} not found")]
-    SimpleIndexParameterIndexNotFound(SimpleParameterIndex<usize>),
+    SimpleIndexParameterIndexNotFound(SimpleParameterIndex<u64>),
     #[error("multi-value parameter index {0} not found")]
     SimpleMultiValueParameterIndexNotFound(SimpleParameterIndex<MultiValue>),
     #[error("parameter index {0} not found")]
     ConstParameterIndexNotFound(ConstParameterIndex<f64>),
     #[error("index parameter index {0} not found")]
-    ConstIndexParameterIndexNotFound(ConstParameterIndex<usize>),
+    ConstIndexParameterIndexNotFound(ConstParameterIndex<u64>),
     #[error("multi-value parameter index {0} not found")]
     ConstMultiValueParameterIndexNotFound(ConstParameterIndex<MultiValue>),
     #[error("multi-value parameter key {0} not found")]
@@ -96,7 +96,7 @@ pub enum PywrError {
     #[error("parameter name `{0}` already exists")]
     ParameterNameAlreadyExists(String),
     #[error("index parameter name `{0}` already exists at index {1}")]
-    IndexParameterNameAlreadyExists(String, ParameterIndex<usize>),
+    IndexParameterNameAlreadyExists(String, ParameterIndex<u64>),
     #[error("multi-value parameter name `{0}` already exists at index {1}")]
     MultiValueParameterNameAlreadyExists(String, ParameterIndex<MultiValue>),
     #[error("metric set name `{0}` already exists")]

--- a/pywr-core/src/metric.rs
+++ b/pywr-core/src/metric.rs
@@ -13,7 +13,7 @@ use crate::PywrError;
 #[derive(Clone, Debug, PartialEq)]
 pub enum ConstantMetricF64 {
     ParameterValue(ConstParameterIndex<f64>),
-    IndexParameterValue(ConstParameterIndex<usize>),
+    IndexParameterValue(ConstParameterIndex<u64>),
     MultiParameterValue((ConstParameterIndex<MultiValue>, String)),
     Constant(f64),
 }
@@ -22,7 +22,7 @@ impl ConstantMetricF64 {
     pub fn get_value(&self, values: &ConstParameterValues) -> Result<f64, PywrError> {
         match self {
             ConstantMetricF64::ParameterValue(idx) => Ok(values.get_const_parameter_f64(*idx)?),
-            ConstantMetricF64::IndexParameterValue(idx) => Ok(values.get_const_parameter_usize(*idx)? as f64),
+            ConstantMetricF64::IndexParameterValue(idx) => Ok(values.get_const_parameter_u64(*idx)? as f64),
             ConstantMetricF64::MultiParameterValue((idx, key)) => Ok(values.get_const_multi_parameter_f64(*idx, key)?),
             ConstantMetricF64::Constant(v) => Ok(*v),
         }
@@ -39,7 +39,7 @@ impl ConstantMetricF64 {
 #[derive(Clone, Debug, PartialEq)]
 pub enum SimpleMetricF64 {
     ParameterValue(SimpleParameterIndex<f64>),
-    IndexParameterValue(SimpleParameterIndex<usize>),
+    IndexParameterValue(SimpleParameterIndex<u64>),
     MultiParameterValue((SimpleParameterIndex<MultiValue>, String)),
     Constant(ConstantMetricF64),
 }
@@ -48,7 +48,7 @@ impl SimpleMetricF64 {
     pub fn get_value(&self, values: &SimpleParameterValues) -> Result<f64, PywrError> {
         match self {
             SimpleMetricF64::ParameterValue(idx) => Ok(values.get_simple_parameter_f64(*idx)?),
-            SimpleMetricF64::IndexParameterValue(idx) => Ok(values.get_simple_parameter_usize(*idx)? as f64),
+            SimpleMetricF64::IndexParameterValue(idx) => Ok(values.get_simple_parameter_u64(*idx)? as f64),
             SimpleMetricF64::MultiParameterValue((idx, key)) => Ok(values.get_simple_multi_parameter_f64(*idx, key)?),
             SimpleMetricF64::Constant(m) => m.get_value(values.get_constant_values()),
         }
@@ -87,7 +87,7 @@ pub enum MetricF64 {
     EdgeFlow(EdgeIndex),
     MultiEdgeFlow { indices: Vec<EdgeIndex>, name: String },
     ParameterValue(GeneralParameterIndex<f64>),
-    IndexParameterValue(GeneralParameterIndex<usize>),
+    IndexParameterValue(GeneralParameterIndex<u64>),
     MultiParameterValue((GeneralParameterIndex<MultiValue>, String)),
     VirtualStorageVolume(VirtualStorageIndex),
     MultiNodeInFlow { indices: Vec<NodeIndex>, name: String },
@@ -241,8 +241,8 @@ impl From<ParameterIndex<f64>> for MetricF64 {
     }
 }
 
-impl From<ParameterIndex<usize>> for MetricF64 {
-    fn from(idx: ParameterIndex<usize>) -> Self {
+impl From<ParameterIndex<u64>> for MetricF64 {
+    fn from(idx: ParameterIndex<u64>) -> Self {
         match idx {
             ParameterIndex::General(idx) => Self::IndexParameterValue(idx),
             ParameterIndex::Simple(idx) => Self::Simple(SimpleMetricF64::IndexParameterValue(idx)),
@@ -265,13 +265,13 @@ impl From<(ParameterIndex<MultiValue>, String)> for MetricF64 {
     }
 }
 
-impl From<(ParameterIndex<MultiValue>, String)> for MetricUsize {
+impl From<(ParameterIndex<MultiValue>, String)> for MetricU64 {
     fn from((idx, key): (ParameterIndex<MultiValue>, String)) -> Self {
         match idx {
             ParameterIndex::General(idx) => Self::MultiParameterValue((idx, key)),
-            ParameterIndex::Simple(idx) => Self::Simple(SimpleMetricUsize::MultiParameterValue((idx, key))),
-            ParameterIndex::Const(idx) => Self::Simple(SimpleMetricUsize::Constant(
-                ConstantMetricUsize::MultiParameterValue((idx, key)),
+            ParameterIndex::Simple(idx) => Self::Simple(SimpleMetricU64::MultiParameterValue((idx, key))),
+            ParameterIndex::Const(idx) => Self::Simple(SimpleMetricU64::Constant(
+                ConstantMetricU64::MultiParameterValue((idx, key)),
             )),
         }
     }
@@ -287,9 +287,9 @@ impl TryFrom<ParameterIndex<f64>> for SimpleMetricF64 {
     }
 }
 
-impl TryFrom<ParameterIndex<usize>> for SimpleMetricUsize {
+impl TryFrom<ParameterIndex<u64>> for SimpleMetricU64 {
     type Error = PywrError;
-    fn try_from(idx: ParameterIndex<usize>) -> Result<Self, Self::Error> {
+    fn try_from(idx: ParameterIndex<u64>) -> Result<Self, Self::Error> {
         match idx {
             ParameterIndex::Simple(idx) => Ok(Self::IndexParameterValue(idx)),
             _ => Err(PywrError::CannotSimplifyMetric),
@@ -298,53 +298,49 @@ impl TryFrom<ParameterIndex<usize>> for SimpleMetricUsize {
 }
 
 #[derive(Clone, Debug, PartialEq)]
-pub enum ConstantMetricUsize {
-    IndexParameterValue(ConstParameterIndex<usize>),
+pub enum ConstantMetricU64 {
+    IndexParameterValue(ConstParameterIndex<u64>),
     MultiParameterValue((ConstParameterIndex<MultiValue>, String)),
-    Constant(usize),
+    Constant(u64),
 }
 
-impl ConstantMetricUsize {
-    pub fn get_value(&self, values: &ConstParameterValues) -> Result<usize, PywrError> {
+impl ConstantMetricU64 {
+    pub fn get_value(&self, values: &ConstParameterValues) -> Result<u64, PywrError> {
         match self {
-            ConstantMetricUsize::IndexParameterValue(idx) => values.get_const_parameter_usize(*idx),
-            ConstantMetricUsize::MultiParameterValue((idx, key)) => {
-                Ok(values.get_const_multi_parameter_usize(*idx, key)?)
-            }
-            ConstantMetricUsize::Constant(v) => Ok(*v),
+            ConstantMetricU64::IndexParameterValue(idx) => values.get_const_parameter_u64(*idx),
+            ConstantMetricU64::MultiParameterValue((idx, key)) => Ok(values.get_const_multi_parameter_u64(*idx, key)?),
+            ConstantMetricU64::Constant(v) => Ok(*v),
         }
     }
 }
 
 #[derive(Clone, Debug, PartialEq)]
-pub enum SimpleMetricUsize {
-    IndexParameterValue(SimpleParameterIndex<usize>),
+pub enum SimpleMetricU64 {
+    IndexParameterValue(SimpleParameterIndex<u64>),
     MultiParameterValue((SimpleParameterIndex<MultiValue>, String)),
-    Constant(ConstantMetricUsize),
+    Constant(ConstantMetricU64),
 }
 
-impl SimpleMetricUsize {
-    pub fn get_value(&self, values: &SimpleParameterValues) -> Result<usize, PywrError> {
+impl SimpleMetricU64 {
+    pub fn get_value(&self, values: &SimpleParameterValues) -> Result<u64, PywrError> {
         match self {
-            SimpleMetricUsize::IndexParameterValue(idx) => values.get_simple_parameter_usize(*idx),
-            SimpleMetricUsize::MultiParameterValue((idx, key)) => {
-                Ok(values.get_simple_multi_parameter_usize(*idx, key)?)
-            }
-            SimpleMetricUsize::Constant(m) => m.get_value(values.get_constant_values()),
+            SimpleMetricU64::IndexParameterValue(idx) => values.get_simple_parameter_u64(*idx),
+            SimpleMetricU64::MultiParameterValue((idx, key)) => Ok(values.get_simple_multi_parameter_u64(*idx, key)?),
+            SimpleMetricU64::Constant(m) => m.get_value(values.get_constant_values()),
         }
     }
 }
 
 #[derive(Clone, Debug, PartialEq)]
-pub enum MetricUsize {
-    IndexParameterValue(GeneralParameterIndex<usize>),
-    Simple(SimpleMetricUsize),
+pub enum MetricU64 {
+    IndexParameterValue(GeneralParameterIndex<u64>),
+    Simple(SimpleMetricU64),
     MultiParameterValue((GeneralParameterIndex<MultiValue>, String)),
     InterNetworkTransfer(MultiNetworkTransferIndex),
 }
 
-impl MetricUsize {
-    pub fn get_value(&self, _network: &Network, state: &State) -> Result<usize, PywrError> {
+impl MetricU64 {
+    pub fn get_value(&self, _network: &Network, state: &State) -> Result<u64, PywrError> {
         match self {
             Self::IndexParameterValue(idx) => state.get_parameter_index(*idx),
             Self::MultiParameterValue((idx, key)) => Ok(state.get_multi_parameter_index(*idx, key)?),
@@ -354,37 +350,37 @@ impl MetricUsize {
     }
 }
 
-impl From<ParameterIndex<usize>> for MetricUsize {
-    fn from(idx: ParameterIndex<usize>) -> Self {
+impl From<ParameterIndex<u64>> for MetricU64 {
+    fn from(idx: ParameterIndex<u64>) -> Self {
         match idx {
             ParameterIndex::General(idx) => Self::IndexParameterValue(idx),
-            ParameterIndex::Simple(idx) => Self::Simple(SimpleMetricUsize::IndexParameterValue(idx)),
-            ParameterIndex::Const(idx) => Self::Simple(SimpleMetricUsize::Constant(
-                ConstantMetricUsize::IndexParameterValue(idx),
-            )),
+            ParameterIndex::Simple(idx) => Self::Simple(SimpleMetricU64::IndexParameterValue(idx)),
+            ParameterIndex::Const(idx) => {
+                Self::Simple(SimpleMetricU64::Constant(ConstantMetricU64::IndexParameterValue(idx)))
+            }
         }
     }
 }
-impl From<usize> for ConstantMetricUsize {
-    fn from(v: usize) -> Self {
-        ConstantMetricUsize::Constant(v)
+impl From<u64> for ConstantMetricU64 {
+    fn from(v: u64) -> Self {
+        ConstantMetricU64::Constant(v)
     }
 }
 
-impl<T> From<T> for SimpleMetricUsize
+impl<T> From<T> for SimpleMetricU64
 where
-    T: Into<ConstantMetricUsize>,
+    T: Into<ConstantMetricU64>,
 {
     fn from(v: T) -> Self {
-        SimpleMetricUsize::Constant(v.into())
+        SimpleMetricU64::Constant(v.into())
     }
 }
 
-impl<T> From<T> for MetricUsize
+impl<T> From<T> for MetricU64
 where
-    T: Into<SimpleMetricUsize>,
+    T: Into<SimpleMetricU64>,
 {
     fn from(v: T) -> Self {
-        MetricUsize::Simple(v.into())
+        MetricU64::Simple(v.into())
     }
 }

--- a/pywr-core/src/network.rs
+++ b/pywr-core/src/network.rs
@@ -645,7 +645,7 @@ impl Network {
 
                             // .. and its internal state
                             let internal_state = internal_states
-                                .get_general_mut_usize_state(*idx)
+                                .get_general_mut_u64_state(*idx)
                                 .ok_or(PywrError::GeneralIndexParameterIndexNotFound(*idx))?;
 
                             let value = p.compute(timestep, scenario_index, self, state, internal_state)?;
@@ -736,7 +736,7 @@ impl Network {
 
                             // .. and its internal state
                             let internal_state = internal_states
-                                .get_general_mut_usize_state(*idx)
+                                .get_general_mut_u64_state(*idx)
                                 .ok_or(PywrError::GeneralIndexParameterIndexNotFound(*idx))?;
 
                             p.after(timestep, scenario_index, self, state, internal_state)?;
@@ -1151,8 +1151,8 @@ impl Network {
     }
 
     /// Get a [`Parameter<usize>`] from its index.
-    pub fn get_index_parameter(&self, index: ParameterIndex<usize>) -> Result<&dyn parameters::Parameter, PywrError> {
-        match self.parameters.get_usize(index) {
+    pub fn get_index_parameter(&self, index: ParameterIndex<u64>) -> Result<&dyn parameters::Parameter, PywrError> {
+        match self.parameters.get_u64(index) {
             Some(p) => Ok(p),
             None => Err(PywrError::IndexParameterIndexNotFound(index)),
         }
@@ -1167,7 +1167,7 @@ impl Network {
     }
 
     /// Get a `IndexParameterIndex` from a parameter's name
-    pub fn get_index_parameter_index_by_name(&self, name: &ParameterName) -> Result<ParameterIndex<usize>, PywrError> {
+    pub fn get_index_parameter_index_by_name(&self, name: &ParameterName) -> Result<ParameterIndex<u64>, PywrError> {
         match self.parameters.get_usize_index_by_name(name) {
             Some(idx) => Ok(idx),
             None => Err(PywrError::ParameterNotFound(name.to_string())),
@@ -1365,9 +1365,9 @@ impl Network {
     /// Add a [`parameters::SimpleParameter`] to the network
     pub fn add_simple_index_parameter(
         &mut self,
-        parameter: Box<dyn parameters::SimpleParameter<usize>>,
-    ) -> Result<ParameterIndex<usize>, PywrError> {
-        self.parameters.add_simple_usize(parameter)
+        parameter: Box<dyn parameters::SimpleParameter<u64>>,
+    ) -> Result<ParameterIndex<u64>, PywrError> {
+        self.parameters.add_simple_u64(parameter)
     }
 
     /// Add a [`parameters::ConstParameter`] to the network
@@ -1381,9 +1381,9 @@ impl Network {
     /// Add a `parameters::IndexParameter` to the network
     pub fn add_index_parameter(
         &mut self,
-        parameter: Box<dyn parameters::GeneralParameter<usize>>,
-    ) -> Result<ParameterIndex<usize>, PywrError> {
-        let parameter_index = self.parameters.add_general_usize(parameter)?;
+        parameter: Box<dyn parameters::GeneralParameter<u64>>,
+    ) -> Result<ParameterIndex<u64>, PywrError> {
+        let parameter_index = self.parameters.add_general_u64(parameter)?;
         // add it to the general resolve order (simple and constant parameters are resolved separately)
         if let ParameterIndex::General(idx) = parameter_index {
             self.resolve_order.push(ComponentType::Parameter(idx.into()));

--- a/pywr-core/src/network.rs
+++ b/pywr-core/src/network.rs
@@ -640,7 +640,7 @@ impl Network {
                         GeneralParameterType::Index(idx) => {
                             let p = self
                                 .parameters
-                                .get_general_usize(*idx)
+                                .get_general_u64(*idx)
                                 .ok_or(PywrError::GeneralIndexParameterIndexNotFound(*idx))?;
 
                             // .. and its internal state
@@ -731,7 +731,7 @@ impl Network {
                         GeneralParameterType::Index(idx) => {
                             let p = self
                                 .parameters
-                                .get_general_usize(*idx)
+                                .get_general_u64(*idx)
                                 .ok_or(PywrError::GeneralIndexParameterIndexNotFound(*idx))?;
 
                             // .. and its internal state
@@ -1160,7 +1160,7 @@ impl Network {
 
     /// Get a `IndexParameter` from a parameter's name
     pub fn get_index_parameter_by_name(&self, name: &ParameterName) -> Result<&dyn parameters::Parameter, PywrError> {
-        match self.parameters.get_usize_by_name(name) {
+        match self.parameters.get_u64_by_name(name) {
             Some(parameter) => Ok(parameter),
             None => Err(PywrError::ParameterNotFound(name.to_string())),
         }
@@ -1168,7 +1168,7 @@ impl Network {
 
     /// Get a `IndexParameterIndex` from a parameter's name
     pub fn get_index_parameter_index_by_name(&self, name: &ParameterName) -> Result<ParameterIndex<u64>, PywrError> {
-        match self.parameters.get_usize_index_by_name(name) {
+        match self.parameters.get_u64_index_by_name(name) {
             Some(idx) => Ok(idx),
             None => Err(PywrError::ParameterNotFound(name.to_string())),
         }

--- a/pywr-core/src/parameters/aggregated_index.rs
+++ b/pywr-core/src/parameters/aggregated_index.rs
@@ -1,7 +1,7 @@
 /// AggregatedIndexParameter
 ///
 use super::{Parameter, ParameterName, ParameterState, PywrError};
-use crate::metric::MetricUsize;
+use crate::metric::MetricU64;
 use crate::network::Network;
 use crate::parameters::{GeneralParameter, ParameterMeta};
 use crate::scenario::ScenarioIndex;
@@ -36,12 +36,12 @@ impl FromStr for AggIndexFunc {
 
 pub struct AggregatedIndexParameter {
     meta: ParameterMeta,
-    values: Vec<MetricUsize>,
+    values: Vec<MetricU64>,
     agg_func: AggIndexFunc,
 }
 
 impl AggregatedIndexParameter {
-    pub fn new(name: ParameterName, values: Vec<MetricUsize>, agg_func: AggIndexFunc) -> Self {
+    pub fn new(name: ParameterName, values: Vec<MetricU64>, agg_func: AggIndexFunc) -> Self {
         Self {
             meta: ParameterMeta::new(name),
             values,
@@ -56,7 +56,7 @@ impl Parameter for AggregatedIndexParameter {
     }
 }
 
-impl GeneralParameter<usize> for AggregatedIndexParameter {
+impl GeneralParameter<u64> for AggregatedIndexParameter {
     fn compute(
         &self,
         _timestep: &Timestep,
@@ -64,8 +64,8 @@ impl GeneralParameter<usize> for AggregatedIndexParameter {
         network: &Network,
         state: &State,
         _internal_state: &mut Option<Box<dyn ParameterState>>,
-    ) -> Result<usize, PywrError> {
-        let value: usize = match self.agg_func {
+    ) -> Result<u64, PywrError> {
+        let value: u64 = match self.agg_func {
             AggIndexFunc::Sum => {
                 let mut total = 0;
                 for p in &self.values {
@@ -74,14 +74,14 @@ impl GeneralParameter<usize> for AggregatedIndexParameter {
                 total
             }
             AggIndexFunc::Max => {
-                let mut total = usize::MIN;
+                let mut total = u64::MIN;
                 for p in &self.values {
                     total = total.max(p.get_value(network, state)?);
                 }
                 total
             }
             AggIndexFunc::Min => {
-                let mut total = usize::MAX;
+                let mut total = u64::MAX;
                 for p in &self.values {
                     total = total.min(p.get_value(network, state)?);
                 }

--- a/pywr-core/src/parameters/array.rs
+++ b/pywr-core/src/parameters/array.rs
@@ -63,18 +63,18 @@ impl SimpleParameter<f64> for Array1Parameter<f64> {
     }
 }
 
-impl SimpleParameter<usize> for Array1Parameter<u64> {
+impl SimpleParameter<u64> for Array1Parameter<u64> {
     fn compute(
         &self,
         timestep: &Timestep,
         _scenario_index: &ScenarioIndex,
         _values: &SimpleParameterValues,
         _internal_state: &mut Option<Box<dyn ParameterState>>,
-    ) -> Result<usize, PywrError> {
+    ) -> Result<u64, PywrError> {
         let idx = self.timestep_index(timestep);
         // This panics if out-of-bounds
         let value = self.array[[idx]];
-        Ok(value as usize)
+        Ok(value)
     }
 
     fn as_parameter(&self) -> &dyn Parameter
@@ -153,19 +153,19 @@ impl SimpleParameter<f64> for Array2Parameter<f64> {
     }
 }
 
-impl SimpleParameter<usize> for Array2Parameter<u64> {
+impl SimpleParameter<u64> for Array2Parameter<u64> {
     fn compute(
         &self,
         timestep: &Timestep,
         scenario_index: &ScenarioIndex,
         _values: &SimpleParameterValues,
         _internal_state: &mut Option<Box<dyn ParameterState>>,
-    ) -> Result<usize, PywrError> {
+    ) -> Result<u64, PywrError> {
         // This panics if out-of-bounds
         let t_idx = self.timestep_index(timestep);
         let s_idx = scenario_index.indices[self.scenario_group_index];
 
-        Ok(self.array[[t_idx, s_idx]] as usize)
+        Ok(self.array[[t_idx, s_idx]])
     }
 
     fn as_parameter(&self) -> &dyn Parameter

--- a/pywr-core/src/parameters/asymmetric.rs
+++ b/pywr-core/src/parameters/asymmetric.rs
@@ -1,4 +1,4 @@
-use crate::metric::MetricUsize;
+use crate::metric::MetricU64;
 use crate::network::Network;
 use crate::parameters::{
     downcast_internal_state_mut, GeneralParameter, Parameter, ParameterMeta, ParameterName, ParameterState,
@@ -10,12 +10,12 @@ use crate::PywrError;
 
 pub struct AsymmetricSwitchIndexParameter {
     meta: ParameterMeta,
-    on_parameter: MetricUsize,
-    off_parameter: MetricUsize,
+    on_parameter: MetricU64,
+    off_parameter: MetricU64,
 }
 
 impl AsymmetricSwitchIndexParameter {
-    pub fn new(name: ParameterName, on_parameter: MetricUsize, off_parameter: MetricUsize) -> Self {
+    pub fn new(name: ParameterName, on_parameter: MetricU64, off_parameter: MetricU64) -> Self {
         Self {
             meta: ParameterMeta::new(name),
             on_parameter,
@@ -33,11 +33,11 @@ impl Parameter for AsymmetricSwitchIndexParameter {
         _timesteps: &[Timestep],
         _scenario_index: &ScenarioIndex,
     ) -> Result<Option<Box<dyn ParameterState>>, PywrError> {
-        Ok(Some(Box::new(0_usize)))
+        Ok(Some(Box::new(0_u64)))
     }
 }
 
-impl GeneralParameter<usize> for AsymmetricSwitchIndexParameter {
+impl GeneralParameter<u64> for AsymmetricSwitchIndexParameter {
     fn compute(
         &self,
         _timestep: &Timestep,
@@ -45,11 +45,11 @@ impl GeneralParameter<usize> for AsymmetricSwitchIndexParameter {
         network: &Network,
         state: &State,
         internal_state: &mut Option<Box<dyn ParameterState>>,
-    ) -> Result<usize, PywrError> {
+    ) -> Result<u64, PywrError> {
         let on_value = self.on_parameter.get_value(network, state)?;
 
         // Downcast the internal state to the correct type
-        let current_state = downcast_internal_state_mut::<usize>(internal_state);
+        let current_state = downcast_internal_state_mut::<u64>(internal_state);
 
         if *current_state > 0 {
             if on_value > 0 {

--- a/pywr-core/src/parameters/control_curves/index.rs
+++ b/pywr-core/src/parameters/control_curves/index.rs
@@ -28,7 +28,7 @@ impl Parameter for ControlCurveIndexParameter {
     }
 }
 
-impl GeneralParameter<usize> for ControlCurveIndexParameter {
+impl GeneralParameter<u64> for ControlCurveIndexParameter {
     fn compute(
         &self,
         _timestep: &Timestep,
@@ -36,17 +36,17 @@ impl GeneralParameter<usize> for ControlCurveIndexParameter {
         model: &Network,
         state: &State,
         _internal_state: &mut Option<Box<dyn ParameterState>>,
-    ) -> Result<usize, PywrError> {
+    ) -> Result<u64, PywrError> {
         // Current value
         let x = self.metric.get_value(model, state)?;
 
         for (idx, control_curve) in self.control_curves.iter().enumerate() {
             let cc_value = control_curve.get_value(model, state)?;
             if x >= cc_value {
-                return Ok(idx);
+                return Ok(idx as u64);
             }
         }
-        Ok(self.control_curves.len())
+        Ok(self.control_curves.len() as u64)
     }
     fn as_parameter(&self) -> &dyn Parameter
     where

--- a/pywr-core/src/parameters/delay.rs
+++ b/pywr-core/src/parameters/delay.rs
@@ -13,12 +13,12 @@ use std::collections::VecDeque;
 pub struct DelayParameter<M> {
     meta: ParameterMeta,
     metric: M,
-    delay: usize,
+    delay: u64,
     initial_value: f64,
 }
 
 impl<M> DelayParameter<M> {
-    pub fn new(name: ParameterName, metric: M, delay: usize, initial_value: f64) -> Self {
+    pub fn new(name: ParameterName, metric: M, delay: u64, initial_value: f64) -> Self {
         Self {
             meta: ParameterMeta::new(name),
             metric,
@@ -178,7 +178,7 @@ mod test {
 
         let volume_idx = model.network_mut().add_simple_parameter(Box::new(volume)).unwrap();
 
-        const DELAY: usize = 3; // 3 time-step delay
+        const DELAY: u64 = 3; // 3 time-step delay
         let parameter = DelayParameter::new(
             "test-parameter".into(),
             volume_idx.into(), // Interpolate with the parameter based values
@@ -189,12 +189,16 @@ mod test {
         // We should have DELAY number of initial values to start with, and then follow the
         // values in the `volumes` array.
         let expected_values: Array1<f64> = [
-            0.0; DELAY // initial values
+            0.0; DELAY as usize // initial values
         ]
             .to_vec()
             .into();
 
-        let expected_values = concatenate![Axis(0), expected_values, volumes.slice(s![..volumes.len() - DELAY])];
+        let expected_values = concatenate![
+            Axis(0),
+            expected_values,
+            volumes.slice(s![..volumes.len() - DELAY as usize])
+        ];
 
         let expected_values: Array2<f64> = expected_values.insert_axis(Axis(1));
 

--- a/pywr-core/src/parameters/indexed_array.rs
+++ b/pywr-core/src/parameters/indexed_array.rs
@@ -1,4 +1,4 @@
-use crate::metric::{MetricF64, MetricUsize};
+use crate::metric::{MetricF64, MetricU64};
 use crate::network::Network;
 use crate::parameters::{GeneralParameter, Parameter, ParameterMeta, ParameterName, ParameterState};
 use crate::scenario::ScenarioIndex;
@@ -8,12 +8,12 @@ use crate::PywrError;
 
 pub struct IndexedArrayParameter {
     meta: ParameterMeta,
-    index_parameter: MetricUsize,
+    index_parameter: MetricU64,
     metrics: Vec<MetricF64>,
 }
 
 impl IndexedArrayParameter {
-    pub fn new(name: ParameterName, index_parameter: MetricUsize, metrics: &[MetricF64]) -> Self {
+    pub fn new(name: ParameterName, index_parameter: MetricU64, metrics: &[MetricF64]) -> Self {
         Self {
             meta: ParameterMeta::new(name),
             index_parameter,
@@ -37,7 +37,7 @@ impl GeneralParameter<f64> for IndexedArrayParameter {
         state: &State,
         _internal_state: &mut Option<Box<dyn ParameterState>>,
     ) -> Result<f64, PywrError> {
-        let index = self.index_parameter.get_value(network, state)?;
+        let index = self.index_parameter.get_value(network, state)? as usize;
 
         let metric = self.metrics.get(index).ok_or(PywrError::DataOutOfRange)?;
 

--- a/pywr-core/src/parameters/mod.rs
+++ b/pywr-core/src/parameters/mod.rs
@@ -405,22 +405,22 @@ impl ParameterStates {
     ) -> Option<&mut Option<Box<dyn ParameterState>>> {
         self.constant.f64.get_mut(*index.deref())
     }
-    pub fn get_general_mut_usize_state(
+    pub fn get_general_mut_u64_state(
         &mut self,
-        index: GeneralParameterIndex<usize>,
+        index: GeneralParameterIndex<u64>,
     ) -> Option<&mut Option<Box<dyn ParameterState>>> {
         self.general.usize.get_mut(*index.deref())
     }
 
-    pub fn get_simple_mut_usize_state(
+    pub fn get_simple_mut_u64_state(
         &mut self,
-        index: SimpleParameterIndex<usize>,
+        index: SimpleParameterIndex<u64>,
     ) -> Option<&mut Option<Box<dyn ParameterState>>> {
         self.simple.usize.get_mut(*index.deref())
     }
-    pub fn get_const_mut_usize_state(
+    pub fn get_const_mut_u64_state(
         &mut self,
-        index: ConstParameterIndex<usize>,
+        index: ConstParameterIndex<u64>,
     ) -> Option<&mut Option<Box<dyn ParameterState>>> {
         self.constant.usize.get_mut(*index.deref())
     }
@@ -623,7 +623,7 @@ pub trait ConstParameter<T>: Parameter {
 
 pub enum GeneralParameterType {
     Parameter(GeneralParameterIndex<f64>),
-    Index(GeneralParameterIndex<usize>),
+    Index(GeneralParameterIndex<u64>),
     Multi(GeneralParameterIndex<MultiValue>),
 }
 
@@ -633,8 +633,8 @@ impl From<GeneralParameterIndex<f64>> for GeneralParameterType {
     }
 }
 
-impl From<GeneralParameterIndex<usize>> for GeneralParameterType {
-    fn from(idx: GeneralParameterIndex<usize>) -> Self {
+impl From<GeneralParameterIndex<u64>> for GeneralParameterType {
+    fn from(idx: GeneralParameterIndex<u64>) -> Self {
         Self::Index(idx)
     }
 }
@@ -647,7 +647,7 @@ impl From<GeneralParameterIndex<MultiValue>> for GeneralParameterType {
 
 pub enum SimpleParameterType {
     Parameter(SimpleParameterIndex<f64>),
-    Index(SimpleParameterIndex<usize>),
+    Index(SimpleParameterIndex<u64>),
     Multi(SimpleParameterIndex<MultiValue>),
 }
 
@@ -657,8 +657,8 @@ impl From<SimpleParameterIndex<f64>> for SimpleParameterType {
     }
 }
 
-impl From<SimpleParameterIndex<usize>> for SimpleParameterType {
-    fn from(idx: SimpleParameterIndex<usize>) -> Self {
+impl From<SimpleParameterIndex<u64>> for SimpleParameterType {
+    fn from(idx: SimpleParameterIndex<u64>) -> Self {
         Self::Index(idx)
     }
 }
@@ -671,7 +671,7 @@ impl From<SimpleParameterIndex<MultiValue>> for SimpleParameterType {
 
 pub enum ConstParameterType {
     Parameter(ConstParameterIndex<f64>),
-    Index(ConstParameterIndex<usize>),
+    Index(ConstParameterIndex<u64>),
     Multi(ConstParameterIndex<MultiValue>),
 }
 
@@ -681,8 +681,8 @@ impl From<ConstParameterIndex<f64>> for ConstParameterType {
     }
 }
 
-impl From<ConstParameterIndex<usize>> for ConstParameterType {
-    fn from(idx: ConstParameterIndex<usize>) -> Self {
+impl From<ConstParameterIndex<u64>> for ConstParameterType {
+    fn from(idx: ConstParameterIndex<u64>) -> Self {
         Self::Index(idx)
     }
 }
@@ -695,7 +695,7 @@ impl From<ConstParameterIndex<MultiValue>> for ConstParameterType {
 
 pub enum ParameterType {
     Parameter(ParameterIndex<f64>),
-    Index(ParameterIndex<usize>),
+    Index(ParameterIndex<u64>),
     Multi(ParameterIndex<MultiValue>),
 }
 
@@ -705,8 +705,8 @@ impl From<ParameterIndex<f64>> for ParameterType {
     }
 }
 
-impl From<ParameterIndex<usize>> for ParameterType {
-    fn from(idx: ParameterIndex<usize>) -> Self {
+impl From<ParameterIndex<u64>> for ParameterType {
+    fn from(idx: ParameterIndex<u64>) -> Self {
         Self::Index(idx)
     }
 }
@@ -763,19 +763,19 @@ pub struct ParameterCollectionSize {
 #[derive(Default)]
 pub struct ParameterCollection {
     constant_f64: Vec<Box<dyn ConstParameter<f64>>>,
-    constant_usize: Vec<Box<dyn ConstParameter<usize>>>,
+    constant_usize: Vec<Box<dyn ConstParameter<u64>>>,
     constant_multi: Vec<Box<dyn ConstParameter<MultiValue>>>,
     constant_resolve_order: Vec<ConstParameterType>,
 
     simple_f64: Vec<Box<dyn SimpleParameter<f64>>>,
-    simple_usize: Vec<Box<dyn SimpleParameter<usize>>>,
+    simple_usize: Vec<Box<dyn SimpleParameter<u64>>>,
     simple_multi: Vec<Box<dyn SimpleParameter<MultiValue>>>,
     simple_resolve_order: Vec<SimpleParameterType>,
 
     // There is no resolve order for general parameters as they are resolved at a model
     // level with other component types (e.g. nodes).
     general_f64: Vec<Box<dyn GeneralParameter<f64>>>,
-    general_usize: Vec<Box<dyn GeneralParameter<usize>>>,
+    general_usize: Vec<Box<dyn GeneralParameter<u64>>>,
     general_multi: Vec<Box<dyn GeneralParameter<MultiValue>>>,
 }
 
@@ -993,16 +993,16 @@ impl ParameterCollection {
         }
     }
 
-    pub fn add_general_usize(
+    pub fn add_general_u64(
         &mut self,
-        parameter: Box<dyn GeneralParameter<usize>>,
-    ) -> Result<ParameterIndex<usize>, PywrError> {
+        parameter: Box<dyn GeneralParameter<u64>>,
+    ) -> Result<ParameterIndex<u64>, PywrError> {
         if self.has_name(parameter.name()) {
             return Err(PywrError::ParameterNameAlreadyExists(parameter.meta().name.to_string()));
         }
 
         match parameter.try_into_simple() {
-            Some(simple) => self.add_simple_usize(simple),
+            Some(simple) => self.add_simple_u64(simple),
             None => {
                 let index = GeneralParameterIndex::new(self.general_usize.len());
                 self.general_usize.push(parameter);
@@ -1011,16 +1011,16 @@ impl ParameterCollection {
         }
     }
 
-    pub fn add_simple_usize(
+    pub fn add_simple_u64(
         &mut self,
-        parameter: Box<dyn SimpleParameter<usize>>,
-    ) -> Result<ParameterIndex<usize>, PywrError> {
+        parameter: Box<dyn SimpleParameter<u64>>,
+    ) -> Result<ParameterIndex<u64>, PywrError> {
         if self.has_name(parameter.name()) {
             return Err(PywrError::ParameterNameAlreadyExists(parameter.meta().name.to_string()));
         }
 
         match parameter.try_into_const() {
-            Some(constant) => self.add_const_usize(constant),
+            Some(constant) => self.add_const_u64(constant),
             None => {
                 let index = SimpleParameterIndex::new(self.simple_f64.len());
 
@@ -1032,10 +1032,7 @@ impl ParameterCollection {
         }
     }
 
-    pub fn add_const_usize(
-        &mut self,
-        parameter: Box<dyn ConstParameter<usize>>,
-    ) -> Result<ParameterIndex<usize>, PywrError> {
+    pub fn add_const_u64(&mut self, parameter: Box<dyn ConstParameter<u64>>) -> Result<ParameterIndex<u64>, PywrError> {
         if self.has_name(parameter.name()) {
             return Err(PywrError::ParameterNameAlreadyExists(parameter.meta().name.to_string()));
         }
@@ -1048,7 +1045,7 @@ impl ParameterCollection {
         Ok(index.into())
     }
 
-    pub fn get_usize(&self, index: ParameterIndex<usize>) -> Option<&dyn Parameter> {
+    pub fn get_u64(&self, index: ParameterIndex<u64>) -> Option<&dyn Parameter> {
         match index {
             ParameterIndex::Const(idx) => self.constant_usize.get(*idx.deref()).map(|p| p.as_parameter()),
             ParameterIndex::Simple(idx) => self.simple_usize.get(*idx.deref()).map(|p| p.as_parameter()),
@@ -1056,7 +1053,7 @@ impl ParameterCollection {
         }
     }
 
-    pub fn get_general_usize(&self, index: GeneralParameterIndex<usize>) -> Option<&dyn GeneralParameter<usize>> {
+    pub fn get_general_usize(&self, index: GeneralParameterIndex<u64>) -> Option<&dyn GeneralParameter<u64>> {
         self.general_usize.get(*index.deref()).map(|p| p.as_ref())
     }
 
@@ -1067,7 +1064,7 @@ impl ParameterCollection {
             .map(|p| p.as_parameter())
     }
 
-    pub fn get_usize_index_by_name(&self, name: &ParameterName) -> Option<ParameterIndex<usize>> {
+    pub fn get_usize_index_by_name(&self, name: &ParameterName) -> Option<ParameterIndex<u64>> {
         if let Some(idx) = self
             .general_usize
             .iter()
@@ -1222,7 +1219,7 @@ impl ParameterCollection {
                         .ok_or(PywrError::SimpleIndexParameterIndexNotFound(*idx))?;
                     // .. and its internal state
                     let internal_state = internal_states
-                        .get_simple_mut_usize_state(*idx)
+                        .get_simple_mut_u64_state(*idx)
                         .ok_or(PywrError::SimpleIndexParameterIndexNotFound(*idx))?;
 
                     let value = p.compute(
@@ -1294,7 +1291,7 @@ impl ParameterCollection {
                         .ok_or(PywrError::SimpleIndexParameterIndexNotFound(*idx))?;
                     // .. and its internal state
                     let internal_state = internal_states
-                        .get_simple_mut_usize_state(*idx)
+                        .get_simple_mut_u64_state(*idx)
                         .ok_or(PywrError::SimpleIndexParameterIndexNotFound(*idx))?;
 
                     p.after(
@@ -1359,7 +1356,7 @@ impl ParameterCollection {
                         .ok_or(PywrError::ConstIndexParameterIndexNotFound(*idx))?;
                     // .. and its internal state
                     let internal_state = internal_states
-                        .get_const_mut_usize_state(*idx)
+                        .get_const_mut_u64_state(*idx)
                         .ok_or(PywrError::ConstIndexParameterIndexNotFound(*idx))?;
 
                     let value = p.compute(scenario_index, &state.get_const_parameter_values(), internal_state)?;
@@ -1548,13 +1545,13 @@ mod tests {
         let ret = collection.add_general_f64(Box::new(TestParameter::default()));
         assert!(ret.is_err());
 
-        let ret = collection.add_const_usize(Box::new(TestParameter::default()));
+        let ret = collection.add_const_u64(Box::new(TestParameter::default()));
         assert!(ret.is_err());
 
-        let ret = collection.add_simple_usize(Box::new(TestParameter::default()));
+        let ret = collection.add_simple_u64(Box::new(TestParameter::default()));
         assert!(ret.is_err());
 
-        let ret = collection.add_general_usize(Box::new(TestParameter::default()));
+        let ret = collection.add_general_u64(Box::new(TestParameter::default()));
         assert!(ret.is_err());
 
         let ret = collection.add_const_multi(Box::new(TestParameter::default()));

--- a/pywr-core/src/parameters/mod.rs
+++ b/pywr-core/src/parameters/mod.rs
@@ -332,7 +332,7 @@ where
 
 struct ParameterStatesByType {
     f64: Vec<Option<Box<dyn ParameterState>>>,
-    usize: Vec<Option<Box<dyn ParameterState>>>,
+    u64: Vec<Option<Box<dyn ParameterState>>>,
     multi: Vec<Option<Box<dyn ParameterState>>>,
 }
 
@@ -409,20 +409,20 @@ impl ParameterStates {
         &mut self,
         index: GeneralParameterIndex<u64>,
     ) -> Option<&mut Option<Box<dyn ParameterState>>> {
-        self.general.usize.get_mut(*index.deref())
+        self.general.u64.get_mut(*index.deref())
     }
 
     pub fn get_simple_mut_u64_state(
         &mut self,
         index: SimpleParameterIndex<u64>,
     ) -> Option<&mut Option<Box<dyn ParameterState>>> {
-        self.simple.usize.get_mut(*index.deref())
+        self.simple.u64.get_mut(*index.deref())
     }
     pub fn get_const_mut_u64_state(
         &mut self,
         index: ConstParameterIndex<u64>,
     ) -> Option<&mut Option<Box<dyn ParameterState>>> {
-        self.constant.usize.get_mut(*index.deref())
+        self.constant.u64.get_mut(*index.deref())
     }
 
     pub fn get_general_mut_multi_state(
@@ -763,19 +763,19 @@ pub struct ParameterCollectionSize {
 #[derive(Default)]
 pub struct ParameterCollection {
     constant_f64: Vec<Box<dyn ConstParameter<f64>>>,
-    constant_usize: Vec<Box<dyn ConstParameter<u64>>>,
+    constant_u64: Vec<Box<dyn ConstParameter<u64>>>,
     constant_multi: Vec<Box<dyn ConstParameter<MultiValue>>>,
     constant_resolve_order: Vec<ConstParameterType>,
 
     simple_f64: Vec<Box<dyn SimpleParameter<f64>>>,
-    simple_usize: Vec<Box<dyn SimpleParameter<u64>>>,
+    simple_u64: Vec<Box<dyn SimpleParameter<u64>>>,
     simple_multi: Vec<Box<dyn SimpleParameter<MultiValue>>>,
     simple_resolve_order: Vec<SimpleParameterType>,
 
     // There is no resolve order for general parameters as they are resolved at a model
     // level with other component types (e.g. nodes).
     general_f64: Vec<Box<dyn GeneralParameter<f64>>>,
-    general_usize: Vec<Box<dyn GeneralParameter<u64>>>,
+    general_u64: Vec<Box<dyn GeneralParameter<u64>>>,
     general_multi: Vec<Box<dyn GeneralParameter<MultiValue>>>,
 }
 
@@ -783,13 +783,13 @@ impl ParameterCollection {
     pub fn size(&self) -> ParameterCollectionSize {
         ParameterCollectionSize {
             const_f64: self.constant_f64.len(),
-            const_usize: self.constant_usize.len(),
+            const_usize: self.constant_u64.len(),
             const_multi: self.constant_multi.len(),
             simple_f64: self.simple_f64.len(),
-            simple_usize: self.simple_usize.len(),
+            simple_usize: self.simple_u64.len(),
             simple_multi: self.simple_multi.len(),
             general_f64: self.general_f64.len(),
-            general_usize: self.general_usize.len(),
+            general_usize: self.general_u64.len(),
             general_multi: self.general_multi.len(),
         }
     }
@@ -806,7 +806,7 @@ impl ParameterCollection {
             .collect::<Result<Vec<_>, _>>()?;
 
         let usize_states = self
-            .general_usize
+            .general_u64
             .iter()
             .map(|p| p.setup(timesteps, scenario_index))
             .collect::<Result<Vec<_>, _>>()?;
@@ -819,7 +819,7 @@ impl ParameterCollection {
 
         Ok(ParameterStatesByType {
             f64: f64_states,
-            usize: usize_states,
+            u64: usize_states,
             multi: multi_states,
         })
     }
@@ -837,7 +837,7 @@ impl ParameterCollection {
             .collect::<Result<Vec<_>, _>>()?;
 
         let usize_states = self
-            .simple_usize
+            .simple_u64
             .iter()
             .map(|p| p.setup(timesteps, scenario_index))
             .collect::<Result<Vec<_>, _>>()?;
@@ -850,7 +850,7 @@ impl ParameterCollection {
 
         Ok(ParameterStatesByType {
             f64: f64_states,
-            usize: usize_states,
+            u64: usize_states,
             multi: multi_states,
         })
     }
@@ -868,7 +868,7 @@ impl ParameterCollection {
             .collect::<Result<Vec<_>, _>>()?;
 
         let usize_states = self
-            .constant_usize
+            .constant_u64
             .iter()
             .map(|p| p.setup(timesteps, scenario_index))
             .collect::<Result<Vec<_>, _>>()?;
@@ -881,7 +881,7 @@ impl ParameterCollection {
 
         Ok(ParameterStatesByType {
             f64: f64_states,
-            usize: usize_states,
+            u64: usize_states,
             multi: multi_states,
         })
     }
@@ -889,7 +889,7 @@ impl ParameterCollection {
     /// Does a parameter with the given name exist in the collection.
     pub fn has_name(&self, name: &ParameterName) -> bool {
         self.get_f64_index_by_name(name).is_some()
-            || self.get_usize_index_by_name(name).is_some()
+            || self.get_u64_index_by_name(name).is_some()
             || self.get_multi_index_by_name(name).is_some()
     }
 
@@ -1004,8 +1004,8 @@ impl ParameterCollection {
         match parameter.try_into_simple() {
             Some(simple) => self.add_simple_u64(simple),
             None => {
-                let index = GeneralParameterIndex::new(self.general_usize.len());
-                self.general_usize.push(parameter);
+                let index = GeneralParameterIndex::new(self.general_u64.len());
+                self.general_u64.push(parameter);
                 Ok(index.into())
             }
         }
@@ -1024,7 +1024,7 @@ impl ParameterCollection {
             None => {
                 let index = SimpleParameterIndex::new(self.simple_f64.len());
 
-                self.simple_usize.push(parameter);
+                self.simple_u64.push(parameter);
                 self.simple_resolve_order.push(SimpleParameterType::Index(index));
 
                 Ok(index.into())
@@ -1037,9 +1037,9 @@ impl ParameterCollection {
             return Err(PywrError::ParameterNameAlreadyExists(parameter.meta().name.to_string()));
         }
 
-        let index = ConstParameterIndex::new(self.constant_usize.len());
+        let index = ConstParameterIndex::new(self.constant_u64.len());
 
-        self.constant_usize.push(parameter);
+        self.constant_u64.push(parameter);
         self.constant_resolve_order.push(ConstParameterType::Index(index));
 
         Ok(index.into())
@@ -1047,40 +1047,40 @@ impl ParameterCollection {
 
     pub fn get_u64(&self, index: ParameterIndex<u64>) -> Option<&dyn Parameter> {
         match index {
-            ParameterIndex::Const(idx) => self.constant_usize.get(*idx.deref()).map(|p| p.as_parameter()),
-            ParameterIndex::Simple(idx) => self.simple_usize.get(*idx.deref()).map(|p| p.as_parameter()),
-            ParameterIndex::General(idx) => self.general_usize.get(*idx.deref()).map(|p| p.as_parameter()),
+            ParameterIndex::Const(idx) => self.constant_u64.get(*idx.deref()).map(|p| p.as_parameter()),
+            ParameterIndex::Simple(idx) => self.simple_u64.get(*idx.deref()).map(|p| p.as_parameter()),
+            ParameterIndex::General(idx) => self.general_u64.get(*idx.deref()).map(|p| p.as_parameter()),
         }
     }
 
-    pub fn get_general_usize(&self, index: GeneralParameterIndex<u64>) -> Option<&dyn GeneralParameter<u64>> {
-        self.general_usize.get(*index.deref()).map(|p| p.as_ref())
+    pub fn get_general_u64(&self, index: GeneralParameterIndex<u64>) -> Option<&dyn GeneralParameter<u64>> {
+        self.general_u64.get(*index.deref()).map(|p| p.as_ref())
     }
 
-    pub fn get_usize_by_name(&self, name: &ParameterName) -> Option<&dyn Parameter> {
-        self.general_usize
+    pub fn get_u64_by_name(&self, name: &ParameterName) -> Option<&dyn Parameter> {
+        self.general_u64
             .iter()
             .find(|p| p.name() == name)
             .map(|p| p.as_parameter())
     }
 
-    pub fn get_usize_index_by_name(&self, name: &ParameterName) -> Option<ParameterIndex<u64>> {
+    pub fn get_u64_index_by_name(&self, name: &ParameterName) -> Option<ParameterIndex<u64>> {
         if let Some(idx) = self
-            .general_usize
+            .general_u64
             .iter()
             .position(|p| p.name() == name)
             .map(GeneralParameterIndex::new)
         {
             Some(idx.into())
         } else if let Some(idx) = self
-            .simple_usize
+            .simple_u64
             .iter()
             .position(|p| p.name() == name)
             .map(SimpleParameterIndex::new)
         {
             Some(idx.into())
         } else {
-            self.constant_usize
+            self.constant_u64
                 .iter()
                 .position(|p| p.name() == name)
                 .map(ConstParameterIndex::new)
@@ -1214,7 +1214,7 @@ impl ParameterCollection {
                 SimpleParameterType::Index(idx) => {
                     // Find the parameter itself
                     let p = self
-                        .simple_usize
+                        .simple_u64
                         .get(*idx.deref())
                         .ok_or(PywrError::SimpleIndexParameterIndexNotFound(*idx))?;
                     // .. and its internal state
@@ -1286,7 +1286,7 @@ impl ParameterCollection {
                 SimpleParameterType::Index(idx) => {
                     // Find the parameter itself
                     let p = self
-                        .simple_usize
+                        .simple_u64
                         .get(*idx.deref())
                         .ok_or(PywrError::SimpleIndexParameterIndexNotFound(*idx))?;
                     // .. and its internal state
@@ -1351,7 +1351,7 @@ impl ParameterCollection {
                 ConstParameterType::Index(idx) => {
                     // Find the parameter itself
                     let p = self
-                        .constant_usize
+                        .constant_u64
                         .get(*idx.deref())
                         .ok_or(PywrError::ConstIndexParameterIndexNotFound(*idx))?;
                     // .. and its internal state

--- a/pywr-core/src/parameters/rhai.rs
+++ b/pywr-core/src/parameters/rhai.rs
@@ -1,5 +1,5 @@
 use super::{GeneralParameter, Parameter, ParameterMeta, ParameterName, ParameterState, PywrError, Timestep};
-use crate::metric::{MetricF64, MetricUsize};
+use crate::metric::{MetricF64, MetricU64};
 use crate::network::Network;
 use crate::parameters::downcast_internal_state_mut;
 use crate::scenario::ScenarioIndex;
@@ -14,7 +14,7 @@ pub struct RhaiParameter {
     ast: AST,
     initial_state: Map,
     metrics: HashMap<String, MetricF64>,
-    indices: HashMap<String, MetricUsize>,
+    indices: HashMap<String, MetricU64>,
 }
 
 #[derive(Clone)]
@@ -28,7 +28,7 @@ impl RhaiParameter {
         script: &str,
         initial_state: Map,
         metrics: &HashMap<String, MetricF64>,
-        indices: &HashMap<String, MetricUsize>,
+        indices: &HashMap<String, MetricU64>,
     ) -> Self {
         let mut engine = Engine::new();
 

--- a/pywr-core/src/parameters/threshold.rs
+++ b/pywr-core/src/parameters/threshold.rs
@@ -74,7 +74,7 @@ impl Parameter for ThresholdParameter {
     }
 }
 
-impl GeneralParameter<usize> for ThresholdParameter {
+impl GeneralParameter<u64> for ThresholdParameter {
     fn compute(
         &self,
         _timestep: &Timestep,
@@ -82,7 +82,7 @@ impl GeneralParameter<usize> for ThresholdParameter {
         model: &Network,
         state: &State,
         internal_state: &mut Option<Box<dyn ParameterState>>,
-    ) -> Result<usize, PywrError> {
+    ) -> Result<u64, PywrError> {
         // Downcast the internal state to the correct type
         let previously_activated = downcast_internal_state_mut::<bool>(internal_state);
 

--- a/pywr-core/src/recorders/mod.rs
+++ b/pywr-core/src/recorders/mod.rs
@@ -5,7 +5,7 @@ mod memory;
 mod metric_set;
 mod py;
 
-use crate::metric::{MetricF64, MetricUsize};
+use crate::metric::{MetricF64, MetricU64};
 use crate::models::ModelDomain;
 use crate::network::Network;
 use crate::scenario::ScenarioIndex;
@@ -292,12 +292,12 @@ where
 
 pub struct IndexAssertionRecorder {
     meta: RecorderMeta,
-    expected_values: Array2<usize>,
-    metric: MetricUsize,
+    expected_values: Array2<u64>,
+    metric: MetricU64,
 }
 
 impl IndexAssertionRecorder {
-    pub fn new(name: &str, metric: MetricUsize, expected_values: Array2<usize>) -> Self {
+    pub fn new(name: &str, metric: MetricU64, expected_values: Array2<u64>) -> Self {
         Self {
             meta: RecorderMeta::new(name),
             expected_values,

--- a/pywr-core/src/state.rs
+++ b/pywr-core/src/state.rs
@@ -263,11 +263,11 @@ impl EdgeState {
 #[derive(Debug, Default, Clone, PartialEq)]
 pub struct MultiValue {
     values: HashMap<String, f64>,
-    indices: HashMap<String, usize>,
+    indices: HashMap<String, u64>,
 }
 
 impl MultiValue {
-    pub fn new(values: HashMap<String, f64>, indices: HashMap<String, usize>) -> Self {
+    pub fn new(values: HashMap<String, f64>, indices: HashMap<String, u64>) -> Self {
         Self { values, indices }
     }
 
@@ -275,7 +275,7 @@ impl MultiValue {
         self.values.get(key)
     }
 
-    pub fn get_index(&self, key: &str) -> Option<&usize> {
+    pub fn get_index(&self, key: &str) -> Option<&u64> {
         self.indices.get(key)
     }
 }
@@ -292,7 +292,7 @@ pub enum ParameterValuesError {
 #[derive(Debug, Clone)]
 struct ParameterValues {
     values: Vec<f64>,
-    indices: Vec<usize>,
+    indices: Vec<u64>,
     multi_values: Vec<MultiValue>,
 }
 
@@ -322,14 +322,14 @@ impl ParameterValues {
         }
     }
 
-    fn get_index(&self, idx: usize) -> Result<usize, ParameterValuesError> {
+    fn get_index(&self, idx: usize) -> Result<u64, ParameterValuesError> {
         self.indices
             .get(idx)
             .ok_or(ParameterValuesError::IndexNotFound(idx))
             .copied()
     }
 
-    fn set_index(&mut self, idx: usize, value: usize) -> Result<(), ParameterValuesError> {
+    fn set_index(&mut self, idx: usize, value: u64) -> Result<(), ParameterValuesError> {
         match self.indices.get_mut(idx) {
             Some(s) => {
                 *s = value;
@@ -361,7 +361,7 @@ impl ParameterValues {
         }
     }
 
-    fn get_multi_index(&self, idx: usize, key: &str) -> Result<usize, ParameterValuesError> {
+    fn get_multi_index(&self, idx: usize, key: &str) -> Result<u64, ParameterValuesError> {
         let value = self
             .multi_values
             .get(idx)
@@ -412,7 +412,7 @@ impl ParameterValuesCollection {
 
 pub struct ParameterValuesRef<'a> {
     values: &'a [f64],
-    indices: &'a [usize],
+    indices: &'a [u64],
     multi_values: &'a [MultiValue],
 }
 
@@ -421,7 +421,7 @@ impl ParameterValuesRef<'_> {
         self.values.get(idx)
     }
 
-    fn get_index(&self, idx: usize) -> Option<&usize> {
+    fn get_index(&self, idx: usize) -> Option<&u64> {
         self.indices.get(idx)
     }
 
@@ -429,7 +429,7 @@ impl ParameterValuesRef<'_> {
         self.multi_values.get(idx).and_then(|s| s.get_value(key))
     }
 
-    fn get_multi_index(&self, idx: usize, key: &str) -> Option<&usize> {
+    fn get_multi_index(&self, idx: usize, key: &str) -> Option<&u64> {
         self.multi_values.get(idx).and_then(|s| s.get_index(key))
     }
 }
@@ -447,7 +447,7 @@ impl SimpleParameterValues<'_> {
             .copied()
     }
 
-    pub fn get_simple_parameter_usize(&self, idx: SimpleParameterIndex<usize>) -> Result<usize, PywrError> {
+    pub fn get_simple_parameter_u64(&self, idx: SimpleParameterIndex<u64>) -> Result<u64, PywrError> {
         self.simple
             .get_index(*idx.deref())
             .ok_or(PywrError::SimpleIndexParameterIndexNotFound(idx))
@@ -465,11 +465,11 @@ impl SimpleParameterValues<'_> {
             .copied()
     }
 
-    pub fn get_simple_multi_parameter_usize(
+    pub fn get_simple_multi_parameter_u64(
         &self,
         idx: SimpleParameterIndex<MultiValue>,
         key: &str,
-    ) -> Result<usize, PywrError> {
+    ) -> Result<u64, PywrError> {
         self.simple
             .get_multi_index(*idx.deref(), key)
             .ok_or(PywrError::SimpleMultiValueParameterIndexNotFound(idx))
@@ -493,7 +493,7 @@ impl ConstParameterValues<'_> {
             .copied()
     }
 
-    pub fn get_const_parameter_usize(&self, idx: ConstParameterIndex<usize>) -> Result<usize, PywrError> {
+    pub fn get_const_parameter_u64(&self, idx: ConstParameterIndex<u64>) -> Result<u64, PywrError> {
         self.constant
             .get_index(*idx.deref())
             .ok_or(PywrError::ConstIndexParameterIndexNotFound(idx))
@@ -511,11 +511,11 @@ impl ConstParameterValues<'_> {
             .copied()
     }
 
-    pub fn get_const_multi_parameter_usize(
+    pub fn get_const_multi_parameter_u64(
         &self,
         idx: ConstParameterIndex<MultiValue>,
         key: &str,
-    ) -> Result<usize, PywrError> {
+    ) -> Result<u64, PywrError> {
         self.constant
             .get_multi_index(*idx.deref(), key)
             .ok_or(PywrError::ConstMultiValueParameterIndexNotFound(idx))
@@ -819,36 +819,28 @@ impl State {
         })
     }
 
-    pub fn get_parameter_index(&self, idx: GeneralParameterIndex<usize>) -> Result<usize, PywrError> {
+    pub fn get_parameter_index(&self, idx: GeneralParameterIndex<u64>) -> Result<u64, PywrError> {
         self.parameters.general.get_index(*idx).map_err(|e| match e {
             ParameterValuesError::IndexNotFound(_) => PywrError::GeneralIndexParameterIndexNotFound(idx),
             ParameterValuesError::KeyNotFound(key) => PywrError::MultiValueParameterKeyNotFound(key),
         })
     }
 
-    pub fn set_parameter_index(&mut self, idx: GeneralParameterIndex<usize>, value: usize) -> Result<(), PywrError> {
+    pub fn set_parameter_index(&mut self, idx: GeneralParameterIndex<u64>, value: u64) -> Result<(), PywrError> {
         self.parameters.general.set_index(*idx, value).map_err(|e| match e {
             ParameterValuesError::IndexNotFound(_) => PywrError::GeneralIndexParameterIndexNotFound(idx),
             ParameterValuesError::KeyNotFound(key) => PywrError::MultiValueParameterKeyNotFound(key),
         })
     }
 
-    pub fn set_simple_parameter_index(
-        &mut self,
-        idx: SimpleParameterIndex<usize>,
-        value: usize,
-    ) -> Result<(), PywrError> {
+    pub fn set_simple_parameter_index(&mut self, idx: SimpleParameterIndex<u64>, value: u64) -> Result<(), PywrError> {
         self.parameters.simple.set_index(*idx, value).map_err(|e| match e {
             ParameterValuesError::IndexNotFound(_) => PywrError::SimpleIndexParameterIndexNotFound(idx),
             ParameterValuesError::KeyNotFound(key) => PywrError::MultiValueParameterKeyNotFound(key),
         })
     }
 
-    pub fn set_const_parameter_index(
-        &mut self,
-        idx: ConstParameterIndex<usize>,
-        value: usize,
-    ) -> Result<(), PywrError> {
+    pub fn set_const_parameter_index(&mut self, idx: ConstParameterIndex<u64>, value: u64) -> Result<(), PywrError> {
         self.parameters.constant.set_index(*idx, value).map_err(|e| match e {
             ParameterValuesError::IndexNotFound(_) => PywrError::ConstIndexParameterIndexNotFound(idx),
             ParameterValuesError::KeyNotFound(key) => PywrError::MultiValueParameterKeyNotFound(key),
@@ -911,7 +903,7 @@ impl State {
         &self,
         idx: GeneralParameterIndex<MultiValue>,
         key: &str,
-    ) -> Result<usize, PywrError> {
+    ) -> Result<u64, PywrError> {
         self.parameters.general.get_multi_index(*idx, key).map_err(|e| match e {
             ParameterValuesError::IndexNotFound(_) => PywrError::GeneralMultiValueParameterIndexNotFound(idx),
             ParameterValuesError::KeyNotFound(key) => PywrError::MultiValueParameterKeyNotFound(key),

--- a/pywr-schema/src/data_tables/mod.rs
+++ b/pywr-schema/src/data_tables/mod.rs
@@ -241,7 +241,7 @@ impl LoadedTableCollection {
     }
 
     /// Return a single scalar value from a table collection.
-    pub fn get_scalar_usize(&self, _table_ref: &TableDataRef) -> Result<usize, TableError> {
+    pub fn get_scalar_u64(&self, _table_ref: &TableDataRef) -> Result<u64, TableError> {
         // let tbl = self.get_table(&table_ref.table)?;
         todo!()
     }

--- a/pywr-schema/src/metric.rs
+++ b/pywr-schema/src/metric.rs
@@ -272,7 +272,7 @@ impl NodeReference {
 
     /// Load a node reference into a [`MetricUsize`].
     #[cfg(feature = "core")]
-    pub fn load_usize(
+    pub fn load_u64(
         &self,
         _network: &mut pywr_core::network::Network,
         args: &LoadArgs,
@@ -414,7 +414,7 @@ impl ParameterReference {
     /// from the `network`. If `parent` is the optional parameter name space from which to load
     /// the parameter.
     #[cfg(feature = "core")]
-    pub fn load_usize(
+    pub fn load_u64(
         &self,
         network: &mut pywr_core::network::Network,
         parent: Option<&str>,
@@ -506,9 +506,9 @@ impl IndexMetric {
         parent: Option<&str>,
     ) -> Result<MetricU64, SchemaError> {
         match self {
-            Self::Node(node_ref) => node_ref.load_usize(network, args),
+            Self::Node(node_ref) => node_ref.load_u64(network, args),
             // Global parameter with no parent
-            Self::Parameter(parameter_ref) => parameter_ref.load_usize(network, None),
+            Self::Parameter(parameter_ref) => parameter_ref.load_u64(network, None),
             // Local parameter loaded from parent's namespace
             Self::LocalParameter(parameter_ref) => {
                 if parent.is_none() {
@@ -517,7 +517,7 @@ impl IndexMetric {
                     ));
                 }
 
-                parameter_ref.load_usize(network, parent)
+                parameter_ref.load_u64(network, parent)
             }
             Self::Constant { value } => Ok((*value).into()),
             Self::Table(table_ref) => {

--- a/pywr-schema/src/nodes/core.rs
+++ b/pywr-schema/src/nodes/core.rs
@@ -1009,8 +1009,8 @@ pub enum Relationship {
         factors: Vec<Metric>,
     },
     Exclusive {
-        min_active: Option<usize>,
-        max_active: Option<usize>,
+        min_active: Option<u64>,
+        max_active: Option<u64>,
     },
 }
 

--- a/pywr-schema/src/nodes/delay.rs
+++ b/pywr-schema/src/nodes/delay.rs
@@ -36,7 +36,7 @@ pub struct DelayNode {
     pub meta: NodeMeta,
     /// Optional local parameters.
     pub parameters: Option<Vec<Parameter>>,
-    pub delay: usize,
+    pub delay: u64,
     pub initial_value: ConstantValue<f64>,
 }
 
@@ -154,7 +154,7 @@ impl TryFrom<DelayNodeV1> for DelayNode {
                     })
                 }
             },
-        } as usize;
+        } as u64;
 
         let initial_value = ConstantValue::Literal(v1.initial_flow.unwrap_or_default());
 

--- a/pywr-schema/src/parameters/aggregated.rs
+++ b/pywr-schema/src/parameters/aggregated.rs
@@ -197,7 +197,7 @@ impl AggregatedIndexParameter {
         &self,
         network: &mut pywr_core::network::Network,
         args: &LoadArgs,
-    ) -> Result<ParameterIndex<usize>, SchemaError> {
+    ) -> Result<ParameterIndex<u64>, SchemaError> {
         let parameters = self
             .parameters
             .iter()

--- a/pywr-schema/src/parameters/asymmetric_switch.rs
+++ b/pywr-schema/src/parameters/asymmetric_switch.rs
@@ -26,7 +26,7 @@ impl AsymmetricSwitchIndexParameter {
         &self,
         network: &mut pywr_core::network::Network,
         args: &LoadArgs,
-    ) -> Result<ParameterIndex<usize>, SchemaError> {
+    ) -> Result<ParameterIndex<u64>, SchemaError> {
         let on_index_parameter = self.on_index_parameter.load(network, args, None)?;
         let off_index_parameter = self.off_index_parameter.load(network, args, None)?;
 

--- a/pywr-schema/src/parameters/control_curves.rs
+++ b/pywr-schema/src/parameters/control_curves.rs
@@ -133,7 +133,7 @@ impl ControlCurveIndexParameter {
         &self,
         network: &mut pywr_core::network::Network,
         args: &LoadArgs,
-    ) -> Result<ParameterIndex<usize>, SchemaError> {
+    ) -> Result<ParameterIndex<u64>, SchemaError> {
         let metric = self.storage_node.load_f64(network, args)?;
 
         let control_curves = self

--- a/pywr-schema/src/parameters/delay.rs
+++ b/pywr-schema/src/parameters/delay.rs
@@ -15,7 +15,7 @@ use schemars::JsonSchema;
 pub struct DelayParameter {
     pub meta: ParameterMeta,
     pub metric: Metric,
-    pub delay: usize,
+    pub delay: u64,
     pub initial_value: f64,
 }
 

--- a/pywr-schema/src/parameters/mod.rs
+++ b/pywr-schema/src/parameters/mod.rs
@@ -593,13 +593,13 @@ impl ConstantValue<f64> {
 }
 
 #[cfg(feature = "core")]
-impl ConstantValue<usize> {
+impl ConstantValue<u64> {
     /// Return the value loading from a table if required.
-    pub fn load(&self, tables: &LoadedTableCollection) -> Result<usize, SchemaError> {
+    pub fn load(&self, tables: &LoadedTableCollection) -> Result<u64, SchemaError> {
         match self {
             Self::Literal(v) => Ok(*v),
             Self::Table(tbl_ref) => tables
-                .get_scalar_usize(tbl_ref)
+                .get_scalar_u64(tbl_ref)
                 .map_err(|error| SchemaError::TableRefLoad {
                     table_ref: tbl_ref.clone(),
                     error,

--- a/pywr-schema/src/parameters/profiles.rs
+++ b/pywr-schema/src/parameters/profiles.rs
@@ -132,9 +132,9 @@ impl TryFromV1<MonthlyProfileParameterV1> for MonthlyProfileParameter {
 #[serde(deny_unknown_fields)]
 pub struct UniformDrawdownProfileParameter {
     pub meta: ParameterMeta,
-    pub reset_day: Option<ConstantValue<usize>>,
-    pub reset_month: Option<ConstantValue<usize>>,
-    pub residual_days: Option<ConstantValue<usize>>,
+    pub reset_day: Option<ConstantValue<u64>>,
+    pub reset_month: Option<ConstantValue<u64>>,
+    pub residual_days: Option<ConstantValue<u64>>,
 }
 
 #[cfg(feature = "core")]
@@ -177,9 +177,9 @@ impl FromV1<UniformDrawdownProfileParameterV1> for UniformDrawdownProfileParamet
 
         Self {
             meta,
-            reset_day: v1.reset_day.map(|v| ConstantValue::Literal(v as usize)),
-            reset_month: v1.reset_day.map(|v| ConstantValue::Literal(v as usize)),
-            residual_days: v1.reset_day.map(|v| ConstantValue::Literal(v as usize)),
+            reset_day: v1.reset_day.map(|v| ConstantValue::Literal(v as u64)),
+            reset_month: v1.reset_day.map(|v| ConstantValue::Literal(v as u64)),
+            residual_days: v1.reset_day.map(|v| ConstantValue::Literal(v as u64)),
         }
     }
 }

--- a/pywr-schema/src/parameters/thresholds.rs
+++ b/pywr-schema/src/parameters/thresholds.rs
@@ -71,7 +71,7 @@ impl ThresholdParameter {
         &self,
         network: &mut pywr_core::network::Network,
         args: &LoadArgs,
-    ) -> Result<ParameterIndex<usize>, SchemaError> {
+    ) -> Result<ParameterIndex<u64>, SchemaError> {
         let metric = self.value.load(network, args, None)?;
         let threshold = self.threshold.load(network, args, None)?;
 

--- a/pywr-schema/src/timeseries/mod.rs
+++ b/pywr-schema/src/timeseries/mod.rs
@@ -166,7 +166,7 @@ impl LoadedTimeseriesCollection {
         network: &mut pywr_core::network::Network,
         name: &str,
         col: &str,
-    ) -> Result<ParameterIndex<usize>, TimeseriesError> {
+    ) -> Result<ParameterIndex<u64>, TimeseriesError> {
         let df = self
             .timeseries
             .get(name)
@@ -230,7 +230,7 @@ impl LoadedTimeseriesCollection {
         &self,
         network: &mut pywr_core::network::Network,
         name: &str,
-    ) -> Result<ParameterIndex<usize>, TimeseriesError> {
+    ) -> Result<ParameterIndex<u64>, TimeseriesError> {
         let df = self
             .timeseries
             .get(name)
@@ -304,7 +304,7 @@ impl LoadedTimeseriesCollection {
         name: &str,
         domain: &ModelDomain,
         scenario: &str,
-    ) -> Result<ParameterIndex<usize>, TimeseriesError> {
+    ) -> Result<ParameterIndex<u64>, TimeseriesError> {
         let scenario_group_index = domain
             .scenarios()
             .group_index(scenario)

--- a/pywr-schema/src/visit.rs
+++ b/pywr-schema/src/visit.rs
@@ -112,7 +112,7 @@ impl VisitMetrics for f32 {}
 impl VisitMetrics for f64 {}
 impl<const N: usize> VisitMetrics for [f64; N] {}
 impl VisitMetrics for bool {}
-impl VisitMetrics for usize {}
+impl VisitMetrics for u64 {}
 impl VisitMetrics for String {}
 impl VisitMetrics for PathBuf {}
 impl VisitMetrics for NonZeroUsize {}
@@ -214,7 +214,7 @@ impl VisitPaths for f32 {}
 impl VisitPaths for f64 {}
 impl<const N: usize> VisitPaths for [f64; N] {}
 impl VisitPaths for bool {}
-impl VisitPaths for usize {}
+impl VisitPaths for u64 {}
 impl VisitPaths for String {}
 impl VisitPaths for PathBuf {
     fn visit_paths<F: FnMut(&Path)>(&self, visitor: &mut F) {


### PR DESCRIPTION
U64 is more appropriate for data that should be the same across multiple platforms. `usize` is platform specific.

This does not change the use of `NonZeroUsize` for the rolling window size in virtual storage nodes. Ultimately this values is used to size an array and that maximum size will be platform dependent.

Currently there is some casting to `usize`. A separate update could warn on the `cast_lossless` lint and remove the use of `as` throughout.

One outstanding query is whether this should actually be i64 to support negative values?

Issue #291.