### PR TITLE
feat: Add pyo3 feature for Python support.

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -30,7 +30,13 @@ jobs:
           mkdir bin
           curl -sSL $url | tar -xz --directory=bin
           echo "$(pwd)/bin" >> $GITHUB_PATH
-
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-hack@0.5
+      - name: Check (pywr-core)
+        run: cargo hack check --feature-powerset --no-dev-deps -p pywr-core --exclude-features ipm-simd,ipm-ocl
+      - name: Check (pywr-schema)
+        run: cargo hack check --feature-powerset --no-dev-deps -p pywr-schema --exclude-features ipm-simd,ipm-ocl
       - name: Build
         run: cargo build --verbose --features highs,cbc --workspace --exclude ipm-simd --exclude pywr-python
       - name: Run tests
@@ -46,17 +52,3 @@ jobs:
           if echo "$output" | grep -q "\[ERROR\]" ; then
               exit 1
           fi
-
-  build_schema_only:
-
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: true
-      - uses: swatinem/rust-cache@v2
-      - name: Build
-        run: cargo build --verbose --no-default-features --package pywr-schema@2.0.0-dev
-      - name: Run tests
-        run: cargo test --verbose --no-default-features --package pywr-schema@2.0.0-dev

--- a/README.md
+++ b/README.md
@@ -204,9 +204,11 @@ Feature flags:
 
 | Feature    | Description                                      | Default |
 |------------|--------------------------------------------------|---------|
+| `pyo3`     | Enable the Python bindings.                      | True    |
 | `highs`    | Enable the HiGHS LP solver.                      | False   |
 | `ipm-ocl`  | Enable the OpenCL IPM solver (requires nightly). | False   |
 | `ipm-simd` | Enable the AVX IPM solver (requires nightly).    | False   |
+| `cbc`      | Enable the CBC MILP solver.                      | False   |
 
 ### Pywr-schema
 
@@ -215,9 +217,14 @@ using `pywr-core`.
 
 Feature flags:
 
-| Feature | Description                                                                                                                                                                                                                                          | Default |
-|---------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|
-| `core`  | Enable building models from the schema with `pywr-core`. This feature is enabled by default, but requires a lot of dependencies. If you only require schema validation and manipulation consider building this crate with `default-features = false` | True    |
+| Feature    | Description                                                                                                                                                                                                                                          | Default |
+|------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|
+| `core`     | Enable building models from the schema with `pywr-core`. This feature is enabled by default, but requires a lot of dependencies. If you only require schema validation and manipulation consider building this crate with `default-features = false` | True    |
+| `pyo3`     | Enable the Python bindings.                                                                                                                                                                                                                          | True    |
+| `highs`    | Enable the HiGHS LP solver.                                                                                                                                                                                                                          | False   |
+| `ipm-ocl`  | Enable the OpenCL IPM solver (requires nightly).                                                                                                                                                                                                     | False   |
+| `ipm-simd` | Enable the AVX IPM solver (requires nightly).                                                                                                                                                                                                        | False   |
+| `cbc`      | Enable the CBC MILP solver.                                                                                                                                                                                                                          | False   |
 
 ### Pywr-cli
 

--- a/pywr-core/Cargo.toml
+++ b/pywr-core/Cargo.toml
@@ -29,7 +29,7 @@ highs-sys = { version = "1.6", optional = true }
 nalgebra = "0.33"
 chrono = { workspace = true }
 polars = { workspace = true }
-pyo3 = { workspace = true, features = ["chrono", "macros"] }
+pyo3 = { workspace = true, features = ["chrono", "macros"], optional = true }
 rayon = "1.6"
 rhai = { version = "1.20", features = ["sync"] }
 ocl = { version = "0.19", optional = true }
@@ -46,8 +46,8 @@ cbc = []
 highs = ["dep:highs-sys"]
 ipm-ocl = ["dep:ipm-ocl", "dep:ocl"]
 ipm-simd = ["dep:ipm-simd"]
-default = []
-
+default = ["pyo3"]
+pyo3 = ["dep:pyo3"]
 
 [[bench]]
 name = "random_models"

