### PR TITLE
feat: Use wide crate for stable SIMD support.

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -22,7 +22,7 @@ jobs:
           submodules: true
       - uses: swatinem/rust-cache@v2
       - name: Run Clippy
-        run: cargo clippy --all-targets --features highs,cbc --all --exclude ipm-simd
+        run: cargo clippy --all-targets --all-features --all
       - name: Install latest mdbook
         run: |
           tag=$(curl 'https://api.github.com/repos/rust-lang/mdbook/releases/latest' | jq -r '.tag_name')
@@ -34,13 +34,13 @@ jobs:
         with:
           tool: cargo-hack@0.5
       - name: Check (pywr-core)
-        run: cargo hack check --feature-powerset --no-dev-deps -p pywr-core --exclude-features ipm-simd,ipm-ocl
+        run: cargo hack check --feature-powerset --no-dev-deps -p pywr-core
       - name: Check (pywr-schema)
-        run: cargo hack check --feature-powerset --no-dev-deps -p pywr-schema --exclude-features ipm-simd,ipm-ocl
+        run: cargo hack check --feature-powerset --no-dev-deps -p pywr-schema
       - name: Build
-        run: cargo build --verbose --features highs,cbc --workspace --exclude ipm-simd --exclude pywr-python
+        run: cargo build --verbose --features highs,cbc,ipm-simd,ipm-ocl --workspace --exclude pywr-python
       - name: Run tests
-        run: cargo test --features highs,cbc --verbose --lib --bins -- --test-threads=1
+        run: cargo test --features highs,cbc,ipm-simd,ipm-ocl --verbose --lib --bins -- --test-threads=1
       - name: Run mdbook test & build
         run: |
           output=$(mdbook test ./pywr-book 2>&1)
@@ -52,20 +52,3 @@ jobs:
           if echo "$output" | grep -q "\[ERROR\]" ; then
               exit 1
           fi
-
-  build_nightly:
-    name: Build (nightly) w/ SIMD and OpenCL
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: true
-      - uses: dtolnay/rust-toolchain@nightly
-      - name: Install Intel OpenCL
-        run: sudo apt-get install -y intel-opencl-icd ocl-icd-opencl-dev
-      - name: Build
-        run: cargo +nightly build --verbose --features highs,cbc,ipm-simd,ipm-ocl
-      - name: Run tests (SIMD only)
-        # Run tests with SIMD only to avoid OpenCL runtime requirement on Github actions.
-        run: cargo +nightly test --features highs,cbc,ipm-simd

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -21,6 +21,8 @@ jobs:
         with:
           submodules: true
       - uses: swatinem/rust-cache@v2
+      - name: Install Intel OpenCL
+        run: sudo apt-get install -y intel-opencl-icd ocl-icd-opencl-dev
       - name: Run Clippy
         run: cargo clippy --all-targets --all-features --all
       - name: Install latest mdbook
@@ -38,9 +40,9 @@ jobs:
       - name: Check (pywr-schema)
         run: cargo hack check --feature-powerset --no-dev-deps -p pywr-schema
       - name: Build
-        run: cargo build --verbose --features highs,cbc,ipm-simd,ipm-ocl --workspace --exclude pywr-python
+        run: cargo build --verbose  --all-features --workspace --exclude pywr-python
       - name: Run tests
-        run: cargo test --features highs,cbc,ipm-simd,ipm-ocl --verbose --lib --bins -- --test-threads=1
+        run: cargo test  --all-features --verbose --lib --bins -- --test-threads=1
       - name: Run mdbook test & build
         run: |
           output=$(mdbook test ./pywr-book 2>&1)

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Build
         run: cargo build --verbose  --all-features --workspace --exclude pywr-python
       - name: Run tests
-        run: cargo test  --all-features --verbose --lib --bins -- --test-threads=1
+        run: cargo test  --features highs,cbc,ipm-simd --verbose --lib --bins -- --test-threads=1
       - name: Run mdbook test & build
         run: |
           output=$(mdbook test ./pywr-book 2>&1)

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -22,10 +22,10 @@ jobs:
           submodules: true
       - uses: swatinem/rust-cache@v2
       - name: Run Clippy
-        run: cargo clippy --all-targets --features highs,cbc
+        run: cargo clippy --all-targets --all-features
       - name: Build
-        run: cargo build --verbose --features highs,cbc --workspace --exclude ipm-simd --exclude pywr-python
+        run: cargo build --verbose --all-features --workspace --exclude pywr-python
       - name: Run tests
         # Only test the library and binaries, not the docs
         # There were some issues with the docs tests timing out on Windows CI
-        run: cargo test --features highs,cbc --verbose --lib --bins -- --test-threads=1
+        run: cargo test --all-features --verbose --lib --bins -- --test-threads=1

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -22,10 +22,10 @@ jobs:
           submodules: true
       - uses: swatinem/rust-cache@v2
       - name: Run Clippy
-        run: cargo clippy --all-targets --all-features
+        run: cargo clippy --all-targets --features highs,cbc,ipm-simd
       - name: Build
-        run: cargo build --verbose --all-features --workspace --exclude pywr-python
+        run: cargo build --verbose --features highs,cbc,ipm-simd --workspace --exclude pywr-python
       - name: Run tests
         # Only test the library and binaries, not the docs
         # There were some issues with the docs tests timing out on Windows CI
