### PR TITLE
feat: Improve HDF5 error handling in pywr-core.

### DIFF
--- a/pywr-core/src/lib.rs
+++ b/pywr-core/src/lib.rs
@@ -40,7 +40,7 @@ pub mod timestep;
 pub mod utils;
 pub mod virtual_storage;
 
-#[derive(Error, Debug, PartialEq, Eq)]
+#[derive(Error, Debug)]
 pub enum PywrError {
     #[error("invalid node connect")]
     InvalidNodeConnection,
@@ -157,7 +157,9 @@ pub enum PywrError {
     #[error("recorder does not supported aggregation")]
     RecorderDoesNotSupportAggregation,
     #[error("hdf5 error: {0}")]
-    HDF5Error(String),
+    HDF5Error(#[from] hdf5_metno::Error),
+    #[error("could not create unicode variable name from: {0}")]
+    HDF5VarLenUnicode(String),
     #[error("csv error: {0}")]
     CSVError(String),
     #[error("not implemented by recorder")]

--- a/pywr-core/src/network.rs
+++ b/pywr-core/src/network.rs
@@ -1714,29 +1714,25 @@ mod tests {
 
         network.add_input_node("my-node", None).unwrap();
         // Second add with the same name
-        assert_eq!(
+        assert!(matches!(
             network.add_input_node("my-node", None),
-            Err(PywrError::NodeNameAlreadyExists("my-node".to_string()))
-        );
+            Err(PywrError::NodeNameAlreadyExists(n)) if n == "my-node"));
 
         network.add_input_node("my-node", Some("a")).unwrap();
         // Second add with the same name
-        assert_eq!(
+        assert!(matches!(
             network.add_input_node("my-node", Some("a")),
-            Err(PywrError::NodeNameAlreadyExists("my-node".to_string()))
-        );
+            Err(PywrError::NodeNameAlreadyExists(n)) if n == "my-node"));
 
-        assert_eq!(
+        assert!(matches!(
             network.add_link_node("my-node", None),
-            Err(PywrError::NodeNameAlreadyExists("my-node".to_string()))
-        );
+            Err(PywrError::NodeNameAlreadyExists(n)) if n == "my-node"));
 
-        assert_eq!(
+        assert!(matches!(
             network.add_output_node("my-node", None),
-            Err(PywrError::NodeNameAlreadyExists("my-node".to_string()))
-        );
+            Err(PywrError::NodeNameAlreadyExists(n)) if n == "my-node"));
 
-        assert_eq!(
+        assert!(matches!(
             network.add_storage_node(
                 "my-node",
                 None,
@@ -1744,8 +1740,7 @@ mod tests {
                 None,
                 Some(10.0.into())
             ),
-            Err(PywrError::NodeNameAlreadyExists("my-node".to_string()))
-        );
+            Err(PywrError::NodeNameAlreadyExists(n)) if n == "my-node"));
     }
 
     #[test]
@@ -1762,10 +1757,10 @@ mod tests {
         node.set_max_flow_constraint(Some(parameter.into())).unwrap();
 
         // Try to assign a constraint not defined for particular node type
-        assert_eq!(
+        assert!(matches!(
             node.set_max_volume_constraint(Some(10.0.into())),
             Err(PywrError::StorageConstraintsUndefined)
-        );
+        ));
     }
 
     #[test]


### PR DESCRIPTION
Implement #[from] for the HDF5 error. This requires removing the `PartialEq` and `Eq` derives for `PywrError`, and adding a new error variant for HDF5 unicode conversion. This allows neater handling of HDF5 errors in core.