### PR TITLE
fix: Fix calculation of proportional volume on VS nodes after reset.

### DIFF
--- a/pywr-core/src/metric.rs
+++ b/pywr-core/src/metric.rs
@@ -229,6 +229,12 @@ where
     }
 }
 
+impl From<DerivedMetricIndex> for MetricF64 {
+    fn from(idx: DerivedMetricIndex) -> Self {
+        Self::DerivedMetric(idx)
+    }
+}
+
 impl From<ParameterIndex<f64>> for MetricF64 {
     fn from(idx: ParameterIndex<f64>) -> Self {
         match idx {

--- a/pywr-core/src/network.rs
+++ b/pywr-core/src/network.rs
@@ -1051,6 +1051,22 @@ impl Network {
     }
 
     /// Get a `VirtualStorageNode` from a node's name
+    pub fn get_mut_virtual_storage_node_by_name(
+        &mut self,
+        name: &str,
+        sub_name: Option<&str>,
+    ) -> Result<&mut VirtualStorage, PywrError> {
+        match self
+            .virtual_storage_nodes
+            .iter_mut()
+            .find(|n| n.full_name() == (name, sub_name))
+        {
+            Some(node) => Ok(node),
+            None => Err(PywrError::NodeNotFound(name.to_string())),
+        }
+    }
+
+    /// Get a `VirtualStorageNode` from a node's name
     pub fn get_virtual_storage_node_index_by_name(
         &self,
         name: &str,
@@ -1337,6 +1353,17 @@ impl Network {
             .push(ComponentType::VirtualStorageNode(vs_node_index));
 
         Ok(vs_node_index)
+    }
+
+    pub fn set_virtual_storage_node_cost(
+        &mut self,
+        name: &str,
+        sub_name: Option<&str>,
+        value: Option<MetricF64>,
+    ) -> Result<(), PywrError> {
+        let node = self.get_mut_virtual_storage_node_by_name(name, sub_name)?;
+        node.set_cost(value);
+        Ok(())
     }
 
     /// Add a [`parameters::GeneralParameter`] to the network
@@ -1771,7 +1798,7 @@ mod tests {
     #[test]
     fn test_step() {
         const NUM_SCENARIOS: usize = 2;
-        let model = simple_model(NUM_SCENARIOS);
+        let model = simple_model(NUM_SCENARIOS, None);
 
         let mut timings = RunTimings::default();
 
@@ -1796,7 +1823,7 @@ mod tests {
     #[test]
     /// Test running a simple model
     fn test_run() {
-        let mut model = simple_model(10);
+        let mut model = simple_model(10, None);
 
         // Set-up assertion for "input" node
         let idx = model.network().get_node_by_name("input", None).unwrap().index();
@@ -1992,7 +2019,7 @@ mod tests {
     #[test]
     /// Test the variable API
     fn test_variable_api() {
-        let mut model = simple_model(1);
+        let mut model = simple_model(1, None);
 
         let variable = ActivationFunction::Unit { min: 0.0, max: 10.0 };
         let input_max_flow = parameters::ConstantParameter::new("my-constant".into(), 10.0);

--- a/pywr-core/src/parameters/control_curves/piecewise.rs
+++ b/pywr-core/src/parameters/control_curves/piecewise.rs
@@ -82,7 +82,7 @@ mod test {
     /// Basic functional test of the piecewise interpolation.
     #[test]
     fn test_basic() {
-        let mut model = simple_model(1);
+        let mut model = simple_model(1, None);
 
         // Create an artificial volume series to use for the interpolation test
         let volume = Array1Parameter::new("test-x".into(), Array1::linspace(1.0, 0.0, 21), None);

--- a/pywr-core/src/parameters/delay.rs
+++ b/pywr-core/src/parameters/delay.rs
@@ -170,7 +170,7 @@ mod test {
     /// Basic functional test of the delay parameter.
     #[test]
     fn test_basic() {
-        let mut model = simple_model(1);
+        let mut model = simple_model(1, None);
 
         // Create an artificial volume series to use for the delay test
         let volumes = Array1::linspace(1.0, 0.0, 21);

--- a/pywr-core/src/parameters/discount_factor.rs
+++ b/pywr-core/src/parameters/discount_factor.rs
@@ -61,7 +61,7 @@ mod test {
     /// Basic functional test of the delay parameter.
     #[test]
     fn test_basic() {
-        let mut model = simple_model(1);
+        let mut model = simple_model(1, None);
         let network = model.network_mut();
 
         // Create an artificial volume series to use for the delay test

--- a/pywr-core/src/recorders/mod.rs
+++ b/pywr-core/src/recorders/mod.rs
@@ -354,7 +354,7 @@ mod tests {
 
     #[test]
     fn test_array2_recorder() {
-        let mut model = simple_model(2);
+        let mut model = simple_model(2, None);
 
         let node_idx = model.network().get_node_index_by_name("input", None).unwrap();
 

--- a/pywr-core/src/test_utils.rs
+++ b/pywr-core/src/test_utils.rs
@@ -91,11 +91,11 @@ pub fn simple_network(network: &mut Network, inflow_scenario_index: usize, num_i
     output_node.set_cost(Some(demand_cost.into()));
 }
 /// Create a simple test model with three nodes.
-pub fn simple_model(num_scenarios: usize) -> Model {
+pub fn simple_model(num_scenarios: usize, timestepper: Option<Timestepper>) -> Model {
     let mut scenario_collection = ScenarioGroupCollection::default();
     scenario_collection.add_group("test-scenario", num_scenarios);
 
-    let domain = ModelDomain::from(default_timestepper(), scenario_collection).unwrap();
+    let domain = ModelDomain::from(timestepper.unwrap_or_else(default_timestepper), scenario_collection).unwrap();
     let mut network = Network::default();
 
     let idx = domain

--- a/pywr-core/src/timestep.rs
+++ b/pywr-core/src/timestep.rs
@@ -105,7 +105,7 @@ impl PywrDuration {
 pub type TimestepIndex = usize;
 
 #[cfg_attr(feature = "pyo3", pyclass)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 pub struct Timestep {
     pub date: NaiveDateTime,
     pub index: TimestepIndex,


### PR DESCRIPTION
Derived metrics, such as proportional volume, must be recalculated at the start of the time-step if the volume has been reset. This ensures that parameters that depend on the proportional volume (e.g., control curve calculations) use the correct value after the volume is reset.