-        run: cargo test --all-features --verbose --lib --bins -- --test-threads=1
+        run: cargo test --features highs,cbc,ipm-simd --verbose --lib --bins -- --test-threads=1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -511,12 +511,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "colamd"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d154256680a4b4440234dca8f8c0ef3d22133ad7b6942c505f291e3ac61f297"
-
-[[package]]
 name = "colorchoice"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1149,10 +1143,9 @@ dependencies = [
 name = "ipm-simd"
 version = "0.1.0"
 dependencies = [
- "colamd",
  "ipm-common",
- "log",
  "nalgebra-sparse",
+ "wide",
 ]
 
 [[package]]
@@ -2573,6 +2566,7 @@ dependencies = [
  "serde",
  "thiserror 2.0.12",
  "tracing",
+ "wide",
 ]
 
 [[package]]
@@ -3686,9 +3680,9 @@ dependencies = [
 
 [[package]]
 name = "wide"
-version = "0.7.28"
+version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b828f995bf1e9622031f8009f8481a85406ce1f4d4588ff746d872043e855690"
+checksum = "41b5576b9a81633f3e8df296ce0063042a73507636cbe956c61133dd7034ab22"
 dependencies = [
  "bytemuck",
  "safe_arch",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,3 +59,4 @@ chrono = { version = "0.4", features = ["serde"] }
 schemars = { version = "0.8", features = ["chrono"] }
 rand = "0.8"
 rand_chacha = "0.3"
+wide = "0.7.32"

--- a/ipm-simd/Cargo.toml
+++ b/ipm-simd/Cargo.toml
@@ -8,5 +8,5 @@ edition = "2021"
 [dependencies]
 ipm-common = { path = "../ipm-common" }
 nalgebra-sparse = "0.10.0"
-log = "0.4.27"
-colamd = "0.1.0"
+wide = { workspace = true }
+

--- a/ipm-simd/src/common.rs
+++ b/ipm-simd/src/common.rs
@@ -66,6 +66,7 @@ pub fn vector_norm(x: &[f64x4]) -> f64x4 {
 ///
 /// `rhs = -(b - A.dot(x) - mu/y - A.dot(x * (c - At.dot(y) + mu/x)/z))`
 ///
+#[allow(clippy::too_many_arguments)]
 pub fn normal_eqn_rhs(
     a: &Matrix,  // Sparse A matrix
     at: &Matrix, // Sparse transpose of A matrix
@@ -181,6 +182,7 @@ pub fn dual_feasibility(
 ///     dz = (mu - z*dx)/x - z
 ///     dw = (mu - w*dy)/y - w
 ///
+#[allow(clippy::too_many_arguments)]
 pub fn compute_dx_dz_dw(
     at: &Matrix, // Sparse A matrix
     x: &[f64x4],

--- a/ipm-simd/src/lib.rs
+++ b/ipm-simd/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(portable_simd)]
-
 mod common;
 mod path_following_direct;
 
@@ -12,75 +10,44 @@ use path_following_direct::LDecompositionIndices;
 use path_following_direct::{LIndices, LTIndices};
 use std::f64;
 use std::fmt::Debug;
-use std::iter::Sum;
 use std::num::NonZeroUsize;
-use std::ops::{Add, AddAssign, Div, Mul, Neg, Sub};
-use std::simd::prelude::{SimdFloat, SimdPartialEq, SimdPartialOrd};
-use std::simd::{LaneCount, Mask, Simd, SimdElement, StdFloat, SupportedLaneCount};
+use wide::f64x4;
 
-struct PathData<T, const N: usize>
-where
-    LaneCount<N>: SupportedLaneCount,
-    T: SimdElement,
-{
-    x: Vec<Simd<T, N>>,
-    z: Vec<Simd<T, N>>,
-    y: Vec<Simd<T, N>>,
-    w: Vec<Simd<T, N>>,
+struct PathData {
+    x: Vec<f64x4>,
+    z: Vec<f64x4>,
+    y: Vec<f64x4>,
+    w: Vec<f64x4>,
 }
 
-impl<T, const N: usize> PathData<T, N>
-where
-    LaneCount<N>: SupportedLaneCount,
-    T: SimdElement + From<f64>,
-{
+impl PathData {
     pub fn new(num_rows: usize, num_cols: usize, num_inequality_constraints: usize) -> Self {
         Self {
-            x: (0..num_cols)
-                .into_iter()
-                .map(|_| Simd::<T, N>::splat(0.0.into()))
-                .collect(),
-            z: (0..num_cols)
-                .into_iter()
-                .map(|_| Simd::<T, N>::splat(0.0.into()))
-                .collect(),
-            y: (0..num_rows)
-                .into_iter()
-                .map(|_| Simd::<T, N>::splat(0.0.into()))
-                .collect(),
-            w: (0..num_inequality_constraints)
-                .into_iter()
-                .map(|_| Simd::<T, N>::splat(0.0.into()))
-                .collect(),
+            x: (0..num_cols).map(|_| f64x4::splat(0.0)).collect(),
+            z: (0..num_cols).map(|_| f64x4::splat(0.0)).collect(),
+            y: (0..num_rows).map(|_| f64x4::splat(0.0)).collect(),
+            w: (0..num_inequality_constraints).map(|_| f64x4::splat(0.0)).collect(),
         }
     }
 }
 
-pub struct PathFollowingDirectSimdData<T, const N: usize>
-where
-    LaneCount<N>: SupportedLaneCount,
-    T: SimdElement,
-{
-    a: Matrix<T, N>,
-    at: Matrix<T, N>,
+pub struct PathFollowingDirectSimdData {
+    a: Matrix,
+    at: Matrix,
     a_norm_ptr: ANormIndices,
     l_decomp_ptr: LDecompositionIndices,
     l_ptr: LIndices,
     lt_ptr: LTIndices,
-    l_data: Vec<Simd<T, N>>,
+    l_data: Vec<f64x4>,
 
-    path_buffers: PathData<T, N>,
-    delta_path_buffers: PathData<T, N>,
+    path_buffers: PathData,
+    delta_path_buffers: PathData,
 
-    tmp: Vec<Simd<T, N>>,
-    rhs: Vec<Simd<T, N>>,
+    tmp: Vec<f64x4>,
+    rhs: Vec<f64x4>,
 }
 
-impl<T, const N: usize> PathFollowingDirectSimdData<T, N>
-where
-    LaneCount<N>: SupportedLaneCount,
-    T: SimdElement + From<f64>,
-{
+impl PathFollowingDirectSimdData {
     pub fn from_data(a: &CsrMatrix<f64>, num_inequality_constraints: usize) -> Self {
         let num_rows = a.nrows();
         let num_cols = a.ncols();
@@ -111,23 +78,14 @@ where
         // println!("ltmap: {}", normal_indices.ltmap.len());
 
         // Require ldata for every SIMD lane
-        let l_data: Vec<Simd<T, N>> = (0..normal_indices.lindices.len())
-            .into_iter()
-            .map(|_| Simd::<T, N>::splat(0.0.into()))
-            .collect();
+        let l_data: Vec<f64x4> = (0..normal_indices.lindices.len()).map(|_| f64x4::splat(0.0)).collect();
 
         let path_buffers = PathData::new(num_rows, num_cols, num_inequality_constraints);
         let delta_path_buffers = PathData::new(num_rows, num_cols, num_inequality_constraints);
 
         // Work buffers
-        let tmp = (0..num_cols)
-            .into_iter()
-            .map(|_| Simd::<T, N>::splat(0.0.into()))
-            .collect();
-        let rhs = (0..num_rows)
-            .into_iter()
-            .map(|_| Simd::<T, N>::splat(0.0.into()))
-            .collect();
+        let tmp = (0..num_cols).map(|_| f64x4::splat(0.0)).collect();
+        let rhs = (0..num_rows).map(|_| f64x4::splat(0.0)).collect();
 
         Self {
             a: a_buffers,
@@ -146,43 +104,27 @@ where
 }
 
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct Tolerances<T, const N: usize>
-where
-    LaneCount<N>: SupportedLaneCount,
-    T: SimdElement,
-{
-    pub primal_feasibility: Simd<T, N>,
-    pub dual_feasibility: Simd<T, N>,
-    pub optimality: Simd<T, N>,
+pub struct Tolerances {
+    pub primal_feasibility: f64x4,
+    pub dual_feasibility: f64x4,
+    pub optimality: f64x4,
 }
 
-impl<T, const N: usize> Default for Tolerances<T, N>
-where
-    LaneCount<N>: SupportedLaneCount,
-    T: SimdElement + From<f64>,
-{
+impl Default for Tolerances {
     fn default() -> Self {
         Self {
-            primal_feasibility: Simd::<T, N>::splat(1e-8.into()),
-            dual_feasibility: Simd::<T, N>::splat(1e-8.into()),
-            optimality: Simd::<T, N>::splat(1e-8.into()),
+            primal_feasibility: f64x4::splat(1e-8),
+            dual_feasibility: f64x4::splat(1e-8),
+            optimality: f64x4::splat(1e-8),
         }
     }
 }
 
-pub struct PathFollowingDirectSimdSolver<T, const N: usize>
-where
-    LaneCount<N>: SupportedLaneCount,
-    T: SimdElement,
-{
-    buffers: PathFollowingDirectSimdData<T, N>,
+pub struct PathFollowingDirectSimdSolver {
+    buffers: PathFollowingDirectSimdData,
 }
 
-impl<T, const N: usize> PathFollowingDirectSimdSolver<T, N>
-where
-    LaneCount<N>: SupportedLaneCount,
-    T: SimdElement + From<f64>,
-{
+impl PathFollowingDirectSimdSolver {
     pub fn from_data(
         num_rows: usize,
         num_cols: usize,
@@ -201,26 +143,11 @@ where
 
     pub fn solve(
         &mut self,
-        b: &[Simd<T, N>],
-        c: &[Simd<T, N>],
-        tolerances: &Tolerances<T, N>,
+        b: &[f64x4],
+        c: &[f64x4],
+        tolerances: &Tolerances,
         max_iterations: NonZeroUsize,
-    ) -> &[Simd<T, N>]
-    where
-        LaneCount<N>: SupportedLaneCount,
-        T: SimdElement<Mask = i64> + From<f64> + Debug,
-        Simd<T, N>: AddAssign
-            + Sum
-            + StdFloat
-            + SimdFloat<Mask = Mask<i64, N>>
-            + SimdPartialOrd
-            + SimdPartialEq<Mask = Mask<i64, N>>
-            + Mul<Output = Simd<T, N>>
-            + Add<Output = Simd<T, N>>
-            + Sub<Output = Simd<T, N>>
-            + Div<Output = Simd<T, N>>
-            + Neg<Output = Simd<T, N>>,
-    {
+    ) -> &[f64x4] {
         normal_eqn_init(
             &mut self.buffers.path_buffers.x,
             &mut self.buffers.path_buffers.z,
@@ -228,7 +155,7 @@ where
             &mut self.buffers.path_buffers.w,
         );
 
-        let delta = Simd::<T, N>::splat(0.1.into());
+        let delta = f64x4::splat(0.1);
         let mut iter = 0;
 
         let last_iteration = loop {
@@ -247,8 +174,8 @@ where
                 &mut self.buffers.path_buffers.z,
                 &mut self.buffers.path_buffers.y,
                 &mut self.buffers.path_buffers.w,
-                &b,
-                &c,
+                b,
+                c,
                 delta,
                 &mut self.buffers.delta_path_buffers.x,
                 &mut self.buffers.delta_path_buffers.z,

--- a/ipm-simd/src/path_following_direct.rs
+++ b/ipm-simd/src/path_following_direct.rs
@@ -71,6 +71,7 @@ impl LTIndices {
 }
 
 /// Compute the Cholesky decomposition of the normal matrix
+#[allow(clippy::too_many_arguments)]
 pub fn normal_matrix_cholesky_decomposition(
     a: &Matrix,
     a_norm_ptr: &ANormIndices,
@@ -165,6 +166,7 @@ fn cholesky_solve(a_size: usize, l_ptr: &LIndices, lt_ptr: &LTIndices, l_data: &
 }
 
 /// Perform a single step of the path-following algorithm.
+#[allow(clippy::too_many_arguments)]
 pub fn normal_eqn_step(
     a: &Matrix,  // Sparse A matrix
     at: &Matrix, // Sparse transpose of A matrix

--- a/ipm-simd/src/path_following_direct.rs
+++ b/ipm-simd/src/path_following_direct.rs
@@ -2,10 +2,7 @@ use super::{dual_feasibility, primal_feasibility, Matrix};
 use crate::common::{compute_dx_dz_dw, dot_product, normal_eqn_rhs, vector_norm, vector_set, vector_update};
 use crate::Tolerances;
 use ipm_common::SparseNormalCholeskyIndices;
-use std::iter::Sum;
-use std::ops::{Add, AddAssign, Div, Mul, Neg, Sub};
-use std::simd::prelude::{SimdFloat, SimdPartialEq, SimdPartialOrd};
-use std::simd::{LaneCount, Mask, Simd, SimdElement, StdFloat, SupportedLaneCount};
+use wide::{f64x4, CmpLt};
 
 pub struct ANormIndices {
     indptr: Vec<usize>,
@@ -74,29 +71,17 @@ impl LTIndices {
 }
 
 /// Compute the Cholesky decomposition of the normal matrix
-pub fn normal_matrix_cholesky_decomposition<T, const N: usize>(
-    a: &Matrix<T, N>,
+pub fn normal_matrix_cholesky_decomposition(
+    a: &Matrix,
     a_norm_ptr: &ANormIndices,
     l_decomp_ptr: &LDecompositionIndices,
-    x: &[Simd<T, N>],
-    z: &[Simd<T, N>],
-    y: &[Simd<T, N>],
-    w: &[Simd<T, N>],
+    x: &[f64x4],
+    z: &[f64x4],
+    y: &[f64x4],
+    w: &[f64x4],
     l_ptr: &LIndices,
-    l_data: &mut [Simd<T, N>],
-) where
-    LaneCount<N>: SupportedLaneCount,
-    T: SimdElement + From<f64>,
-    Simd<T, N>: AddAssign
-        + Sum
-        + StdFloat
-        + SimdFloat
-        + Mul<Output = Simd<T, N>>
-        + Add<Output = Simd<T, N>>
-        + Sub<Output = Simd<T, N>>
-        + Div<Output = Simd<T, N>>
-        + Neg<Output = Simd<T, N>>,
-{
+    l_data: &mut [f64x4],
+) {
     let mut l_entry = 0;
     for row in 0..a.size {
         let row_ind_start = l_ptr.indptr[row];
@@ -110,7 +95,7 @@ pub fn normal_matrix_cholesky_decomposition<T, const N: usize>(
             let mut val = if (row == col) && (row < w.len()) {
                 w[row] / y[row]
             } else {
-                Simd::<T, N>::splat(0.0.into())
+                f64x4::splat(0.0)
             };
 
             let ind_start = a_norm_ptr.indptr[l_entry];
@@ -131,7 +116,7 @@ pub fn normal_matrix_cholesky_decomposition<T, const N: usize>(
             if row == col {
                 val = val.abs().sqrt();
             } else {
-                val = val / l_data[l_ptr.diag_indptr[col]];
+                val /= l_data[l_ptr.diag_indptr[col]];
             }
             l_data[l_entry] = val;
             l_entry += 1;
@@ -144,26 +129,7 @@ pub fn normal_matrix_cholesky_decomposition<T, const N: usize>(
 /// L is a lower triangular matrix. Entries are stored such that the lth
 /// entry of L is the i(i + 1)/2 + j entry in dense i, j  coordinates.
 ///
-fn cholesky_solve<T, const N: usize>(
-    a_size: usize,
-    l_ptr: &LIndices,
-    lt_ptr: &LTIndices,
-    l_data: &[Simd<T, N>],
-    b: &[Simd<T, N>],
-    x: &mut [Simd<T, N>],
-) where
-    LaneCount<N>: SupportedLaneCount,
-    T: SimdElement + From<f64>,
-    Simd<T, N>: AddAssign
-        + Sum
-        + StdFloat
-        + SimdFloat
-        + Mul<Output = Simd<T, N>>
-        + Add<Output = Simd<T, N>>
-        + Sub<Output = Simd<T, N>>
-        + Div<Output = Simd<T, N>>
-        + Neg<Output = Simd<T, N>>,
-{
+fn cholesky_solve(a_size: usize, l_ptr: &LIndices, lt_ptr: &LTIndices, l_data: &[f64x4], b: &[f64x4], x: &mut [f64x4]) {
     // Forward substitution
     for i in 0..a_size {
         x[i] = b[i];
@@ -199,44 +165,29 @@ fn cholesky_solve<T, const N: usize>(
 }
 
 /// Perform a single step of the path-following algorithm.
-pub fn normal_eqn_step<T, const N: usize>(
-    a: &Matrix<T, N>,  // Sparse A matrix
-    at: &Matrix<T, N>, // Sparse transpose of A matrix
+pub fn normal_eqn_step(
+    a: &Matrix,  // Sparse A matrix
+    at: &Matrix, // Sparse transpose of A matrix
     a_norm_ptr: &ANormIndices,
     l_decomp_ptr: &LDecompositionIndices,
     l_ptr: &LIndices,
     lt_ptr: &LTIndices,
-    l_data: &mut [Simd<T, N>],
-    x: &mut [Simd<T, N>],
-    z: &mut [Simd<T, N>],
-    y: &mut [Simd<T, N>],
-    w: &mut [Simd<T, N>],
-    b: &[Simd<T, N>],
-    c: &[Simd<T, N>],
-    delta: Simd<T, N>,
-    dx: &mut [Simd<T, N>],
-    dz: &mut [Simd<T, N>],
-    dy: &mut [Simd<T, N>],
-    dw: &mut [Simd<T, N>],
-    tmp: &mut [Simd<T, N>],
-    tmp2: &mut [Simd<T, N>],
-    tolerances: &Tolerances<T, N>,
-) -> Mask<i64, N>
-where
-    LaneCount<N>: SupportedLaneCount,
-    T: SimdElement<Mask = i64> + From<f64>,
-    Simd<T, N>: AddAssign
-        + Sum
-        + StdFloat
-        + SimdFloat<Mask = Mask<i64, N>>
-        + SimdPartialOrd
-        + SimdPartialEq<Mask = Mask<i64, N>>
-        + Mul<Output = Simd<T, N>>
-        + Add<Output = Simd<T, N>>
-        + Sub<Output = Simd<T, N>>
-        + Div<Output = Simd<T, N>>
-        + Neg<Output = Simd<T, N>>,
-{
+    l_data: &mut [f64x4],
+    x: &mut [f64x4],
+    z: &mut [f64x4],
+    y: &mut [f64x4],
+    w: &mut [f64x4],
+    b: &[f64x4],
+    c: &[f64x4],
+    delta: f64x4,
+    dx: &mut [f64x4],
+    dz: &mut [f64x4],
+    dy: &mut [f64x4],
+    dw: &mut [f64x4],
+    tmp: &mut [f64x4],
+    tmp2: &mut [f64x4],
+    tolerances: &Tolerances,
+) -> f64x4 {
     // printf("%d %d", gid, wsize);
 
     // Compute feasibilities
@@ -246,11 +197,11 @@ where
     // Compute optimality
     let mut gamma = dot_product(z, x) + dot_product(w, y);
 
-    let mu = delta * gamma / Simd::<T, N>::splat(((at.size + w.len()) as f64).into());
+    let mu = delta * gamma / (at.size + w.len()) as f64;
     // update relative tolerance
-    gamma = gamma / (Simd::<T, N>::splat(1.0.into()) + vector_norm(x) + vector_norm(y));
+    gamma /= 1.0 + vector_norm(x) + vector_norm(y);
 
-    let is_nan: Mask<i64, N> = gamma.is_nan();
+    let is_nan = gamma.is_nan();
     if is_nan.any() {
         panic!("NaN encountered during IPM solve!")
     }
@@ -261,9 +212,9 @@ where
     // }
     // #endif
 
-    let status: Mask<i64, N> = normr.simd_lt(tolerances.primal_feasibility)
-        & norms.simd_lt(tolerances.dual_feasibility)
-        & gamma.simd_lt(tolerances.optimality);
+    let status = normr.cmp_lt(tolerances.primal_feasibility)
+        & norms.cmp_lt(tolerances.dual_feasibility)
+        & gamma.cmp_lt(tolerances.optimality);
 
     if status.all() {
         // Feasible and optimal; no further work!
@@ -290,34 +241,26 @@ where
     // println!("dx: {:?}, dz: {:?}, dy: {:?}, dw: {:?}", dx, dz, dy, dw);
     // println!("Theta: {:?}", theta);
 
-    theta = (Simd::<T, N>::splat(0.9995.into()) / theta).simd_min(Simd::<T, N>::splat(1.0.into()));
+    theta = (0.9995 / theta).min(f64x4::splat(1.0));
     // if (gid == 0) {
     //     printf("%d theta: %g", gid, theta);
     // }
 
     // println!("Theta: {:?}", theta);
     // Set theta to zero for lanes that have completed (status == True)
-    theta = status.select(Simd::<T, N>::splat(0.0.into()), theta);
+    theta = status.blend(f64x4::splat(0.0), theta);
 
-    vector_update(x, dx, Simd::<T, N>::splat(1.0.into()), theta);
-    vector_update(z, dz, Simd::<T, N>::splat(1.0.into()), theta);
-    vector_update(y, dy, Simd::<T, N>::splat(1.0.into()), theta);
-    vector_update(w, dw, Simd::<T, N>::splat(1.0.into()), theta);
+    vector_update(x, dx, f64x4::splat(1.0), theta);
+    vector_update(z, dz, f64x4::splat(1.0), theta);
+    vector_update(y, dy, f64x4::splat(1.0), theta);
+    vector_update(w, dw, f64x4::splat(1.0), theta);
 
-    return status;
+    status
 }
 
-pub fn normal_eqn_init<T, const N: usize>(
-    x: &mut [Simd<T, N>],
-    z: &mut [Simd<T, N>],
-    y: &mut [Simd<T, N>],
-    w: &mut [Simd<T, N>],
-) where
-    LaneCount<N>: SupportedLaneCount,
-    T: SimdElement + From<f64>,
-{
-    vector_set(x, Simd::<T, N>::splat(1000.0.into()));
-    vector_set(z, Simd::<T, N>::splat(1000.0.into()));
-    vector_set(y, Simd::<T, N>::splat(1000.0.into()));
-    vector_set(w, Simd::<T, N>::splat(1000.0.into()));
+pub fn normal_eqn_init(x: &mut [f64x4], z: &mut [f64x4], y: &mut [f64x4], w: &mut [f64x4]) {
+    vector_set(x, f64x4::splat(1000.0));
+    vector_set(z, f64x4::splat(1000.0));
+    vector_set(y, f64x4::splat(1000.0));
+    vector_set(w, f64x4::splat(1000.0));
 }

--- a/pywr-cli/src/main.rs
+++ b/pywr-cli/src/main.rs
@@ -354,7 +354,7 @@ fn run(
             }
 
             let settings = settings_builder.build();
-            model.run_multi_scenario::<SimdIpmF64Solver<4>>(&settings)
+            model.run_multi_scenario::<SimdIpmF64Solver>(&settings)
         }
     }
     .unwrap();
@@ -379,7 +379,7 @@ fn run_multi(path: &Path, solver: &Solver, data_path: Option<&Path>, output_path
         #[cfg(feature = "ipm-ocl")]
         Solver::CLIPMF64 => model.run_multi_scenario::<ClIpmF64Solver>(&ClIpmSolverSettings::default()),
         #[cfg(feature = "ipm-simd")]
-        Solver::IpmSimd => model.run_multi_scenario::<SimdIpmF64Solver<4>>(&SimdIpmSolverSettings::default()),
+        Solver::IpmSimd => model.run_multi_scenario::<SimdIpmF64Solver>(&SimdIpmSolverSettings::default()),
     }
     .unwrap();
 }
@@ -399,7 +399,7 @@ fn run_random(num_systems: usize, density: usize, num_scenarios: usize, solver: 
         #[cfg(feature = "ipm-ocl")]
         Solver::CLIPMF64 => model.run_multi_scenario::<ClIpmF64Solver>(&ClIpmSolverSettings::default()),
         #[cfg(feature = "ipm-simd")]
-        Solver::IpmSimd => model.run_multi_scenario::<SimdIpmF64Solver<4>>(&SimdIpmSolverSettings::default()),
+        Solver::IpmSimd => model.run_multi_scenario::<SimdIpmF64Solver>(&SimdIpmSolverSettings::default()),
     }
     .unwrap();
 }

--- a/pywr-core/Cargo.toml
+++ b/pywr-core/Cargo.toml
@@ -36,6 +36,7 @@ rand = { workspace = true }
 rand_distr = "0.4"
 rand_chacha = { workspace = true }
 serde = { version = "1.0", features = ["derive"] }
+wide = { workspace = true, optional = true }
 
 [dev-dependencies]
 criterion = "0.5"
@@ -44,7 +45,7 @@ criterion = "0.5"
 cbc = []
 highs = ["dep:highs-sys"]
 ipm-ocl = ["dep:ipm-ocl", "dep:ocl"]
-ipm-simd = ["dep:ipm-simd"]
+ipm-simd = ["dep:ipm-simd", "dep:wide"]
 default = ["pyo3"]
 pyo3 = ["dep:pyo3"]
 

--- a/pywr-core/benches/random_models.rs
+++ b/pywr-core/benches/random_models.rs
@@ -93,10 +93,10 @@ fn random_benchmark(
                                 |b, _n| {
                                     // Do the setup here outside of the time-step loop
                                     let mut state = model
-                                        .setup_multi_scenario::<SimdIpmF64Solver>(&settings)
+                                        .setup_multi_scenario::<SimdIpmF64Solver>(settings)
                                         .expect("Failed to setup the model.");
 
-                                    b.iter(|| model.run_multi_scenario_with_state(&mut state, &settings))
+                                    b.iter(|| model.run_multi_scenario_with_state(&mut state, settings))
                                 },
                             );
                         }
@@ -111,10 +111,10 @@ fn random_benchmark(
                                 |b, _n| {
                                     // Do the setup here outside of the time-step loop
                                     let mut state = model
-                                        .setup_multi_scenario::<ClIpmF64Solver>(&settings)
+                                        .setup_multi_scenario::<ClIpmF64Solver>(settings)
                                         .expect("Failed to setup the model.");
 
-                                    b.iter(|| model.run_multi_scenario_with_state(&mut state, &settings))
+                                    b.iter(|| model.run_multi_scenario_with_state(&mut state, settings))
                                 },
                             );
                         }

--- a/pywr-core/benches/random_models.rs
+++ b/pywr-core/benches/random_models.rs
@@ -83,41 +83,6 @@ fn random_benchmark(
                             );
                         }
                         #[cfg(feature = "ipm-simd")]
-                        SolverSetting::IpmSimdF64x1(settings) => {
-                            let parameter_string =
-                                format!("ipm-simd-f64x1 * {n_sys} * {density} * {n_sc} * {}", &setup.name);
-
-                            group.bench_with_input(
-                                BenchmarkId::new("random-model", parameter_string),
-                                &(n_sys, density, n_sc),
-                                |b, _n| {
-                                    let mut state = model
-                                        .setup_multi_scenario::<SimdIpmF64Solver<1>>(&settings)
-                                        .expect("Failed to setup the model.");
-
-                                    b.iter(|| model.run_multi_scenario_with_state(&mut state, &settings))
-                                },
-                            );
-                        }
-                        #[cfg(feature = "ipm-simd")]
-                        SolverSetting::IpmSimdF64x2(settings) => {
-                            let parameter_string =
-                                format!("ipm-simd-f64x2 * {n_sys} * {density} * {n_sc} * {}", &setup.name);
-
-                            group.bench_with_input(
-                                BenchmarkId::new("random-model", parameter_string),
-                                &(n_sys, density, n_sc),
-                                |b, _n| {
-                                    // Do the setup here outside of the time-step loop
-                                    let mut state = model
-                                        .setup_multi_scenario::<SimdIpmF64Solver<2>>(&settings)
-                                        .expect("Failed to setup the model.");
-
-                                    b.iter(|| model.run_multi_scenario_with_state(&mut state, &settings))
-                                },
-                            );
-                        }
-                        #[cfg(feature = "ipm-simd")]
                         SolverSetting::IpmSimdF64x4(settings) => {
                             let parameter_string =
                                 format!("ipm-simd-f64x4 * {n_sys} * {density} * {n_sc} * {}", &setup.name);
@@ -128,7 +93,7 @@ fn random_benchmark(
                                 |b, _n| {
                                     // Do the setup here outside of the time-step loop
                                     let mut state = model
-                                        .setup_multi_scenario::<SimdIpmF64Solver<4>>(&settings)
+                                        .setup_multi_scenario::<SimdIpmF64Solver>(&settings)
                                         .expect("Failed to setup the model.");
 
                                     b.iter(|| model.run_multi_scenario_with_state(&mut state, &settings))
@@ -167,11 +132,7 @@ enum SolverSetting {
     #[cfg(feature = "highs")]
     Highs(HighsSolverSettings),
     #[cfg(feature = "ipm-simd")]
-    IpmSimdF64x1(SimdIpmSolverSettings<f64, 1>),
-    #[cfg(feature = "ipm-simd")]
-    IpmSimdF64x2(SimdIpmSolverSettings<f64, 2>),
-    #[cfg(feature = "ipm-simd")]
-    IpmSimdF64x4(SimdIpmSolverSettings<f64, 4>),
+    IpmSimdF64x4(SimdIpmSolverSettings),
     #[cfg(feature = "ipm-ocl")]
     IpmOcl(ClIpmSolverSettings),
 }
@@ -190,16 +151,6 @@ fn default_solver_setups() -> Vec<SolverSetup> {
         },
         SolverSetup {
             setting: SolverSetting::Clp(ClpSolverSettings::default()),
-            name: "default".to_string(),
-        },
-        #[cfg(feature = "ipm-simd")]
-        SolverSetup {
-            setting: SolverSetting::IpmSimdF64x1(SimdIpmSolverSettings::default()),
-            name: "default".to_string(),
-        },
-        #[cfg(feature = "ipm-simd")]
-        SolverSetup {
-            setting: SolverSetting::IpmSimdF64x2(SimdIpmSolverSettings::default()),
             name: "default".to_string(),
         },
         #[cfg(feature = "ipm-simd")]
@@ -252,27 +203,6 @@ fn bench_threads(c: &mut Criterion) {
         solver_setups.push(SolverSetup {
             setting: SolverSetting::Clp(
                 ClpSolverSettingsBuilder::default()
-                    .parallel()
-                    .threads(n_threads)
-                    .build(),
-            ),
-            name: format!("threads-{}", n_threads),
-        });
-
-        #[cfg(feature = "ipm-simd")]
-        solver_setups.push(SolverSetup {
-            setting: SolverSetting::IpmSimdF64x1(
-                SimdIpmSolverSettingsBuilder::default()
-                    .parallel()
-                    .threads(n_threads)
-                    .build(),
-            ),
-            name: format!("threads-{}", n_threads),
-        });
-        #[cfg(feature = "ipm-simd")]
-        solver_setups.push(SolverSetup {
-            setting: SolverSetting::IpmSimdF64x2(
-                SimdIpmSolverSettingsBuilder::default()
                     .parallel()
                     .threads(n_threads)
                     .build(),
@@ -406,26 +336,6 @@ fn bench_hyper_scenarios(c: &mut Criterion) {
         SolverSetup {
             setting: SolverSetting::Clp(
                 ClpSolverSettingsBuilder::default()
-                    .parallel()
-                    .threads(N_THREADS)
-                    .build(),
-            ),
-            name: "default".to_string(),
-        },
-        #[cfg(feature = "ipm-simd")]
-        SolverSetup {
-            setting: SolverSetting::IpmSimdF64x1(
-                SimdIpmSolverSettingsBuilder::default()
-                    .parallel()
-                    .threads(N_THREADS)
-                    .build(),
-            ),
-            name: "default".to_string(),
-        },
-        #[cfg(feature = "ipm-simd")]
-        SolverSetup {
-            setting: SolverSetting::IpmSimdF64x2(
-                SimdIpmSolverSettingsBuilder::default()
                     .parallel()
                     .threads(N_THREADS)
                     .build(),

--- a/pywr-core/src/lib.rs
+++ b/pywr-core/src/lib.rs
@@ -1,4 +1,3 @@
-#![cfg_attr(feature = "ipm-simd", feature(portable_simd))]
 // Requires upgrading to PyO3 v0.23 which is blocked by updating Polars
 // See also: https://github.com/PyO3/pyo3/issues/4743
 #![allow(unexpected_cfgs)]

--- a/pywr-core/src/solvers/ipm_ocl/mod.rs
+++ b/pywr-core/src/solvers/ipm_ocl/mod.rs
@@ -307,7 +307,7 @@ impl BuiltSolver {
             let cost = states
                 .iter()
                 .map(|s| {
-                    edge.cost(&network.nodes(), network, s)
+                    edge.cost(network.nodes(), network, s)
                         .map(|c| if c != 0.0 { -c } else { 0.0 })
                 })
                 .collect::<Result<Vec<f64>, _>>()?;

--- a/pywr-core/src/solvers/ipm_simd/mod.rs
+++ b/pywr-core/src/solvers/ipm_simd/mod.rs
@@ -64,7 +64,7 @@ struct Lp {
 impl Lp {
     /// Zero all objective coefficients.
     fn zero_obj_coefficients(&mut self) {
-        self.col_obj_coef.fill(f64x4::splat(0.0.into()));
+        self.col_obj_coef.fill(f64x4::splat(0.0));
     }
 
     pub fn add_obj_coefficient(&mut self, col: usize, obj_coef: &[f64]) {
@@ -320,7 +320,7 @@ impl BuiltSolver {
             let cost = states
                 .iter()
                 .map(|s| {
-                    edge.cost(&network.nodes(), network, s)
+                    edge.cost(network.nodes(), network, s)
                         .map(|c| if c != 0.0 { -c } else { 0.0 })
                 })
                 .collect::<Result<Vec<f64>, _>>()?;

--- a/pywr-core/src/solvers/ipm_simd/mod.rs
+++ b/pywr-core/src/solvers/ipm_simd/mod.rs
@@ -16,9 +16,8 @@ pub use settings::{SimdIpmSolverSettings, SimdIpmSolverSettingsBuilder};
 use std::collections::BTreeMap;
 use std::num::NonZeroUsize;
 use std::ops::Deref;
-use std::simd::prelude::SimdFloat;
-use std::simd::{LaneCount, Simd, SupportedLaneCount};
 use std::time::Instant;
+use wide::f64x4;
 
 const B_MAX: f64 = 999999.0;
 
@@ -54,38 +53,32 @@ impl Matrix {
     }
 }
 
-struct Lp<const N: usize>
-where
-    LaneCount<N>: SupportedLaneCount,
-{
+struct Lp {
     inequality: Matrix,
     equality: Matrix,
     num_cols: usize,
-    row_upper: Vec<Simd<f64, N>>,
-    col_obj_coef: Vec<Simd<f64, N>>,
+    row_upper: Vec<f64x4>,
+    col_obj_coef: Vec<f64x4>,
 }
 
-impl<const N: usize> Lp<N>
-where
-    LaneCount<N>: SupportedLaneCount,
-{
+impl Lp {
     /// Zero all objective coefficients.
     fn zero_obj_coefficients(&mut self) {
-        self.col_obj_coef.fill(Simd::<f64, N>::splat(0.0.into()));
+        self.col_obj_coef.fill(f64x4::splat(0.0.into()));
     }
 
     pub fn add_obj_coefficient(&mut self, col: usize, obj_coef: &[f64]) {
         let value = if obj_coef.is_empty() {
             panic!("Row bound vector is empty!")
-        } else if obj_coef.len() > N {
+        } else if obj_coef.len() > 4 {
             panic!("Row bound vector is larger than the number of SIMD lanes.")
-        } else if obj_coef.len() == N {
-            Simd::<f64, N>::from_slice(obj_coef)
+        } else if obj_coef.len() == 4 {
+            f64x4::from(obj_coef)
         } else {
             // Pad the last entry to ensure it is the full width
-            let pad: Vec<_> = (0..N - obj_coef.len()).map(|_| *obj_coef.last().unwrap()).collect();
+            let pad: Vec<_> = (0..4 - obj_coef.len()).map(|_| *obj_coef.last().unwrap()).collect();
             let values = [obj_coef, &pad].concat();
-            Simd::<f64, N>::from_slice(values.as_slice())
+            f64x4::from(values.as_slice())
         };
 
         self.col_obj_coef[col] += value;
@@ -94,25 +87,25 @@ where
     /// Reset the row bounds to `FMIN` and `FMAX` for all rows with a mask.
     fn reset_row_bounds(&mut self) {
         for ub in self.row_upper.iter_mut().take(self.inequality.nrows()) {
-            *ub = Simd::<f64, N>::splat(B_MAX)
+            *ub = f64x4::splat(B_MAX)
         }
     }
 
     pub fn apply_row_bounds(&mut self, row: usize, ub: &[f64]) {
         let value = if ub.is_empty() {
             panic!("Row bound vector is empty!")
-        } else if ub.len() > N {
+        } else if ub.len() > 4 {
             panic!("Row bound vector is larger than the number of SIMD lanes.")
-        } else if ub.len() == N {
-            Simd::<f64, N>::from_slice(ub)
+        } else if ub.len() == 4 {
+            f64x4::from(ub)
         } else {
             // Pad the last entry to ensure it is the full width
-            let pad: Vec<_> = (0..N - ub.len()).map(|_| *ub.last().unwrap()).collect();
+            let pad: Vec<_> = (0..4 - ub.len()).map(|_| *ub.last().unwrap()).collect();
             let values = [ub, &pad].concat();
-            Simd::<f64, N>::from_slice(values.as_slice())
+            f64x4::from(values.as_slice())
         };
 
-        self.row_upper[row] = self.row_upper[row].simd_min(value);
+        self.row_upper[row] = self.row_upper[row].min(value);
     }
 
     fn get_full_matrix(&self) -> Matrix {
@@ -184,19 +177,16 @@ impl LpBuilder {
     }
 
     /// Build the LP into a final sparse form
-    fn build<const N: usize>(self) -> Lp<N>
-    where
-        LaneCount<N>: SupportedLaneCount,
-    {
+    fn build(self) -> Lp {
         let num_rows = self.equality.len() + self.inequality.len();
 
         // By using chunks we make sure any scenarios that do not divide in to the number
         // of lanes are padded at the end.
         // let row_range: Vec<_> = (0..num_rows).collect();
-        let row_upper = (0..num_rows).map(|_| Simd::<f64, N>::splat(0.0)).collect();
+        let row_upper = (0..num_rows).map(|_| f64x4::splat(0.0)).collect();
 
         // let col_range: Vec<_> = (0..self.num_cols).collect();
-        let col_obj_coef = (0..self.num_cols).map(|_| Simd::<f64, N>::splat(0.0)).collect();
+        let col_obj_coef = (0..self.num_cols).map(|_| f64x4::splat(0.0)).collect();
 
         // println!("Number of columns: {}", self.num_cols);
         // println!("Number of rows: {num_rows}");
@@ -282,24 +272,18 @@ impl RowBuilder {
     }
 }
 
-struct BuiltSolver<const N: usize>
-where
-    LaneCount<N>: SupportedLaneCount,
-{
-    lp: Lp<N>,
+struct BuiltSolver {
+    lp: Lp,
     col_edge_map: ColumnEdgeMap<usize>,
     node_constraints_row_ids: Vec<usize>,
 }
 
-impl<const N: usize> BuiltSolver<N>
-where
-    LaneCount<N>: SupportedLaneCount,
-{
-    pub fn col_obj_coef(&self) -> &[Simd<f64, N>] {
+impl BuiltSolver {
+    pub fn col_obj_coef(&self) -> &[f64x4] {
         &self.lp.col_obj_coef
     }
 
-    pub fn row_upper(&self) -> &[Simd<f64, N>] {
+    pub fn row_upper(&self) -> &[f64x4] {
         &self.lp.row_upper
     }
 
@@ -422,10 +406,7 @@ impl SolverBuilder {
         self.col_edge_map.col_for_edge(edge_index)
     }
 
-    fn create<const N: usize>(mut self, network: &Network) -> Result<BuiltSolver<N>, PywrError>
-    where
-        LaneCount<N>: SupportedLaneCount,
-    {
+    fn create(mut self, network: &Network) -> Result<BuiltSolver, PywrError> {
         // Create the columns
         self.create_columns(network)?;
 
@@ -595,21 +576,15 @@ impl SolverBuilder {
     }
 }
 
-pub struct SimdIpmF64Solver<const N: usize>
-where
-    LaneCount<N>: SupportedLaneCount,
-{
-    built: Vec<BuiltSolver<N>>,
-    ipm: Vec<PathFollowingDirectSimdSolver<f64, N>>,
-    tolerances: Tolerances<f64, N>,
+pub struct SimdIpmF64Solver {
+    built: Vec<BuiltSolver>,
+    ipm: Vec<PathFollowingDirectSimdSolver>,
+    tolerances: Tolerances,
     max_iterations: NonZeroUsize,
 }
 
-impl<const N: usize> MultiStateSolver for SimdIpmF64Solver<N>
-where
-    LaneCount<N>: SupportedLaneCount,
-{
-    type Settings = SimdIpmSolverSettings<f64, N>;
+impl MultiStateSolver for SimdIpmF64Solver {
+    type Settings = SimdIpmSolverSettings;
 
     fn name() -> &'static str {
         "ipm-simd"
@@ -623,7 +598,7 @@ where
         let mut built_solvers = Vec::new();
         let mut ipms = Vec::new();
 
-        for _ in (0..num_scenarios).collect::<Vec<_>>().chunks(N) {
+        for _ in (0..num_scenarios).collect::<Vec<_>>().chunks(4) {
             let builder = SolverBuilder::new();
             let built = builder.create(network)?;
 
@@ -663,7 +638,7 @@ where
 
         // TODO this will miss off anything that doesn't divide in to 4
         states
-            .par_chunks_mut(N)
+            .par_chunks_mut(4)
             .zip(&mut self.built)
             .zip(&mut self.ipm)
             .for_each(|((chunk_states, built), ipm)| {
@@ -693,7 +668,7 @@ where
                     let col = built.col_for_edge(&edge.index());
                     let flows = solution[col];
 
-                    for (state, flow) in chunk_states.iter_mut().zip(flows.as_array()) {
+                    for (state, flow) in chunk_states.iter_mut().zip(flows.as_array_ref()) {
                         if !flow.is_finite() {
                             panic!(
                                 "Non-finite flow encountered from solver. Edge: {:#?}, value: {}",

--- a/pywr-core/src/solvers/ipm_simd/settings.rs
+++ b/pywr-core/src/solvers/ipm_simd/settings.rs
@@ -104,17 +104,17 @@ impl SimdIpmSolverSettingsBuilder {
     }
 
     pub fn primal_feasibility(mut self, tolerance: f64) -> Self {
-        self.tolerances.primal_feasibility = f64x4::splat(tolerance.into());
+        self.tolerances.primal_feasibility = f64x4::splat(tolerance);
         self
     }
 
     pub fn dual_feasibility(mut self, tolerance: f64) -> Self {
-        self.tolerances.dual_feasibility = f64x4::splat(tolerance.into());
+        self.tolerances.dual_feasibility = f64x4::splat(tolerance);
         self
     }
 
     pub fn optimality(mut self, tolerance: f64) -> Self {
-        self.tolerances.optimality = f64x4::splat(tolerance.into());
+        self.tolerances.optimality = f64x4::splat(tolerance);
         self
     }
 

--- a/pywr-core/src/test_utils.rs
+++ b/pywr-core/src/test_utils.rs
@@ -229,7 +229,7 @@ pub fn run_all_solvers(
     #[cfg(feature = "ipm-simd")]
     {
         if !solvers_to_skip.contains(&"ipm-simd") {
-            check_features_and_run_multi::<SimdIpmF64Solver<4>>(model, !solvers_without_features.contains(&"ipm-simd"));
+            check_features_and_run_multi::<SimdIpmF64Solver>(model, !solvers_without_features.contains(&"ipm-simd"));
         }
     }
 
@@ -455,7 +455,7 @@ mod tests {
 
         let settings = SimdIpmSolverSettings::default();
         model
-            .run_multi_scenario::<SimdIpmF64Solver<4>>(&settings)
+            .run_multi_scenario::<SimdIpmF64Solver>(&settings)
             .expect("Failed to run model!");
     }
 }

--- a/pywr-core/src/test_utils.rs
+++ b/pywr-core/src/test_utils.rs
@@ -287,7 +287,7 @@ where
         );
         model
             .run_multi_scenario::<S>(&Default::default())
-            .expect(&format!("Failed to solve with: {}", S::name()));
+            .unwrap_or_else(|_| panic!("Failed to solve with: {}", S::name()));
     } else {
         assert!(
             !has_features,

--- a/pywr-python/src/lib.rs
+++ b/pywr-python/src/lib.rs
@@ -208,7 +208,7 @@ impl Model {
             #[cfg(feature = "ipm-simd")]
             "ipm-simd" => {
                 let settings = build_ipm_simd_settings(solver_kwargs)?;
-                run_multi_allowing_threads::<SimdIpmF64Solver<4>>(py, &self.model, &settings)?;
+                run_multi_allowing_threads::<SimdIpmF64Solver>(py, &self.model, &settings)?;
             }
             #[cfg(feature = "ipm-ocl")]
             "clipm-f32" => {
@@ -290,7 +290,7 @@ fn build_highs_settings(kwargs: Option<&Bound<'_, PyDict>>) -> PyResult<HighsSol
 }
 
 #[cfg(feature = "ipm-simd")]
-fn build_ipm_simd_settings(kwargs: Option<&Bound<'_, PyDict>>) -> PyResult<SimdIpmSolverSettings<f64, 4>> {
+fn build_ipm_simd_settings(kwargs: Option<&Bound<'_, PyDict>>) -> PyResult<SimdIpmSolverSettings> {
     let mut builder = SimdIpmSolverSettingsBuilder::default();
 
     if let Some(kwargs) = kwargs {

--- a/pywr-schema/tests/test_models.rs
+++ b/pywr-schema/tests/test_models.rs
@@ -71,12 +71,13 @@ model_tests! {
 
 /// Test Pandas backend for reading timeseries data.
 ///
-/// This test requires Python environment with Pandas#[test]
+/// This test requires Python environment with Pandas
+#[test]
 #[cfg(feature = "test-python")]
 fn test_timeseries_pandas() {
     let input = "timeseries_pandas.json";
     let input_pth = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests").join(input);
-    let expected = vec!["timeseries-expected.csv"];
+    let expected = ["timeseries-expected.csv"];
     let expected_paths = expected
         .iter()
         .map(|p| Path::new(env!("CARGO_MANIFEST_DIR")).join("tests").join(p))


### PR DESCRIPTION
This removes the need for the nightly Rust compiler to use the IPM SIMD solver. This is achieved, with safe code, by using the `wide` crate. However, it does mean that the solver is now not generic with regard the SIMD type and number of lanes. Instead it is now hard-coded to be f64x4.