### PR TITLE
fix: Correctly use Python::allow_threads() to avoid deadlock.

### DIFF
--- a/pywr-cli/src/main.rs
+++ b/pywr-cli/src/main.rs
@@ -7,7 +7,7 @@ use clap::{Parser, Subcommand, ValueEnum};
 #[cfg(feature = "cbc")]
 use pywr_core::solvers::{CbcSolver, CbcSolverSettings, CbcSolverSettingsBuilder};
 #[cfg(feature = "ipm-ocl")]
-use pywr_core::solvers::{ClIpmF32Solver, ClIpmF64Solver, ClIpmSolverSettings};
+use pywr_core::solvers::{ClIpmF32Solver, ClIpmF64Solver, ClIpmSolverSettings, ClIpmSolverSettingsBuilder};
 use pywr_core::solvers::{ClpSolver, ClpSolverSettings, ClpSolverSettingsBuilder};
 #[cfg(feature = "highs")]
 use pywr_core::solvers::{HighsSolver, HighsSolverSettings, HighsSolverSettingsBuilder};
@@ -315,9 +315,33 @@ fn run(
             model.run::<HighsSolver>(&settings)
         }
         #[cfg(feature = "ipm-ocl")]
-        Solver::CLIPMF32 => model.run_multi_scenario::<ClIpmF32Solver>(&ClIpmSolverSettings::default()),
+        Solver::CLIPMF32 => {
+            let mut settings_builder = ClIpmSolverSettingsBuilder::default();
+            if threads > 1 {
+                settings_builder = settings_builder.parallel();
+                settings_builder = settings_builder.threads(threads);
+            }
+            if ignore_feature_requirements {
+                settings_builder = settings_builder.ignore_feature_requirements();
+            }
+
+            let settings = settings_builder.build();
+            model.run_multi_scenario::<ClIpmF32Solver>(&settings)
+        }
         #[cfg(feature = "ipm-ocl")]