--- a/pywr-core/src/lib.rs
+++ b/pywr-core/src/lib.rs
@@ -11,8 +11,12 @@ use crate::parameters::{
 use crate::recorders::{AggregationError, MetricSetIndex, RecorderIndex};
 use crate::state::MultiValue;
 use crate::virtual_storage::VirtualStorageIndex;
-use pyo3::exceptions::{PyException, PyRuntimeError};
-use pyo3::{create_exception, PyErr};
+#[cfg(feature = "pyo3")]
+use pyo3::{
+    create_exception,
+    exceptions::{PyException, PyRuntimeError},
+    PyErr,
+};
 use thiserror::Error;
 
 pub mod aggregated_node;
@@ -202,8 +206,10 @@ pub enum PywrError {
 }
 
 // Python errors
+#[cfg(feature = "pyo3")]
 create_exception!(pywr, ParameterNotFoundError, PyException);
 
+#[cfg(feature = "pyo3")]
 impl From<PywrError> for PyErr {
     fn from(err: PywrError) -> PyErr {
         match err {

--- a/pywr-core/src/parameters/mod.rs
+++ b/pywr-core/src/parameters/mod.rs
@@ -20,6 +20,8 @@ mod negativemin;
 mod offset;
 mod polynomial;
 mod profiles;
+
+#[cfg(feature = "pyo3")]
 mod py;
 mod rhai;
 mod threshold;
@@ -62,6 +64,7 @@ pub use profiles::{
     RbfProfileVariableConfig, UniformDrawdownProfileParameter, WeeklyInterpDay, WeeklyProfileError,
     WeeklyProfileParameter, WeeklyProfileValues,
 };
+#[cfg(feature = "pyo3")]
 pub use py::PyParameter;
 use std::fmt;
 use std::fmt::{Display, Formatter};

--- a/pywr-core/src/solvers/builder.rs
+++ b/pywr-core/src/solvers/builder.rs
@@ -331,10 +331,12 @@ where
         I::from(self.builder.col_upper.len()).unwrap()
     }
 
+    #[allow(dead_code)]
     pub fn num_rows(&self) -> I {
         I::from(self.builder.row_upper.len()).unwrap()
     }
 
+    #[allow(dead_code)]
     pub fn num_non_zero(&self) -> I {
         I::from(self.builder.elements.len()).unwrap()
     }
@@ -351,6 +353,7 @@ where
         &self.builder.col_obj_coef
     }
 
+    #[allow(dead_code)]
     pub fn col_type(&self) -> &[ColType] {
         &self.builder.col_type
     }
@@ -363,6 +366,7 @@ where
         &self.builder.row_upper
     }
 
+    #[allow(dead_code)]
     pub fn row_mask(&self) -> &[I] {
         &self.builder.row_mask
     }

--- a/pywr-core/src/timestep.rs
+++ b/pywr-core/src/timestep.rs
@@ -1,11 +1,11 @@
+use crate::PywrError;
 use chrono::Datelike;
 use chrono::{Months, NaiveDateTime, TimeDelta};
 use polars::datatypes::TimeUnit;
 use polars::time::ClosedWindow;
-use pyo3::prelude::*;
+#[cfg(feature = "pyo3")]
+use pyo3::pyclass;
 use std::ops::Add;
-
-use crate::PywrError;
 
 const SECS_IN_DAY: i64 = 60 * 60 * 24;
 const MILLISECS_IN_DAY: i64 = 1000 * SECS_IN_DAY;
@@ -104,7 +104,7 @@ impl PywrDuration {
 
 pub type TimestepIndex = usize;
 
-#[pyclass]
+#[cfg_attr(feature = "pyo3", pyclass)]
 #[derive(Debug, Copy, Clone)]
 pub struct Timestep {
     pub date: NaiveDateTime,

--- a/pywr-schema/Cargo.toml
+++ b/pywr-schema/Cargo.toml
@@ -16,7 +16,7 @@ categories = ["science", "simulation"]
 [dependencies]
 svgbobdoc = { git = "https://github.com/yvt/svgbobdoc.git", features = ["enable"] }
 polars = { workspace = true, features = ["csv", "diff", "dtype-datetime", "dtype-date", "dynamic_group_by"], optional = true }
-pyo3 = { workspace = true }
+pyo3 = { workspace = true, optional = true }
 pyo3-polars = { workspace = true, optional = true }
 strum = "0.26"
 strum_macros = "0.26"
@@ -41,9 +41,10 @@ tempfile = "3.15"
 [features]
 # Core feature requires additional dependencies
 core = ["dep:pywr-core", "dep:hdf5-metno", "dep:csv", "dep:polars", "dep:pyo3-polars", "dep:ndarray", "dep:tracing"]
-default = ["core"]
+default = ["core", "pyo3"]
 cbc = ["pywr-core/cbc"]
 highs = ["pywr-core/highs"]
 ipm-ocl = ["pywr-core/ipm-ocl"]
 ipm-simd = ["pywr-core/ipm-simd"]
 test-python = []
+pyo3 = ["dep:pyo3", "pywr-core/pyo3"]

--- a/pywr-schema/src/error.rs
+++ b/pywr-schema/src/error.rs
@@ -1,6 +1,7 @@
 use crate::data_tables::{DataTable, TableDataRef, TableError};
 use crate::nodes::NodeAttribute;
 use crate::timeseries::TimeseriesError;
+#[cfg(feature = "pyo3")]
 use pyo3::prelude::*;
 use std::path::PathBuf;
 use thiserror::Error;
@@ -69,9 +70,11 @@ pub enum SchemaError {
     OutOfRange(#[from] chrono::OutOfRange),
     #[error("The metric set with name '{0}' contains no metrics")]
     EmptyMetricSet(String),
+    #[error("The feature '{0}' must be enabled to use this functionality.")]
+    FeatureNotEnabled(String),
 }
 
-#[cfg(feature = "core")]
+#[cfg(all(feature = "core", feature = "pyo3"))]
 impl From<SchemaError> for PyErr {
     fn from(err: SchemaError) -> PyErr {
         pyo3::exceptions::PyRuntimeError::new_err(err.to_string())
@@ -79,7 +82,7 @@ impl From<SchemaError> for PyErr {
 }
 
 #[derive(Error, Debug, PartialEq, Eq, Clone)]
-#[pyclass]
+#[cfg_attr(feature = "pyo3", pyclass)]
 pub enum ComponentConversionError {
     #[error("Failed to convert `{attr}` on node `{name}`: {error}")]
     Node {
@@ -96,7 +99,7 @@ pub enum ComponentConversionError {
 }
 
 #[derive(Error, Debug, PartialEq, Eq, Clone)]
-#[pyclass]
+#[cfg_attr(feature = "pyo3", pyclass)]
 pub enum ConversionError {
     #[error("Constant float value cannot be a parameter reference.")]
     ConstantFloatReferencesParameter {},

--- a/pywr-schema/src/model.rs
+++ b/pywr-schema/src/model.rs
@@ -16,6 +16,7 @@ use crate::visit::{VisitMetrics, VisitPaths};
 #[cfg(feature = "core")]
 use chrono::NaiveTime;
 use chrono::{NaiveDate, NaiveDateTime};
+#[cfg(feature = "pyo3")]
 use pyo3::pyclass;
 #[cfg(feature = "core")]
 use pywr_core::{models::ModelDomain, timestep::TimestepDuration, PywrError};
@@ -152,7 +153,7 @@ pub struct LoadArgs<'a> {
 }
 
 #[derive(serde::Deserialize, serde::Serialize, Clone, Default, JsonSchema)]
-#[pyclass]
+#[cfg_attr(feature = "pyo3", pyclass)]
 pub struct PywrNetwork {
     pub nodes: Vec<Node>,
     pub edges: Vec<Edge>,

--- a/pywr-schema/src/parameters/mod.rs
+++ b/pywr-schema/src/parameters/mod.rs
@@ -56,7 +56,7 @@ pub use profiles::{
     DailyProfileParameter, MonthlyInterpDay, MonthlyProfileParameter, RadialBasisFunction, RbfProfileParameter,
     RbfProfileVariableSettings, UniformDrawdownProfileParameter, WeeklyProfileParameter,
 };
-#[cfg(feature = "core")]
+#[cfg(all(feature = "core", feature = "pyo3"))]
 pub use python::try_json_value_into_py;
 pub use python::{PythonParameter, PythonReturnType, PythonSource};
 use pywr_schema_macros::PywrVisitAll;

--- a/pywr-schema/src/parameters/python.rs
+++ b/pywr-schema/src/parameters/python.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "core")]
+#[cfg(all(feature = "core", feature = "pyo3"))]
 use crate::data_tables::make_path;
 #[cfg(feature = "core")]
 use crate::error::SchemaError;
@@ -7,16 +7,18 @@ use crate::metric::{IndexMetric, Metric};
 use crate::model::LoadArgs;
 use crate::parameters::{DynamicFloatValueType, ParameterMeta};
 use crate::visit::{VisitMetrics, VisitPaths};
+#[cfg(all(feature = "core", feature = "pyo3"))]
+use pyo3::{
+    prelude::{PyAnyMethods, PyModule},
+    types::{PyDict, PyTuple},
+    IntoPy, PyErr, PyObject, Python,
+};
 #[cfg(feature = "core")]
-use pyo3::prelude::{PyAnyMethods, PyModule};
-#[cfg(feature = "core")]
-use pyo3::types::{PyDict, PyTuple};
-#[cfg(feature = "core")]
-use pyo3::{IntoPy, PyErr, PyObject, Python};
-#[cfg(feature = "core")]
-use pywr_core::parameters::{ParameterType, PyParameter};
+use pywr_core::parameters::ParameterType;
+#[cfg(all(feature = "core", feature = "pyo3"))]
+use pywr_core::parameters::PyParameter;
 use schemars::JsonSchema;
-#[cfg(feature = "core")]
+#[cfg(all(feature = "core", feature = "pyo3"))]
 use serde_json::Value;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -106,7 +108,7 @@ pub struct PythonParameter {
     pub indices: Option<HashMap<String, IndexMetric>>,
 }
 
-#[cfg(feature = "core")]
+#[cfg(all(feature = "core", feature = "pyo3"))]
 pub fn try_json_value_into_py(py: Python, value: &serde_json::Value) -> Result<Option<PyObject>, SchemaError> {
     let py_value = match value {
         Value::Null => None,
@@ -190,7 +192,17 @@ impl PythonParameter {
     }
 }
 
-#[cfg(feature = "core")]
+#[cfg(all(feature = "core", not(feature = "pyo3")))]
+impl PythonParameter {
+    pub fn add_to_model(
+        &self,
+        _network: &mut pywr_core::network::Network,
+        _args: &LoadArgs,
+    ) -> Result<ParameterType, SchemaError> {
+        Err(SchemaError::FeatureNotEnabled("pyo3".to_string()))
+    }
+}
+#[cfg(all(feature = "core", feature = "pyo3"))]
 impl PythonParameter {
     pub fn add_to_model(
         &self,
@@ -270,7 +282,7 @@ impl PythonParameter {
 }
 
 #[cfg(test)]
-#[cfg(feature = "core")]
+#[cfg(all(feature = "core", feature = "pyo3"))]
 mod tests {
     use crate::data_tables::LoadedTableCollection;
     use crate::model::{LoadArgs, PywrNetwork};

--- a/pywr-schema/src/timeseries/mod.rs
+++ b/pywr-schema/src/timeseries/mod.rs
@@ -62,6 +62,9 @@ pub enum TimeseriesError {
     #[cfg(feature = "core")]
     #[error("Pywr core error: {0}")]
     PywrCore(#[from] PywrError),
+    #[cfg(feature = "core")]
+    #[error("Python not enabled.")]
+    PythonNotEnabled,
 }
 
 #[derive(serde::Deserialize, serde::Serialize, Debug, Clone, JsonSchema)]

--- a/pywr-schema/src/timeseries/pandas.rs
+++ b/pywr-schema/src/timeseries/pandas.rs
@@ -27,7 +27,27 @@ impl VisitPaths for PandasDataset {
     }
 }
 
-#[cfg(feature = "core")]
+#[cfg(all(feature = "core", not(feature = "pyo3")))]
+mod core {
+    use super::PandasDataset;
+    use crate::timeseries::TimeseriesError;
+    use polars::frame::DataFrame;
+    use pywr_core::models::ModelDomain;
+    use std::path::Path;
+
+    impl PandasDataset {
+        pub fn load(
+            &self,
+            _name: &str,
+            _data_path: Option<&Path>,
+            _domain: &ModelDomain,
+        ) -> Result<DataFrame, TimeseriesError> {
+            Err(TimeseriesError::PythonNotEnabled)
+        }
+    }
+}
+
+#[cfg(all(feature = "core", feature = "pyo3"))]
 mod core {
     const PANDAS_LOAD_SCRIPT: &str = include_str!("pandas_load.py");
 


### PR DESCRIPTION
Adds a new default feature, `pyo3`, for enabling Python support. It is useful to feature gate PyO3 functionality to allow pywr-schema to built on a wider range of platforms (e.g. WASM).

This also updates the Linux CI to use cargo hack to check every feature combination is functional.