-        Solver::CLIPMF64 => model.run_multi_scenario::<ClIpmF64Solver>(&ClIpmSolverSettings::default()),
+        Solver::CLIPMF64 => {
+            let mut settings_builder = ClIpmSolverSettingsBuilder::default();
+            if threads > 1 {
+                settings_builder = settings_builder.parallel();
+                settings_builder = settings_builder.threads(threads);
+            }
+            if ignore_feature_requirements {
+                settings_builder = settings_builder.ignore_feature_requirements();
+            }
+
+            let settings = settings_builder.build();
+            model.run_multi_scenario::<ClIpmF64Solver>(&settings)
+        }
         #[cfg(feature = "ipm-simd")]
         Solver::IpmSimd => {
             let mut settings_builder = SimdIpmSolverSettingsBuilder::default();

--- a/pywr-cli/src/main.rs
+++ b/pywr-cli/src/main.rs
@@ -12,7 +12,7 @@ use pywr_core::solvers::{ClpSolver, ClpSolverSettings, ClpSolverSettingsBuilder}
 #[cfg(feature = "highs")]
 use pywr_core::solvers::{HighsSolver, HighsSolverSettings, HighsSolverSettingsBuilder};
 #[cfg(feature = "ipm-simd")]
-use pywr_core::solvers::{SimdIpmF64Solver, SimdIpmSolverSettings};
+use pywr_core::solvers::{SimdIpmF64Solver, SimdIpmSolverSettings, SimdIpmSolverSettingsBuilder};
 use pywr_core::test_utils::make_random_model;
 use pywr_schema::model::{PywrModel, PywrMultiNetworkModel, PywrNetwork};
 use pywr_schema::ComponentConversionError;
@@ -94,6 +94,9 @@ enum Commands {
         /// The number of threads to use in parallel simulation.
         #[arg(short, long, default_value_t = 1)]
         threads: usize,
+        /// Ignore the feature requirements of a solver.
+        #[arg(short, long, default_value_t = false)]
+        ignore_feature_requirements: bool,
     },
     RunMulti {
         /// Path to Pywr model JSON.
@@ -140,7 +143,15 @@ fn main() -> Result<()> {
             data_path,
             output_path,
             threads,
-        } => run(model, solver, data_path.as_deref(), output_path.as_deref(), *threads),
+            ignore_feature_requirements,
+        } => run(
+            model,
+            solver,
+            data_path.as_deref(),
+            output_path.as_deref(),
+            *threads,
+            *ignore_feature_requirements,
+        ),
         Commands::RunMulti {
             model,
             solver,
@@ -250,7 +261,14 @@ fn handle_conversion_errors(errors: &[ComponentConversionError], stop_on_error: 
     Ok(())
 }
 
-fn run(path: &Path, solver: &Solver, data_path: Option<&Path>, output_path: Option<&Path>, threads: usize) {
+fn run(
+    path: &Path,
+    solver: &Solver,
+    data_path: Option<&Path>,
+    output_path: Option<&Path>,
+    threads: usize,
+    ignore_feature_requirements: bool,
+) {
     let data = std::fs::read_to_string(path).unwrap();
     let data_path = data_path.or_else(|| path.parent());
     let schema_v2: PywrModel = serde_json::from_str(data.as_str()).unwrap();
@@ -264,6 +282,9 @@ fn run(path: &Path, solver: &Solver, data_path: Option<&Path>, output_path: Opti
                 settings_builder = settings_builder.parallel();
                 settings_builder = settings_builder.threads(threads);
             }
+            if ignore_feature_requirements {
+                settings_builder = settings_builder.ignore_feature_requirements();
+            }
             let settings = settings_builder.build();
             model.run::<ClpSolver>(&settings)
         }
@@ -273,6 +294,9 @@ fn run(path: &Path, solver: &Solver, data_path: Option<&Path>, output_path: Opti
             if threads > 1 {
                 settings_builder = settings_builder.parallel();
                 settings_builder = settings_builder.threads(threads);
+            }
+            if ignore_feature_requirements {
+                settings_builder = settings_builder.ignore_feature_requirements();
             }
             let settings = settings_builder.build();
             model.run::<CbcSolver>(&settings)
@@ -284,6 +308,9 @@ fn run(path: &Path, solver: &Solver, data_path: Option<&Path>, output_path: Opti
                 settings_builder = settings_builder.parallel();
                 settings_builder = settings_builder.threads(threads);
             }
+            if ignore_feature_requirements {
+                settings_builder = settings_builder.ignore_feature_requirements();
+            }
             let settings = settings_builder.build();
             model.run::<HighsSolver>(&settings)
         }
@@ -292,7 +319,19 @@ fn run(path: &Path, solver: &Solver, data_path: Option<&Path>, output_path: Opti
         #[cfg(feature = "ipm-ocl")]
         Solver::CLIPMF64 => model.run_multi_scenario::<ClIpmF64Solver>(&ClIpmSolverSettings::default()),
         #[cfg(feature = "ipm-simd")]
-        Solver::IpmSimd => model.run_multi_scenario::<SimdIpmF64Solver<4>>(&SimdIpmSolverSettings::default()),
+        Solver::IpmSimd => {
+            let mut settings_builder = SimdIpmSolverSettingsBuilder::default();
+            if threads > 1 {
+                settings_builder = settings_builder.parallel();
+                settings_builder = settings_builder.threads(threads);
+            }
+            if ignore_feature_requirements {
+                settings_builder = settings_builder.ignore_feature_requirements();
+            }
+
+            let settings = settings_builder.build();
+            model.run_multi_scenario::<SimdIpmF64Solver<4>>(&settings)
+        }
     }
     .unwrap();
 }

--- a/pywr-core/src/models/multi.rs
+++ b/pywr-core/src/models/multi.rs
@@ -150,6 +150,7 @@ impl MultiNetworkModel {
     pub fn setup<S>(&self, settings: &S::Settings) -> Result<MultiNetworkModelState<Vec<Box<S>>>, PywrError>
     where
         S: Solver,
+        <S as Solver>::Settings: SolverSettings,
     {
         let timesteps = self.domain.time.timesteps();
         let scenario_indices = self.domain.scenarios.indices();
@@ -181,6 +182,7 @@ impl MultiNetworkModel {
     pub fn setup_multi_scenario<S>(&self, settings: &S::Settings) -> Result<MultiNetworkModelState<Box<S>>, PywrError>
     where
         S: MultiStateSolver,
+        <S as MultiStateSolver>::Settings: SolverSettings,
     {
         let timesteps = self.domain.time.timesteps();
         let scenario_indices = self.domain.scenarios.indices();

--- a/pywr-core/src/models/simple.rs
+++ b/pywr-core/src/models/simple.rs
@@ -72,6 +72,7 @@ impl Model {
     pub fn setup<S>(&self, settings: &S::Settings) -> Result<ModelState<Vec<Box<S>>>, PywrError>
     where
         S: Solver,
+        <S as Solver>::Settings: SolverSettings,
     {
         let timesteps = self.domain.time.timesteps();
         let scenario_indices = self.domain.scenarios.indices();
@@ -91,6 +92,7 @@ impl Model {
     pub fn setup_multi_scenario<S>(&self, settings: &S::Settings) -> Result<ModelState<Box<S>>, PywrError>
     where
         S: MultiStateSolver,
+        <S as MultiStateSolver>::Settings: SolverSettings,
     {
         let timesteps = self.domain.time.timesteps();
         let scenario_indices = self.domain.scenarios.indices();

--- a/pywr-core/src/solvers/cbc/settings.rs
+++ b/pywr-core/src/solvers/cbc/settings.rs
@@ -7,6 +7,7 @@ use crate::solvers::SolverSettings;
 pub struct CbcSolverSettings {
     parallel: bool,
     threads: usize,
+    ignore_feature_requirements: bool,
 }
 
 // Default implementation is a convenience that defers to the builder.
@@ -23,6 +24,10 @@ impl SolverSettings for CbcSolverSettings {
 
     fn threads(&self) -> usize {
         self.threads
+    }
+
+    fn ignore_feature_requirements(&self) -> bool {
+        self.ignore_feature_requirements
     }
 }
 
@@ -53,6 +58,7 @@ impl CbcSolverSettings {
 pub struct CbcSolverSettingsBuilder {
     parallel: bool,
     threads: usize,
+    ignore_feature_requirements: bool,
 }
 
 impl CbcSolverSettingsBuilder {
@@ -66,11 +72,17 @@ impl CbcSolverSettingsBuilder {
         self
     }
 
+    pub fn ignore_feature_requirements(mut self) -> Self {
+        self.ignore_feature_requirements = true;
+        self
+    }
+
     /// Construct a [`CbcSolverSettings`] from the builder.
     pub fn build(self) -> CbcSolverSettings {
         CbcSolverSettings {
             parallel: self.parallel,
             threads: self.threads,
+            ignore_feature_requirements: self.ignore_feature_requirements,
         }
     }
 }
@@ -84,6 +96,7 @@ mod tests {
         let _settings = CbcSolverSettings {
             parallel: true,
             threads: 0,
+            ignore_feature_requirements: false,
         };
         let settings_from_builder = CbcSolverSettingsBuilder::default().parallel().build();
 

--- a/pywr-core/src/solvers/clp/settings.rs
+++ b/pywr-core/src/solvers/clp/settings.rs
@@ -7,6 +7,7 @@ use crate::solvers::SolverSettings;
 pub struct ClpSolverSettings {
     parallel: bool,
     threads: usize,
+    ignore_feature_requirements: bool,
 }
 
 // Default implementation is a convenience that defers to the builder.
@@ -23,6 +24,10 @@ impl SolverSettings for ClpSolverSettings {
 
     fn threads(&self) -> usize {
         self.threads
+    }
+
+    fn ignore_feature_requirements(&self) -> bool {
+        self.ignore_feature_requirements
     }
 }
 
@@ -53,6 +58,7 @@ impl ClpSolverSettings {
 pub struct ClpSolverSettingsBuilder {
     parallel: bool,
     threads: usize,
+    ignore_feature_requirements: bool,
 }
 
 impl ClpSolverSettingsBuilder {
@@ -66,11 +72,17 @@ impl ClpSolverSettingsBuilder {
         self
     }
 
+    pub fn ignore_feature_requirements(mut self) -> Self {
+        self.ignore_feature_requirements = true;
+        self
+    }
+
     /// Construct a [`ClpSolverSettings`] from the builder.
     pub fn build(self) -> ClpSolverSettings {
         ClpSolverSettings {
             parallel: self.parallel,
             threads: self.threads,
+            ignore_feature_requirements: self.ignore_feature_requirements,
         }
     }
 }
@@ -84,6 +96,7 @@ mod tests {
         let _settings = ClpSolverSettings {
             parallel: true,
             threads: 0,
+            ignore_feature_requirements: false,
         };
         let settings_from_builder = ClpSolverSettingsBuilder::default().parallel().build();
 

--- a/pywr-core/src/solvers/highs/settings.rs
+++ b/pywr-core/src/solvers/highs/settings.rs
@@ -7,6 +7,7 @@ use crate::solvers::SolverSettings;
 pub struct HighsSolverSettings {
     parallel: bool,
     threads: usize,
+    ignore_feature_requirements: bool,
 }
 
 // Default implementation is a convenience that defers to the builder.
@@ -23,6 +24,10 @@ impl SolverSettings for HighsSolverSettings {
 
     fn threads(&self) -> usize {
         self.threads
+    }
+
+    fn ignore_feature_requirements(&self) -> bool {
+        self.ignore_feature_requirements
     }
 }
 
@@ -52,6 +57,7 @@ impl HighsSolverSettings {
 pub struct HighsSolverSettingsBuilder {
     parallel: bool,
     threads: usize,
+    ignore_feature_requirements: bool,
 }
 
 impl HighsSolverSettingsBuilder {
@@ -65,11 +71,17 @@ impl HighsSolverSettingsBuilder {
         self
     }
 
+    pub fn ignore_feature_requirements(mut self) -> Self {
+        self.ignore_feature_requirements = true;
+        self
+    }
+
     /// Construct a [`HighsSolverSettings`] from the builder.
     pub fn build(self) -> HighsSolverSettings {
         HighsSolverSettings {
             parallel: self.parallel,
             threads: self.threads,
+            ignore_feature_requirements: self.ignore_feature_requirements,
         }
     }
 }
@@ -83,6 +95,7 @@ mod tests {
         let settings = HighsSolverSettings {
             parallel: true,
             threads: 0,
+            ignore_feature_requirements: false,
         };
         let settings_from_builder = HighsSolverSettingsBuilder::default().parallel().build();
 

--- a/pywr-core/src/solvers/ipm_ocl/settings.rs
+++ b/pywr-core/src/solvers/ipm_ocl/settings.rs
@@ -133,7 +133,7 @@ impl ClIpmSolverSettingsBuilder {
         self
     }
 
-    fn ignore_feature_requirements(mut self) -> Self {
+    pub fn ignore_feature_requirements(mut self) -> Self {
         self.ignore_feature_requirements = true;
         self
     }

--- a/pywr-core/src/solvers/ipm_ocl/settings.rs
+++ b/pywr-core/src/solvers/ipm_ocl/settings.rs
@@ -12,6 +12,7 @@ pub struct ClIpmSolverSettings {
     num_chunks: NonZeroUsize,
     tolerances: Tolerances,
     max_iterations: NonZeroUsize,
+    ignore_feature_requirements: bool,
 }
 
 // Default implementation is a convenience that defers to the builder.
@@ -28,6 +29,10 @@ impl SolverSettings for ClIpmSolverSettings {
 
     fn threads(&self) -> usize {
         self.threads
+    }
+
+    fn ignore_feature_requirements(&self) -> bool {
+        self.ignore_feature_requirements
     }
 }
 
@@ -56,15 +61,16 @@ impl ClIpmSolverSettings {
 ///
 /// ```
 /// use std::num::NonZeroUsize;
-/// use pywr::solvers::ClIpmSolverSettingsBuilder;
+/// use pywr_core::solvers::ClIpmSolverSettingsBuilder;
 /// // Settings with parallel enabled and 4 threads.
 /// let settings = ClIpmSolverSettingsBuilder::default().parallel().threads(4).build();
 ///
-/// let mut builder = ClIpmSolverSettingsBuilder::default();
-/// builder.num_chunks(NonZeroUsize::new(8).unwrap());
+/// let builder = ClIpmSolverSettingsBuilder::default()
+///     .num_chunks(NonZeroUsize::new(8).unwrap());
 /// let settings = builder.build();
 ///
-/// builder.parallel();
+/// let builder = ClIpmSolverSettingsBuilder::default()
+///     .parallel();
 /// let settings = builder.build();
 ///
 /// ```
@@ -74,6 +80,7 @@ pub struct ClIpmSolverSettingsBuilder {
     num_chunks: NonZeroUsize,
     tolerances: Tolerances,
     max_iterations: NonZeroUsize,
+    ignore_feature_requirements: bool,
 }
 
 impl Default for ClIpmSolverSettingsBuilder {
@@ -85,6 +92,7 @@ impl Default for ClIpmSolverSettingsBuilder {
             num_chunks: NonZeroUsize::new(4).unwrap(),
             tolerances: Tolerances::default(),
             max_iterations: NonZeroUsize::new(200).unwrap(),
+            ignore_feature_requirements: false,
         }
     }
 }
@@ -125,6 +133,11 @@ impl ClIpmSolverSettingsBuilder {
         self
     }
 
+    fn ignore_feature_requirements(mut self) -> Self {
+        self.ignore_feature_requirements = true;
+        self
+    }
+
     /// Construct a [`ClIpmSolverSettings`] from the builder.
     pub fn build(self) -> ClIpmSolverSettings {
         ClIpmSolverSettings {
@@ -133,6 +146,7 @@ impl ClIpmSolverSettingsBuilder {
             num_chunks: self.num_chunks,
             tolerances: self.tolerances,
             max_iterations: self.max_iterations,
+            ignore_feature_requirements: self.ignore_feature_requirements,
         }
     }
 }
@@ -151,6 +165,7 @@ mod tests {
             num_chunks: NonZeroUsize::new(4).unwrap(),
             max_iterations: NonZeroUsize::new(200).unwrap(),
             tolerances: Tolerances::default(),
+            ignore_feature_requirements: false,
         };
         let settings_from_builder = ClIpmSolverSettingsBuilder::default().parallel().build();
 

--- a/pywr-core/src/solvers/ipm_simd/settings.rs
+++ b/pywr-core/src/solvers/ipm_simd/settings.rs
@@ -16,6 +16,7 @@ where
     threads: usize,
     tolerances: Tolerances<T, N>,
     max_iterations: NonZeroUsize,
+    ignore_feature_requirements: bool,
 }
 
 // Default implementation is a convenience that defers to the builder.
@@ -40,6 +41,10 @@ where
 
     fn threads(&self) -> usize {
         self.threads
+    }
+
+    fn ignore_feature_requirements(&self) -> bool {
+        self.ignore_feature_requirements
     }
 }
 
@@ -91,6 +96,7 @@ where
     threads: usize,
     tolerances: Tolerances<T, N>,
     max_iterations: NonZeroUsize,
+    ignore_feature_requirements: bool,
 }
 
 impl<T, const N: usize> Default for SimdIpmSolverSettingsBuilder<T, N>
@@ -105,6 +111,7 @@ where
             tolerances: Tolerances::default(),
             // Unwrap is safe as the value is non-zero!
             max_iterations: NonZeroUsize::new(200).unwrap(),
+            ignore_feature_requirements: false,
         }
     }
 }
@@ -143,6 +150,12 @@ where
         self.max_iterations = max_iterations;
         self
     }
+
+    pub fn ignore_feature_requirements(mut self) -> Self {
+        self.ignore_feature_requirements = true;
+        self
+    }
+
     /// Construct a [`SimdIpmSolverSettings`] from the builder.
     pub fn build(self) -> SimdIpmSolverSettings<T, N> {
         SimdIpmSolverSettings {
@@ -150,6 +163,7 @@ where
             threads: self.threads,
             tolerances: self.tolerances,
             max_iterations: self.max_iterations,
+            ignore_feature_requirements: self.ignore_feature_requirements,
         }
     }
 }
@@ -167,6 +181,7 @@ mod tests {
             threads: 0,
             tolerances: Tolerances::default(),
             max_iterations: NonZeroUsize::new(200).unwrap(),
+            ignore_feature_requirements: false,
         };
         let settings_from_builder = SimdIpmSolverSettingsBuilder::<f64, 4>::default().parallel().build();
 

--- a/pywr-core/src/solvers/mod.rs
+++ b/pywr-core/src/solvers/mod.rs
@@ -81,6 +81,7 @@ pub enum SolverFeatures {
 pub trait SolverSettings {
     fn parallel(&self) -> bool;
     fn threads(&self) -> usize;
+    fn ignore_feature_requirements(&self) -> bool;
 }
 
 pub trait Solver: Send {

--- a/pywr-python/src/lib.rs
+++ b/pywr-python/src/lib.rs
@@ -2,20 +2,17 @@ use chrono::NaiveDateTime;
 use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyTuple, PyType};
-
 use pyo3::IntoPyObjectExt;
-/// Python API
-///
-/// The following structures provide a Python API to access the core model structures.
-///
-///
-///
-
+#[cfg(any(feature = "ipm-ocl", feature = "ipm-simd"))]
+use pywr_core::solvers::MultiStateSolver;
 #[cfg(feature = "ipm-ocl")]
 use pywr_core::solvers::{ClIpmF32Solver, ClIpmF64Solver, ClIpmSolverSettings};
-use pywr_core::solvers::{ClpSolver, ClpSolverSettings, ClpSolverSettingsBuilder};
+use pywr_core::solvers::{ClpSolver, ClpSolverSettings, ClpSolverSettingsBuilder, Solver, SolverSettings};
 #[cfg(feature = "highs")]
 use pywr_core::solvers::{HighsSolver, HighsSolverSettings, HighsSolverSettingsBuilder};
+#[cfg(feature = "ipm-simd")]
+use pywr_core::solvers::{SimdIpmF64Solver, SimdIpmSolverSettings, SimdIpmSolverSettingsBuilder};
+use pywr_core::PywrError;
 use pywr_schema::model::DateType;
 use pywr_schema::{ComponentConversionError, ConversionData, ConversionError, TryIntoV2};
 use std::fmt;
@@ -154,6 +151,41 @@ fn convert_metric_from_v1_json_string(_py: Python, data: &str) -> PyResult<Metri
     Ok(py_metric)
 }
 
+/// Run a model using the specified solver unlocking the GIL
+fn run_allowing_threads<S>(
+    py: Python<'_>,
+    model: &pywr_core::models::Model,
+    settings: &S::Settings,
+) -> Result<(), PyErr>
+where
+    S: Solver,
+    <S as Solver>::Settings: SolverSettings + Sync,
+{
+    py.allow_threads(|| {
+        let _results = model.run::<S>(settings)?;
+        Ok::<(), PywrError>(())
+    })?;
+    Ok(())
+}
+
+/// Run a model using the specified multi solver unlocking the GIL
+#[cfg(any(feature = "ipm-ocl", feature = "ipm-simd"))]
+fn run_multi_allowing_threads<S>(
+    py: Python<'_>,
+    model: &pywr_core::models::Model,
+    settings: &S::Settings,
+) -> Result<(), PyErr>
+where
+    S: MultiStateSolver,
+    <S as MultiStateSolver>::Settings: SolverSettings + Sync,
+{
+    py.allow_threads(|| {
+        let _results = model.run_multi_scenario::<S>(settings)?;
+        Ok::<(), PywrError>(())
+    })?;
+    Ok(())
+}
+
 #[pyclass]
 pub struct Model {
     model: pywr_core::models::Model,
@@ -162,25 +194,31 @@ pub struct Model {
 #[pymethods]
 impl Model {
     #[pyo3(signature = (solver_name, solver_kwargs=None))]
-    fn run(&self, solver_name: &str, solver_kwargs: Option<&Bound<'_, PyDict>>) -> PyResult<()> {
+    fn run(&self, py: Python<'_>, solver_name: &str, solver_kwargs: Option<&Bound<'_, PyDict>>) -> PyResult<()> {
         match solver_name {
             "clp" => {
                 let settings = build_clp_settings(solver_kwargs)?;
-                self.model.run::<ClpSolver>(&settings)?;
+                run_allowing_threads::<ClpSolver>(py, &self.model, &settings)?;
             }
             #[cfg(feature = "highs")]
             "highs" => {
                 let settings = build_highs_settings(solver_kwargs)?;
-                self.model.run::<HighsSolver>(&settings)?;
+                run_allowing_threads::<HighsSolver>(py, &self.model, &settings)?;
+            }
+            #[cfg(feature = "ipm-simd")]
+            "ipm-simd" => {
+                let settings = build_ipm_simd_settings(solver_kwargs)?;
+                run_multi_allowing_threads::<SimdIpmF64Solver<4>>(py, &self.model, &settings)?;
             }
             #[cfg(feature = "ipm-ocl")]
-            "clipm-f32" => self
-                .model
-                .run_multi_scenario::<ClIpmF32Solver>(&ClIpmSolverSettings::default()),
+            "clipm-f32" => {
+                run_multi_allowing_threads::<ClIpmF32Solver>(py, &self.model, &ClIpmSolverSettings::default())?
+            }
+
             #[cfg(feature = "ipm-ocl")]
-            "clipm-f64" => self
-                .model
-                .run_multi_scenario::<ClIpmF64Solver>(&ClIpmSolverSettings::default()),
+            "clipm-f64" => {
+                run_multi_allowing_threads::<ClIpmF64Solver>(py, &self.model, &ClIpmSolverSettings::default())?
+            }
             _ => return Err(PyRuntimeError::new_err(format!("Unknown solver: {}", solver_name))),
         }
 
@@ -238,6 +276,47 @@ fn build_highs_settings(kwargs: Option<&Bound<'_, PyDict>>) -> PyResult<HighsSol
                 }
             }
             kwargs.del_item("parallel")?;
+        }
+
+        if !kwargs.is_empty() {
+            return Err(PyRuntimeError::new_err(format!(
+                "Unknown keyword arguments: {:?}",
+                kwargs
+            )));
+        }
+    }
+
+    Ok(builder.build())
+}
+
+#[cfg(feature = "ipm-simd")]
+fn build_ipm_simd_settings(kwargs: Option<&Bound<'_, PyDict>>) -> PyResult<SimdIpmSolverSettings<f64, 4>> {
+    let mut builder = SimdIpmSolverSettingsBuilder::default();
+
+    if let Some(kwargs) = kwargs {
+        if let Ok(value) = kwargs.get_item("threads") {
+            if let Some(threads) = value {
+                builder = builder.threads(threads.extract::<usize>()?);
+            }
+            kwargs.del_item("threads")?;
+        }
+
+        if let Ok(value) = kwargs.get_item("parallel") {
+            if let Some(parallel) = value {
+                if parallel.extract::<bool>()? {
+                    builder = builder.parallel();
+                }
+            }
+            kwargs.del_item("parallel")?;
+        }
+
+        if let Ok(value) = kwargs.get_item("ignore_feature_requirements") {
+            if let Some(ignore) = value {
+                if ignore.extract::<bool>()? {
+                    builder = builder.ignore_feature_requirements();
+                }
+            }
+            kwargs.del_item("ignore_feature_requirements")?;
         }
 
         if !kwargs.is_empty() {

--- a/pywr-schema/src/parameters/profiles.rs
+++ b/pywr-schema/src/parameters/profiles.rs
@@ -458,12 +458,12 @@ impl From<WeeklyInterpDay> for pywr_core::parameters::WeeklyInterpDay {
 /// # Arguments
 ///
 /// * `values` - The weekly values; this can be an array of 52 or 53 values. With 52 items,
-///     the value for the 53<sup>rd</sup> week (day 364 - 29<sup>th</sup> Dec or 30<sup>th</sup>
-///     Dec for a leap year) is copied from week 52<sup>nd</sup>.
+///   the value for the 53<sup>rd</sup> week (day 364 - 29<sup>th</sup> Dec or 30<sup>th</sup>
+///   Dec for a leap year) is copied from week 52<sup>nd</sup>.
 /// * `interp_day` - This is an optional field to control the parameter interpolation. When this
-///     is not provided, the profile is piecewise. When this equals "First" or "Last", the values
-///     are linearly interpolated in each week and the string specifies whether the given values are
-///     the first or last day of the week. See the examples below for more information.
+///   is not provided, the profile is piecewise. When this equals "First" or "Last", the values
+///   are linearly interpolated in each week and the string specifies whether the given values are
+///   the first or last day of the week. See the examples below for more information.
 ///
 /// ## Interpolation notes
 /// When the profile is interpolated, the following assumptions are made for a 52-week profile due to the missing


### PR DESCRIPTION
Python extension was deadlocking because allow_threads() was not being called.

Also updates the IpmSimd solver settings to allow overriding the feature check.