### PR TITLE
feat: Add RollingParameter.

### DIFF
--- a/pywr-core/src/aggregated_node.rs
+++ b/pywr-core/src/aggregated_node.rs
@@ -582,7 +582,7 @@ mod tests {
     use crate::models::Model;
     use crate::network::Network;
     use crate::parameters::MonthlyProfileParameter;
-    use crate::recorders::AssertionRecorder;
+    use crate::recorders::AssertionF64Recorder;
     use crate::test_utils::{default_time_domain, run_all_solvers};
     use ndarray::Array2;
 
@@ -620,13 +620,13 @@ mod tests {
         // Set-up assertion for "input" node
         let idx = network.get_node_by_name("link", Some("0")).unwrap().index();
         let expected = Array2::from_elem((366, 10), 100.0);
-        let recorder = AssertionRecorder::new("link-0-flow", MetricF64::NodeOutFlow(idx), expected, None, None);
+        let recorder = AssertionF64Recorder::new("link-0-flow", MetricF64::NodeOutFlow(idx), expected, None, None);
         network.add_recorder(Box::new(recorder)).unwrap();
 
         // Set-up assertion for "input" node
         let idx = network.get_node_by_name("link", Some("1")).unwrap().index();
         let expected = Array2::from_elem((366, 10), 50.0);
-        let recorder = AssertionRecorder::new("link-0-flow", MetricF64::NodeOutFlow(idx), expected, None, None);
+        let recorder = AssertionF64Recorder::new("link-0-flow", MetricF64::NodeOutFlow(idx), expected, None, None);
         network.add_recorder(Box::new(recorder)).unwrap();
 
         let model = Model::new(default_time_domain().into(), network);
@@ -674,13 +674,13 @@ mod tests {
         // Set-up assertion for "input" node
         let idx = network.get_node_by_name("link", Some("0")).unwrap().index();
         let expected = Array2::from_elem((366, 10), 100.0);
-        let recorder = AssertionRecorder::new("link-0-flow", MetricF64::NodeOutFlow(idx), expected, None, None);
+        let recorder = AssertionF64Recorder::new("link-0-flow", MetricF64::NodeOutFlow(idx), expected, None, None);
         network.add_recorder(Box::new(recorder)).unwrap();
 
         // Set-up assertion for "input" node
         let idx = network.get_node_by_name("link", Some("1")).unwrap().index();
         let expected = Array2::from_elem((366, 10), 50.0);
-        let recorder = AssertionRecorder::new("link-0-flow", MetricF64::NodeOutFlow(idx), expected, None, None);
+        let recorder = AssertionF64Recorder::new("link-0-flow", MetricF64::NodeOutFlow(idx), expected, None, None);
         network.add_recorder(Box::new(recorder)).unwrap();
 
         let model = Model::new(default_time_domain().into(), network);
@@ -730,13 +730,13 @@ mod tests {
         // Set-up assertion for "output-0" node
         let idx = network.get_node_by_name("link", Some("0")).unwrap().index();
         let expected = Array2::from_elem((366, 10), 100.0);
-        let recorder = AssertionRecorder::new("link-0-flow", MetricF64::NodeOutFlow(idx), expected, None, None);
+        let recorder = AssertionF64Recorder::new("link-0-flow", MetricF64::NodeOutFlow(idx), expected, None, None);
         network.add_recorder(Box::new(recorder)).unwrap();
 
         // Set-up assertion for "output-1" node
         let idx = network.get_node_by_name("link", Some("1")).unwrap().index();
         let expected = Array2::from_elem((366, 10), 0.0);
-        let recorder = AssertionRecorder::new("link-1-flow", MetricF64::NodeOutFlow(idx), expected, None, None);
+        let recorder = AssertionF64Recorder::new("link-1-flow", MetricF64::NodeOutFlow(idx), expected, None, None);
         network.add_recorder(Box::new(recorder)).unwrap();
 
         let model = Model::new(default_time_domain().into(), network);
@@ -805,19 +805,19 @@ mod tests {
         // Set-up assertion for "output-0" node
         let idx = network.get_node_by_name("link", Some("0")).unwrap().index();
         let expected = Array2::from_elem((366, 10), 0.0);
-        let recorder = AssertionRecorder::new("link-0-flow", MetricF64::NodeOutFlow(idx), expected, None, None);
+        let recorder = AssertionF64Recorder::new("link-0-flow", MetricF64::NodeOutFlow(idx), expected, None, None);
         network.add_recorder(Box::new(recorder)).unwrap();
 
         // Set-up assertion for "output-0" node
         let idx = network.get_node_by_name("link", Some("1")).unwrap().index();
         let expected = Array2::from_elem((366, 10), 100.0);
-        let recorder = AssertionRecorder::new("link-1-flow", MetricF64::NodeOutFlow(idx), expected, None, None);
+        let recorder = AssertionF64Recorder::new("link-1-flow", MetricF64::NodeOutFlow(idx), expected, None, None);
         network.add_recorder(Box::new(recorder)).unwrap();
 
         // Set-up assertion for "output-2" node
         let idx = network.get_node_by_name("link", Some("2")).unwrap().index();
         let expected = Array2::from_elem((366, 10), 0.0);
-        let recorder = AssertionRecorder::new("link-2-flow", MetricF64::NodeOutFlow(idx), expected, None, None);
+        let recorder = AssertionF64Recorder::new("link-2-flow", MetricF64::NodeOutFlow(idx), expected, None, None);
         network.add_recorder(Box::new(recorder)).unwrap();
 
         let model = Model::new(default_time_domain().into(), network);

--- a/pywr-core/src/metric.rs
+++ b/pywr-core/src/metric.rs
@@ -390,3 +390,25 @@ where
         MetricU64::Simple(v.into())
     }
 }
+
+impl TryFrom<MetricU64> for SimpleMetricU64 {
+    type Error = PywrError;
+
+    fn try_from(value: MetricU64) -> Result<Self, Self::Error> {
+        match value {
+            MetricU64::Simple(s) => Ok(s),
+            _ => Err(PywrError::CannotSimplifyMetric),
+        }
+    }
+}
+
+impl TryFrom<SimpleMetricU64> for ConstantMetricU64 {
+    type Error = PywrError;
+
+    fn try_from(value: SimpleMetricU64) -> Result<Self, Self::Error> {
+        match value {
+            SimpleMetricU64::Constant(c) => Ok(c),
+            _ => Err(PywrError::CannotSimplifyMetric),
+        }
+    }
+}

--- a/pywr-core/src/models/mod.rs
+++ b/pywr-core/src/models/mod.rs
@@ -7,7 +7,7 @@ use crate::PywrError;
 pub use multi::{MultiNetworkModel, MultiNetworkTransferIndex};
 pub use simple::{Model, ModelState};
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ModelDomain {
     time: TimeDomain,
     scenarios: ScenarioDomain,

--- a/pywr-core/src/parameters/aggregated.rs
+++ b/pywr-core/src/parameters/aggregated.rs
@@ -9,10 +9,15 @@ use std::str::FromStr;
 
 #[derive(Debug, Clone, Copy)]
 pub enum AggFunc {
+    /// Sum of all values.
     Sum,
+    /// Product of all values.
     Product,
+    /// Mean of all values.
     Mean,
+    /// Minimum value among all values.
     Min,
+    /// Maximum value among all values.
     Max,
 }
 

--- a/pywr-core/src/parameters/aggregated_index.rs
+++ b/pywr-core/src/parameters/aggregated_index.rs
@@ -9,13 +9,20 @@ use crate::state::State;
 use crate::timestep::Timestep;
 use std::str::FromStr;
 
+/// Aggregation functions for aggregated index parameters.
 #[derive(Debug, Clone, Copy)]
 pub enum AggIndexFunc {
+    /// Sum of all values.
     Sum,
+    /// Product of all values.
     Product,
+    /// Minimum value among all values.
     Min,
+    /// Maximum value among all values.
     Max,
+    /// Returns 1 if any value is non-zero, otherwise 0.
     Any,
+    /// Returns 1 if all values are non-zero, otherwise 0.
     All,
 }
 

--- a/pywr-core/src/parameters/aggregated_index.rs
+++ b/pywr-core/src/parameters/aggregated_index.rs
@@ -9,6 +9,7 @@ use crate::state::State;
 use crate::timestep::Timestep;
 use std::str::FromStr;
 
+#[derive(Debug, Clone, Copy)]
 pub enum AggIndexFunc {
     Sum,
     Product,

--- a/pywr-core/src/parameters/delay.rs
+++ b/pywr-core/src/parameters/delay.rs
@@ -1,4 +1,4 @@
-use crate::metric::{MetricF64, SimpleMetricF64};
+use crate::metric::{MetricF64, MetricU64, SimpleMetricF64, SimpleMetricU64};
 use crate::network::Network;
 use crate::parameters::{
     downcast_internal_state_mut, GeneralParameter, Parameter, ParameterMeta, ParameterName, ParameterState,
@@ -10,15 +10,15 @@ use crate::timestep::Timestep;
 use crate::PywrError;
 use std::collections::VecDeque;
 
-pub struct DelayParameter<M> {
+pub struct DelayParameter<M, T> {
     meta: ParameterMeta,
     metric: M,
     delay: u64,
-    initial_value: f64,
+    initial_value: T,
 }
 
-impl<M> DelayParameter<M> {
-    pub fn new(name: ParameterName, metric: M, delay: u64, initial_value: f64) -> Self {
+impl<M, T> DelayParameter<M, T> {
+    pub fn new(name: ParameterName, metric: M, delay: u64, initial_value: T) -> Self {
         Self {
             meta: ParameterMeta::new(name),
             metric,
@@ -28,10 +28,13 @@ impl<M> DelayParameter<M> {
     }
 }
 
-impl TryInto<DelayParameter<SimpleMetricF64>> for &DelayParameter<MetricF64> {
+impl<T> TryInto<DelayParameter<SimpleMetricF64, T>> for &DelayParameter<MetricF64, T>
+where
+    T: Copy,
+{
     type Error = PywrError;
 
-    fn try_into(self) -> Result<DelayParameter<SimpleMetricF64>, Self::Error> {
+    fn try_into(self) -> Result<DelayParameter<SimpleMetricF64, T>, Self::Error> {
         Ok(DelayParameter {
             meta: self.meta.clone(),
             metric: self.metric.clone().try_into()?,
@@ -41,9 +44,26 @@ impl TryInto<DelayParameter<SimpleMetricF64>> for &DelayParameter<MetricF64> {
     }
 }
 
-impl<M> Parameter for DelayParameter<M>
+impl<T> TryInto<DelayParameter<SimpleMetricU64, T>> for &DelayParameter<MetricU64, T>
+where
+    T: Copy,
+{
+    type Error = PywrError;
+
+    fn try_into(self) -> Result<DelayParameter<SimpleMetricU64, T>, Self::Error> {
+        Ok(DelayParameter {
+            meta: self.meta.clone(),
+            metric: self.metric.clone().try_into()?,
+            delay: self.delay,
+            initial_value: self.initial_value,
+        })
+    }
+}
+
+impl<M, T> Parameter for DelayParameter<M, T>
 where
     M: Send + Sync,
+    T: Send + Sync + Copy + 'static,
 {
     fn meta(&self) -> &ParameterMeta {
         &self.meta
@@ -55,12 +75,12 @@ where
         _scenario_index: &ScenarioIndex,
     ) -> Result<Option<Box<dyn ParameterState>>, PywrError> {
         // Internally we need to store a history of previous values
-        let memory: VecDeque<f64> = (0..self.delay).map(|_| self.initial_value).collect();
+        let memory: VecDeque<T> = (0..self.delay).map(|_| self.initial_value).collect();
         Ok(Some(Box::new(memory)))
     }
 }
 
-impl GeneralParameter<f64> for DelayParameter<MetricF64> {
+impl GeneralParameter<f64> for DelayParameter<MetricF64, f64> {
     fn compute(
         &self,
         _timestep: &Timestep,
@@ -105,7 +125,7 @@ impl GeneralParameter<f64> for DelayParameter<MetricF64> {
     {
         self.try_into()
             .ok()
-            .map(|p: DelayParameter<SimpleMetricF64>| Box::new(p) as Box<dyn SimpleParameter<f64>>)
+            .map(|p: DelayParameter<SimpleMetricF64, f64>| Box::new(p) as Box<dyn SimpleParameter<f64>>)
     }
 
     fn as_parameter(&self) -> &dyn Parameter
@@ -116,7 +136,7 @@ impl GeneralParameter<f64> for DelayParameter<MetricF64> {
     }
 }
 
-impl SimpleParameter<f64> for DelayParameter<SimpleMetricF64> {
+impl SimpleParameter<f64> for DelayParameter<SimpleMetricF64, f64> {
     fn compute(
         &self,
         _timestep: &Timestep,
@@ -161,15 +181,117 @@ impl SimpleParameter<f64> for DelayParameter<SimpleMetricF64> {
     }
 }
 
+impl GeneralParameter<u64> for DelayParameter<MetricU64, u64> {
+    fn compute(
+        &self,
+        _timestep: &Timestep,
+        _scenario_index: &ScenarioIndex,
+        _model: &Network,
+        _state: &State,
+        internal_state: &mut Option<Box<dyn ParameterState>>,
+    ) -> Result<u64, PywrError> {
+        // Downcast the internal state to the correct type
+        let memory = downcast_internal_state_mut::<VecDeque<u64>>(internal_state);
+
+        // Take the oldest value from the queue
+        // It should be guaranteed that the internal memory/queue has self.delay number of values
+        let value = memory
+            .pop_front()
+            .expect("Delay parameter queue did not contain any values. This internal error should not be possible!");
+
+        Ok(value)
+    }
+
+    fn after(
+        &self,
+        _timestep: &Timestep,
+        _scenario_index: &ScenarioIndex,
+        model: &Network,
+        state: &State,
+        internal_state: &mut Option<Box<dyn ParameterState>>,
+    ) -> Result<(), PywrError> {
+        // Downcast the internal state to the correct type
+        let memory = downcast_internal_state_mut::<VecDeque<u64>>(internal_state);
+
+        // Get today's value from the metric
+        let value = self.metric.get_value(model, state)?;
+        memory.push_back(value);
+
+        Ok(())
+    }
+
+    fn try_into_simple(&self) -> Option<Box<dyn SimpleParameter<u64>>>
+    where
+        Self: Sized,
+    {
+        self.try_into()
+            .ok()
+            .map(|p: DelayParameter<SimpleMetricU64, u64>| Box::new(p) as Box<dyn SimpleParameter<u64>>)
+    }
+
+    fn as_parameter(&self) -> &dyn Parameter
+    where
+        Self: Sized,
+    {
+        self
+    }
+}
+
+impl SimpleParameter<u64> for DelayParameter<SimpleMetricU64, u64> {
+    fn compute(
+        &self,
+        _timestep: &Timestep,
+        _scenario_index: &ScenarioIndex,
+        _values: &SimpleParameterValues,
+        internal_state: &mut Option<Box<dyn ParameterState>>,
+    ) -> Result<u64, PywrError> {
+        // Downcast the internal state to the correct type
+        let memory = downcast_internal_state_mut::<VecDeque<u64>>(internal_state);
+
+        // Take the oldest value from the queue
+        // It should be guaranteed that the internal memory/queue has self.delay number of values
+        let value = memory
+            .pop_front()
+            .expect("Delay parameter queue did not contain any values. This internal error should not be possible!");
+
+        Ok(value)
+    }
+
+    fn after(
+        &self,
+        _timestep: &Timestep,
+        _scenario_index: &ScenarioIndex,
+        values: &SimpleParameterValues,
+        internal_state: &mut Option<Box<dyn ParameterState>>,
+    ) -> Result<(), PywrError> {
+        // Downcast the internal state to the correct type
+        let memory = downcast_internal_state_mut::<VecDeque<u64>>(internal_state);
+
+        // Get today's value from the metric
+        let value = self.metric.get_value(values)?;
+        memory.push_back(value);
+
+        Ok(())
+    }
+
+    fn as_parameter(&self) -> &dyn Parameter
+    where
+        Self: Sized,
+    {
+        self
+    }
+}
+
 #[cfg(test)]
 mod test {
+    use crate::metric::MetricU64;
     use crate::parameters::{Array1Parameter, DelayParameter};
-    use crate::test_utils::{run_and_assert_parameter, simple_model};
+    use crate::test_utils::{run_and_assert_parameter, run_and_assert_parameter_u64, simple_model};
     use ndarray::{concatenate, s, Array1, Array2, Axis};
 
     /// Basic functional test of the delay parameter.
     #[test]
-    fn test_basic() {
+    fn test_delay_f64() {
         let mut model = simple_model(1, None);
 
         // Create an artificial volume series to use for the delay test
@@ -179,12 +301,7 @@ mod test {
         let volume_idx = model.network_mut().add_simple_parameter(Box::new(volume)).unwrap();
 
         const DELAY: u64 = 3; // 3 time-step delay
-        let parameter = DelayParameter::new(
-            "test-parameter".into(),
-            volume_idx.into(), // Interpolate with the parameter based values
-            DELAY,
-            0.0,
-        );
+        let parameter = DelayParameter::new("test-parameter".into(), volume_idx.into(), DELAY, 0.0);
 
         // We should have DELAY number of initial values to start with, and then follow the
         // values in the `volumes` array.
@@ -203,5 +320,42 @@ mod test {
         let expected_values: Array2<f64> = expected_values.insert_axis(Axis(1));
 
         run_and_assert_parameter(&mut model, Box::new(parameter), expected_values, None, Some(1e-12));
+    }
+
+    /// Basic functional test of the delay parameter.
+    #[test]
+    fn test_delay_u64() {
+        let mut model = simple_model(1, None);
+
+        // Create an artificial volume series to use for the delay test
+        let volumes: Array1<u64> = Array1::from(Array1::linspace(1.0, 0.0, 21).map(|x| *x as u64));
+        let volume = Array1Parameter::new("test-x".into(), volumes.clone(), None);
+
+        let metric: MetricU64 = model
+            .network_mut()
+            .add_simple_index_parameter(Box::new(volume))
+            .unwrap()
+            .into();
+
+        const DELAY: u64 = 3; // 3 time-step delay
+        let parameter = DelayParameter::new("test-parameter".into(), metric, DELAY, 0);
+
+        // We should have DELAY number of initial values to start with, and then follow the
+        // values in the `volumes` array.
+        let expected_values: Array1<u64> = [
+            0; DELAY as usize // initial values
+        ]
+            .to_vec()
+            .into();
+
+        let expected_values = concatenate![
+            Axis(0),
+            expected_values,
+            volumes.slice(s![..volumes.len() - DELAY as usize])
+        ];
+
+        let expected_values: Array2<u64> = expected_values.insert_axis(Axis(1));
+
+        run_and_assert_parameter_u64(&mut model, Box::new(parameter), expected_values);
     }
 }

--- a/pywr-core/src/parameters/mod.rs
+++ b/pywr-core/src/parameters/mod.rs
@@ -23,6 +23,7 @@ mod profiles;
 
 #[cfg(feature = "pyo3")]
 mod py;
+mod rolling;
 mod threshold;
 mod vector;
 
@@ -64,6 +65,7 @@ pub use profiles::{
 };
 #[cfg(feature = "pyo3")]
 pub use py::PyParameter;
+pub use rolling::RollingParameter;
 use std::fmt;
 use std::fmt::{Display, Formatter};
 use std::marker::PhantomData;
@@ -1033,7 +1035,7 @@ impl ParameterCollection {
         match parameter.try_into_const() {
             Some(constant) => self.add_const_u64(constant),
             None => {
-                let index = SimpleParameterIndex::new(self.simple_f64.len());
+                let index = SimpleParameterIndex::new(self.simple_u64.len());
 
                 self.simple_u64.push(parameter);
                 self.simple_resolve_order.push(SimpleParameterType::Index(index));

--- a/pywr-core/src/parameters/rolling.rs
+++ b/pywr-core/src/parameters/rolling.rs
@@ -1,0 +1,457 @@
+use crate::metric::{MetricF64, MetricU64, SimpleMetricF64, SimpleMetricU64};
+use crate::network::Network;
+use crate::parameters::{
+    downcast_internal_state_mut, downcast_internal_state_ref, AggFunc, AggIndexFunc, GeneralParameter, Parameter,
+    ParameterMeta, ParameterName, ParameterState, SimpleParameter,
+};
+use crate::scenario::ScenarioIndex;
+use crate::state::{SimpleParameterValues, State};
+use crate::timestep::Timestep;
+use crate::PywrError;
+use std::collections::VecDeque;
+
+/// A rolling parameter that computes an aggregated value over a specified window of metric
+/// values.
+///
+/// This parameter is useful for scenarios where you want to smooth out fluctuations in a metric
+/// by averaging over a defined number of previous values. The `window_size` determines how many
+/// previous metric values are included in the calculation. If an `initial_value` is provided,
+/// it will be used as the return value until `min_values` number of metric values have been
+/// processed.
+pub struct RollingParameter<M, T, AF> {
+    meta: ParameterMeta,
+    metric: M,
+    window_size: usize,
+    initial_value: T,
+    min_values: usize,
+    agg_func: AF,
+}
+
+impl<M, T, AF> RollingParameter<M, T, AF>
+where
+    M: Send + Sync,
+    T: Send + Sync,
+    AF: Send + Sync,
+{
+    /// Creates a new `RollingParameter`.
+    ///
+    /// # Arguments
+    /// * `name` - The name of the parameter.
+    /// * `metric` - The metric to aggregate over.
+    /// * `window_size` - The size of the rolling window.
+    /// * `initial_value` - The initial value to return before enough values are collected.
+    /// * `min_values` - The minimum number of values required before aggregation starts.
+    /// * `agg_func` - The aggregation function to use (e.g., sum, mean).
+    pub fn new(
+        name: ParameterName,
+        metric: M,
+        window_size: usize,
+        initial_value: T,
+        min_values: usize,
+        agg_func: AF,
+    ) -> Self {
+        Self {
+            meta: ParameterMeta::new(name),
+            metric,
+            window_size,
+            initial_value,
+            min_values,
+            agg_func,
+        }
+    }
+}
+
+impl TryInto<RollingParameter<SimpleMetricF64, f64, AggFunc>> for &RollingParameter<MetricF64, f64, AggFunc> {
+    type Error = PywrError;
+
+    fn try_into(self) -> Result<RollingParameter<SimpleMetricF64, f64, AggFunc>, Self::Error> {
+        Ok(RollingParameter {
+            meta: self.meta.clone(),
+            metric: self.metric.clone().try_into()?,
+            window_size: self.window_size,
+            initial_value: self.initial_value,
+            min_values: self.min_values,
+            agg_func: self.agg_func,
+        })
+    }
+}
+
+impl TryInto<RollingParameter<SimpleMetricU64, u64, AggIndexFunc>> for &RollingParameter<MetricU64, u64, AggIndexFunc> {
+    type Error = PywrError;
+
+    fn try_into(self) -> Result<RollingParameter<SimpleMetricU64, u64, AggIndexFunc>, Self::Error> {
+        Ok(RollingParameter {
+            meta: self.meta.clone(),
+            metric: self.metric.clone().try_into()?,
+            window_size: self.window_size,
+            initial_value: self.initial_value,
+            min_values: self.min_values,
+            agg_func: self.agg_func,
+        })
+    }
+}
+
+impl<M, AF> Parameter for RollingParameter<M, f64, AF>
+where
+    M: Send + Sync,
+    AF: Send + Sync,
+{
+    fn meta(&self) -> &ParameterMeta {
+        &self.meta
+    }
+
+    fn setup(
+        &self,
+        _timesteps: &[Timestep],
+        _scenario_index: &ScenarioIndex,
+    ) -> Result<Option<Box<dyn ParameterState>>, PywrError> {
+        // Internal state is the memory
+        let memory: VecDeque<f64> = VecDeque::with_capacity(self.window_size);
+        Ok(Some(Box::new(memory)))
+    }
+}
+
+impl<M, AF> Parameter for RollingParameter<M, u64, AF>
+where
+    M: Send + Sync,
+    AF: Send + Sync,
+{
+    fn meta(&self) -> &ParameterMeta {
+        &self.meta
+    }
+
+    fn setup(
+        &self,
+        _timesteps: &[Timestep],
+        _scenario_index: &ScenarioIndex,
+    ) -> Result<Option<Box<dyn ParameterState>>, PywrError> {
+        // Internal state is the memory
+        let memory: VecDeque<u64> = VecDeque::with_capacity(self.window_size);
+        Ok(Some(Box::new(memory)))
+    }
+}
+
+impl GeneralParameter<f64> for RollingParameter<MetricF64, f64, AggFunc> {
+    fn compute(
+        &self,
+        _timestep: &Timestep,
+        _scenario_index: &ScenarioIndex,
+        _model: &Network,
+        _state: &State,
+        internal_state: &mut Option<Box<dyn ParameterState>>,
+    ) -> Result<f64, PywrError> {
+        // Downcast the internal state to the correct type
+        let memory = downcast_internal_state_ref::<VecDeque<f64>>(internal_state);
+
+        if memory.len() < self.min_values {
+            // Not enough values collected yet, return the initial value
+            Ok(self.initial_value)
+        } else {
+            Ok(aggregate_f64_memory(memory, &self.agg_func))
+        }
+    }
+
+    fn after(
+        &self,
+        _timestep: &Timestep,
+        _scenario_index: &ScenarioIndex,
+        model: &Network,
+        state: &State,
+        internal_state: &mut Option<Box<dyn ParameterState>>,
+    ) -> Result<(), PywrError> {
+        // Downcast the internal state to the correct type
+        let memory = downcast_internal_state_mut::<VecDeque<f64>>(internal_state);
+
+        // Get today's value from the metric
+        let value = self.metric.get_value(model, state)?;
+        memory.push_back(value);
+
+        // If the memory exceeds the window size, remove the oldest value
+        if memory.len() > self.window_size {
+            memory.pop_front();
+        }
+
+        Ok(())
+    }
+
+    fn try_into_simple(&self) -> Option<Box<dyn SimpleParameter<f64>>>
+    where
+        Self: Sized,
+    {
+        self.try_into()
+            .ok()
+            .map(|p: RollingParameter<SimpleMetricF64, f64, AggFunc>| Box::new(p) as Box<dyn SimpleParameter<f64>>)
+    }
+
+    fn as_parameter(&self) -> &dyn Parameter
+    where
+        Self: Sized,
+    {
+        self
+    }
+}
+
+impl SimpleParameter<f64> for RollingParameter<SimpleMetricF64, f64, AggFunc> {
+    fn compute(
+        &self,
+        _timestep: &Timestep,
+        _scenario_index: &ScenarioIndex,
+        _values: &SimpleParameterValues,
+        internal_state: &mut Option<Box<dyn ParameterState>>,
+    ) -> Result<f64, PywrError> {
+        // Downcast the internal state to the correct type
+        let memory = downcast_internal_state_ref::<VecDeque<f64>>(internal_state);
+
+        if memory.len() < self.min_values {
+            // Not enough values collected yet, return the initial value
+            Ok(self.initial_value)
+        } else {
+            Ok(aggregate_f64_memory(memory, &self.agg_func))
+        }
+    }
+
+    fn after(
+        &self,
+        _timestep: &Timestep,
+        _scenario_index: &ScenarioIndex,
+        values: &SimpleParameterValues,
+        internal_state: &mut Option<Box<dyn ParameterState>>,
+    ) -> Result<(), PywrError> {
+        // Downcast the internal state to the correct type
+        let memory = downcast_internal_state_mut::<VecDeque<f64>>(internal_state);
+
+        // Get today's value from the metric
+        let value = self.metric.get_value(values)?;
+        memory.push_back(value);
+
+        // If the memory exceeds the window size, remove the oldest value
+        if memory.len() > self.window_size {
+            memory.pop_front();
+        }
+
+        Ok(())
+    }
+
+    fn as_parameter(&self) -> &dyn Parameter
+    where
+        Self: Sized,
+    {
+        self
+    }
+}
+
+impl GeneralParameter<u64> for RollingParameter<MetricU64, u64, AggIndexFunc> {
+    fn compute(
+        &self,
+        _timestep: &Timestep,
+        _scenario_index: &ScenarioIndex,
+        _model: &Network,
+        _state: &State,
+        internal_state: &mut Option<Box<dyn ParameterState>>,
+    ) -> Result<u64, PywrError> {
+        // Downcast the internal state to the correct type
+        let memory = downcast_internal_state_ref::<VecDeque<u64>>(internal_state);
+
+        if memory.len() < self.min_values {
+            // Not enough values collected yet, return the initial value
+            Ok(self.initial_value)
+        } else {
+            Ok(aggregate_u64_memory(memory, &self.agg_func))
+        }
+    }
+
+    fn after(
+        &self,
+        _timestep: &Timestep,
+        _scenario_index: &ScenarioIndex,
+        model: &Network,
+        state: &State,
+        internal_state: &mut Option<Box<dyn ParameterState>>,
+    ) -> Result<(), PywrError> {
+        // Downcast the internal state to the correct type
+        let memory = downcast_internal_state_mut::<VecDeque<u64>>(internal_state);
+
+        // Get today's value from the metric
+        let value = self.metric.get_value(model, state)?;
+        memory.push_back(value);
+
+        // If the memory exceeds the window size, remove the oldest value
+        if memory.len() > self.window_size {
+            memory.pop_front();
+        }
+
+        Ok(())
+    }
+
+    fn try_into_simple(&self) -> Option<Box<dyn SimpleParameter<u64>>>
+    where
+        Self: Sized,
+    {
+        self.try_into()
+            .ok()
+            .map(|p: RollingParameter<SimpleMetricU64, u64, AggIndexFunc>| Box::new(p) as Box<dyn SimpleParameter<u64>>)
+    }
+
+    fn as_parameter(&self) -> &dyn Parameter
+    where
+        Self: Sized,
+    {
+        self
+    }
+}
+
+impl SimpleParameter<u64> for RollingParameter<SimpleMetricU64, u64, AggIndexFunc> {
+    fn compute(
+        &self,
+        _timestep: &Timestep,
+        _scenario_index: &ScenarioIndex,
+        _values: &SimpleParameterValues,
+        internal_state: &mut Option<Box<dyn ParameterState>>,
+    ) -> Result<u64, PywrError> {
+        // Downcast the internal state to the correct type
+        let memory = downcast_internal_state_ref::<VecDeque<u64>>(internal_state);
+
+        if memory.len() < self.min_values {
+            // Not enough values collected yet, return the initial value
+            Ok(self.initial_value)
+        } else {
+            Ok(aggregate_u64_memory(memory, &self.agg_func))
+        }
+    }
+
+    fn after(
+        &self,
+        _timestep: &Timestep,
+        _scenario_index: &ScenarioIndex,
+        values: &SimpleParameterValues,
+        internal_state: &mut Option<Box<dyn ParameterState>>,
+    ) -> Result<(), PywrError> {
+        // Downcast the internal state to the correct type
+        let memory = downcast_internal_state_mut::<VecDeque<u64>>(internal_state);
+
+        // Get today's value from the metric
+        let value = self.metric.get_value(values)?;
+        memory.push_back(value);
+
+        // If the memory exceeds the window size, remove the oldest value
+        if memory.len() > self.window_size {
+            memory.pop_front();
+        }
+
+        Ok(())
+    }
+
+    fn as_parameter(&self) -> &dyn Parameter
+    where
+        Self: Sized,
+    {
+        self
+    }
+}
+
+/// Aggregates the values in the memory using the specified aggregation function.
+fn aggregate_f64_memory(memory: &VecDeque<f64>, agg_func: &AggFunc) -> f64 {
+    match agg_func {
+        AggFunc::Sum => memory.iter().sum(),
+        AggFunc::Mean => memory.iter().sum::<f64>() / memory.len() as f64,
+        AggFunc::Max => *memory
+            .iter()
+            .max_by(|a, b| a.partial_cmp(b).unwrap())
+            .unwrap_or(&f64::MIN),
+        AggFunc::Min => *memory
+            .iter()
+            .min_by(|a, b| a.partial_cmp(b).unwrap())
+            .unwrap_or(&f64::MAX),
+        AggFunc::Product => memory.iter().product(),
+    }
+}
+
+/// Aggregates the values in the memory using the specified aggregation function.
+fn aggregate_u64_memory(memory: &VecDeque<u64>, agg_func: &AggIndexFunc) -> u64 {
+    match agg_func {
+        AggIndexFunc::Sum => memory.iter().sum(),
+        AggIndexFunc::Max => *memory.iter().max_by(|a, b| a.cmp(b)).unwrap_or(&u64::MIN),
+        AggIndexFunc::Min => *memory.iter().min_by(|a, b| a.cmp(b)).unwrap_or(&u64::MAX),
+        AggIndexFunc::Any => {
+            if memory.iter().any(|&x| x > 0) {
+                1
+            } else {
+                0
+            }
+        }
+        AggIndexFunc::All => {
+            if memory.iter().all(|&x| x > 0) {
+                1
+            } else {
+                0
+            }
+        }
+        AggIndexFunc::Product => memory.iter().product(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parameters::Array1Parameter;
+    use crate::test_utils::{run_and_assert_parameter, run_and_assert_parameter_u64, simple_model};
+    use ndarray::{Array1, Array2, Axis};
+
+    #[test]
+    /// Test `RollingParameter` returns the correct f64 value.
+    fn test_rolling_f64() {
+        let mut model = simple_model(1, None);
+
+        let metric = Array1Parameter::new("my-metric".into(), Array1::from(Array1::linspace(1.0, 21.0, 21)), None);
+        let metric_idx: MetricF64 = model
+            .network_mut()
+            .add_simple_parameter(Box::new(metric))
+            .unwrap()
+            .into();
+
+        let parameter = RollingParameter::new("my-parameter".into(), metric_idx, 3, 0.0, 3, AggFunc::Mean);
+
+        // Before the first three values are collected, the parameter should return the initial value.
+        let expected_values: Array1<f64> = [
+            0.0, 0.0, 0.0, // initial values
+            2.0, 3.0, 4.0, // first rolling values
+            5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0, 21.0,
+        ]
+        .to_vec()
+        .into();
+
+        let expected_values: Array2<f64> = expected_values.insert_axis(Axis(1));
+
+        run_and_assert_parameter(&mut model, Box::new(parameter), expected_values, None, Some(1e-12));
+    }
+
+    #[test]
+    /// Test `RollingParameter` returns the correct u64 value.
+    fn test_rolling_u64() {
+        let mut model = simple_model(1, None);
+
+        let values: Array1<u64> = Array1::from(Array1::linspace(1.0, 21.0, 21).map(|x| *x as u64));
+
+        let metric = Array1Parameter::new("my-metric".into(), values, None);
+        let metric_idx: MetricU64 = model
+            .network_mut()
+            .add_simple_index_parameter(Box::new(metric))
+            .unwrap()
+            .into();
+
+        let parameter = RollingParameter::new("my-parameter".into(), metric_idx, 3, 0, 3, AggIndexFunc::Max);
+
+        // Before the first three values are collected, the parameter should return the initial value.
+        let expected_values: Array1<u64> = [
+            0, 0, 0, // initial values
+            3, 4, 5, // first rolling values
+            6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
+        ]
+        .to_vec()
+        .into();
+
+        let expected_values: Array2<u64> = expected_values.insert_axis(Axis(1));
+
+        run_and_assert_parameter_u64(&mut model, Box::new(parameter), expected_values);
+    }
+}

--- a/pywr-core/src/scenario.rs
+++ b/pywr-core/src/scenario.rs
@@ -573,7 +573,7 @@ impl ScenarioIndex {
 }
 
 /// The scenario domain for a model.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ScenarioDomain {
     indices: Vec<ScenarioIndex>,
     groups: Vec<ScenarioGroup>,

--- a/pywr-core/src/test_utils.rs
+++ b/pywr-core/src/test_utils.rs
@@ -178,7 +178,7 @@ pub fn run_and_assert_parameter(
 /// This function will run a number of time-steps equal to the number of rows in the expected
 /// values array.
 ///
-/// See [`AssertionF64Recorder`] for more information.
+/// See [`AssertionU64Recorder`] for more information.
 pub fn run_and_assert_parameter_u64(
     model: &mut Model,
     parameter: Box<dyn GeneralParameter<u64>>,

--- a/pywr-core/src/test_utils.rs
+++ b/pywr-core/src/test_utils.rs
@@ -5,7 +5,7 @@ use crate::models::{Model, ModelDomain};
 use crate::network::Network;
 use crate::node::StorageInitialVolume;
 use crate::parameters::{AggFunc, AggregatedParameter, Array2Parameter, ConstantParameter, GeneralParameter};
-use crate::recorders::AssertionRecorder;
+use crate::recorders::{AssertionF64Recorder, AssertionU64Recorder};
 use crate::scenario::{ScenarioDomainBuilder, ScenarioGroupBuilder};
 #[cfg(feature = "cbc")]
 use crate::solvers::CbcSolver;
@@ -148,7 +148,7 @@ pub fn simple_storage_model() -> Model {
 /// This function will run a number of time-steps equal to the number of rows in the expected
 /// values array.
 ///
-/// See [`AssertionRecorder`] for more information.
+/// See [`AssertionF64Recorder`] for more information.
 pub fn run_and_assert_parameter(
     model: &mut Model,
     parameter: Box<dyn GeneralParameter<f64>>,
@@ -166,7 +166,35 @@ pub fn run_and_assert_parameter(
         .checked_add_days(Days::new(expected_values.nrows() as u64 - 1))
         .unwrap();
 
-    let rec = AssertionRecorder::new("assert", p_idx.into(), expected_values, ulps, epsilon);
+    let rec = AssertionF64Recorder::new("assert", p_idx.into(), expected_values, ulps, epsilon);
+
+    model.network_mut().add_recorder(Box::new(rec)).unwrap();
+    run_all_solvers(model, &[], &[], &[])
+}
+
+/// Add the given parameter to the given model along with an assertion recorder that asserts
+/// whether the parameter returns the expected values when the model is run.
+///
+/// This function will run a number of time-steps equal to the number of rows in the expected
+/// values array.
+///
+/// See [`AssertionF64Recorder`] for more information.
+pub fn run_and_assert_parameter_u64(
+    model: &mut Model,
+    parameter: Box<dyn GeneralParameter<u64>>,
+    expected_values: Array2<u64>,
+) {
+    let p_idx = model.network_mut().add_index_parameter(parameter).unwrap();
+
+    let start = NaiveDate::from_ymd_opt(2020, 1, 1)
+        .unwrap()
+        .and_hms_opt(0, 0, 0)
+        .unwrap();
+    let _end = start
+        .checked_add_days(Days::new(expected_values.nrows() as u64 - 1))
+        .unwrap();
+
+    let rec = AssertionU64Recorder::new("assert", p_idx.into(), expected_values);
 
     model.network_mut().add_recorder(Box::new(rec)).unwrap();
     run_all_solvers(model, &[], &[], &[])
@@ -259,7 +287,7 @@ where
         );
         model
             .run::<S>(&Default::default())
-            .unwrap_or_else(|_| panic!("Failed to solve with: {}", S::name()));
+            .unwrap_or_else(|e| panic!("Failed to solve with {}: {}", S::name(), e));
 
         // Verify any expected outputs
         for expected_output in expected_outputs {

--- a/pywr-core/src/timestep.rs
+++ b/pywr-core/src/timestep.rs
@@ -241,7 +241,7 @@ impl Timestepper {
 }
 
 /// The time domain that a model will be simulated over.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct TimeDomain {
     timesteps: Vec<Timestep>,
     duration: PywrDuration,

--- a/pywr-core/src/virtual_storage.rs
+++ b/pywr-core/src/virtual_storage.rs
@@ -306,7 +306,7 @@ mod tests {
     use crate::network::Network;
     use crate::node::StorageInitialVolume;
     use crate::parameters::ControlCurveInterpolatedParameter;
-    use crate::recorders::{AssertionFnRecorder, AssertionRecorder};
+    use crate::recorders::{AssertionF64Recorder, AssertionFnRecorder};
     use crate::scenario::ScenarioIndex;
     use crate::test_utils::{default_timestepper, run_all_solvers, simple_model};
     use crate::timestep::{Timestep, TimestepDuration, Timestepper};
@@ -457,7 +457,7 @@ mod tests {
         let expected = Array::zeros((366, 1));
 
         let idx = network.get_node_by_name("output", None).unwrap().index();
-        let recorder = AssertionRecorder::new("output-flow", MetricF64::NodeInFlow(idx), expected, None, None);
+        let recorder = AssertionF64Recorder::new("output-flow", MetricF64::NodeInFlow(idx), expected, None, None);
         network.add_recorder(Box::new(recorder)).unwrap();
 
         // Test all solvers

--- a/pywr-schema/src/model.rs
+++ b/pywr-schema/src/model.rs
@@ -1178,7 +1178,9 @@ mod core_tests {
     use crate::metric::{Metric, ParameterReference};
     use crate::parameters::{AggFunc, AggregatedParameter, ConstantParameter, ConstantValue, Parameter, ParameterMeta};
     use ndarray::{Array1, Array2, Axis};
-    use pywr_core::{metric::MetricF64, recorders::AssertionRecorder, solvers::ClpSolver, test_utils::run_all_solvers};
+    use pywr_core::{
+        metric::MetricF64, recorders::AssertionF64Recorder, solvers::ClpSolver, test_utils::run_all_solvers,
+    };
     use std::fs::read_to_string;
     use std::path::PathBuf;
 
@@ -1201,7 +1203,7 @@ mod core_tests {
         let expected_values: Array1<f64> = [10.0; 365].to_vec().into();
         let expected_values: Array2<f64> = expected_values.insert_axis(Axis(1));
 
-        let rec = AssertionRecorder::new(
+        let rec = AssertionF64Recorder::new(
             "assert-demand1",
             MetricF64::NodeInFlow(demand1_idx),
             expected_values,
@@ -1338,7 +1340,7 @@ mod core_tests {
         let expected_values: Array1<f64> = [10.0; 365].to_vec().into();
         let expected_values: Array2<f64> = expected_values.insert_axis(Axis(1));
 
-        let rec = AssertionRecorder::new(
+        let rec = AssertionF64Recorder::new(
             "assert-demand1",
             MetricF64::NodeInFlow(demand1_idx),
             expected_values,
@@ -1357,7 +1359,7 @@ mod core_tests {
         let expected_values: Array1<f64> = [10.0; 365].to_vec().into();
         let expected_values: Array2<f64> = expected_values.insert_axis(Axis(1));
 
-        let rec = AssertionRecorder::new(
+        let rec = AssertionF64Recorder::new(
             "assert-demand2",
             MetricF64::NodeInFlow(demand1_idx),
             expected_values,
@@ -1389,7 +1391,7 @@ mod core_tests {
         let expected_values: Array1<f64> = [10.0; 365].to_vec().into();
         let expected_values: Array2<f64> = expected_values.insert_axis(Axis(1));
 
-        let rec = AssertionRecorder::new(
+        let rec = AssertionF64Recorder::new(
             "assert-demand1",
             MetricF64::NodeInFlow(demand1_idx),
             expected_values,
@@ -1408,7 +1410,7 @@ mod core_tests {
         let expected_values: Array1<f64> = [10.0; 365].to_vec().into();
         let expected_values: Array2<f64> = expected_values.insert_axis(Axis(1));
 
-        let rec = AssertionRecorder::new(
+        let rec = AssertionF64Recorder::new(
             "assert-demand2",
             MetricF64::NodeInFlow(demand1_idx),
             expected_values,

--- a/pywr-schema/src/parameters/aggregated.rs
+++ b/pywr-schema/src/parameters/aggregated.rs
@@ -22,8 +22,9 @@ use std::collections::HashMap;
 pub enum AggFunc {
     Sum,
     Product,
-    Max,
+    Mean,
     Min,
+    Max,
 }
 
 #[cfg(feature = "core")]
@@ -34,6 +35,7 @@ impl From<AggFunc> for pywr_core::parameters::AggFunc {
             AggFunc::Product => pywr_core::parameters::AggFunc::Product,
             AggFunc::Max => pywr_core::parameters::AggFunc::Max,
             AggFunc::Min => pywr_core::parameters::AggFunc::Min,
+            AggFunc::Mean => pywr_core::parameters::AggFunc::Mean,
         }
     }
 }

--- a/pywr-schema/src/parameters/aggregated.rs
+++ b/pywr-schema/src/parameters/aggregated.rs
@@ -17,13 +17,23 @@ use schemars::JsonSchema;
 use std::collections::HashMap;
 
 // TODO complete these
+/// Aggregation functions for float values.
+///
+/// This enum defines the possible aggregation functions that can be applied to index metrics.
+/// They are mapped to the corresponding functions in the `pywr_core::parameters::AggFunc` enum
+/// when used in the core library.
 #[derive(serde::Deserialize, serde::Serialize, Debug, Copy, Clone, strum_macros::Display, JsonSchema, PywrVisitAll)]
 #[serde(rename_all = "lowercase")]
 pub enum AggFunc {
+    /// Sum of all values.
     Sum,
+    /// Product of all values.
     Product,
+    /// Mean of all values.
     Mean,
+    /// Minimum value among all values.
     Min,
+    /// Maximum value among all values.
     Max,
 }
 
@@ -131,14 +141,25 @@ impl TryFromV1<AggregatedParameterV1> for AggregatedParameter {
 }
 
 // TODO complete these
+/// Aggregation functions for index (integer) values.
+///
+/// This enum defines the possible aggregation functions that can be applied to index metrics.
+/// They are mapped to the corresponding functions in the `pywr_core::parameters::AggIndexFunc` enum
+/// when used in the core library.
 #[derive(serde::Deserialize, serde::Serialize, Debug, Copy, Clone, strum_macros::Display, JsonSchema, PywrVisitAll)]
 #[serde(rename_all = "lowercase")]
 pub enum IndexAggFunc {
+    /// Sum of all values.
     Sum,
+    /// Product of all values.
     Product,
-    Max,
+    /// Minimum value among all values.
     Min,
+    /// Maximum value among all values.
+    Max,
+    /// Returns 1 if any value is non-zero, otherwise 0.
     Any,
+    /// Returns 1 if all values are non-zero, otherwise 0.
     All,
 }
 

--- a/pywr-schema/src/parameters/delay.rs
+++ b/pywr-schema/src/parameters/delay.rs
@@ -1,6 +1,6 @@
 #[cfg(feature = "core")]
 use crate::error::SchemaError;
-use crate::metric::Metric;
+use crate::metric::{IndexMetric, Metric};
 #[cfg(feature = "core")]
 use crate::model::LoadArgs;
 use crate::parameters::ParameterMeta;
@@ -34,5 +34,33 @@ impl DelayParameter {
             self.initial_value,
         );
         Ok(network.add_parameter(Box::new(p))?)
+    }
+}
+
+/// A parameter that delays a value from the network by a number of time-steps.
+#[derive(serde::Deserialize, serde::Serialize, Debug, Clone, JsonSchema, PywrVisitAll)]
+#[serde(deny_unknown_fields)]
+pub struct DelayIndexParameter {
+    pub meta: ParameterMeta,
+    pub metric: IndexMetric,
+    pub delay: u64,
+    pub initial_value: u64,
+}
+
+#[cfg(feature = "core")]
+impl DelayIndexParameter {
+    pub fn add_to_model(
+        &self,
+        network: &mut pywr_core::network::Network,
+        args: &LoadArgs,
+    ) -> Result<ParameterIndex<u64>, SchemaError> {
+        let metric = self.metric.load(network, args, None)?;
+        let p = pywr_core::parameters::DelayParameter::new(
+            self.meta.name.as_str().into(),
+            metric,
+            self.delay,
+            self.initial_value,
+        );
+        Ok(network.add_index_parameter(Box::new(p))?)
     }
 }

--- a/pywr-schema/src/parameters/mod.rs
+++ b/pywr-schema/src/parameters/mod.rs
@@ -33,6 +33,7 @@ use crate::error::{ComponentConversionError, ConversionError};
 use crate::metric::Metric;
 #[cfg(feature = "core")]
 use crate::model::LoadArgs;
+use crate::parameters::delay::DelayIndexParameter;
 use crate::timeseries::ConvertedTimeseriesReference;
 use crate::v1::{ConversionData, IntoV2, TryFromV1, TryIntoV2};
 use crate::visit::{VisitMetrics, VisitPaths};
@@ -109,6 +110,7 @@ pub enum Parameter {
     TablesArray(TablesArrayParameter),
     Python(PythonParameter),
     Delay(DelayParameter),
+    DelayIndex(DelayIndexParameter),
     Division(DivisionParameter),
     Offset(OffsetParameter),
     DiscountFactor(DiscountFactorParameter),
@@ -143,6 +145,7 @@ impl Parameter {
             Self::Python(p) => p.meta.name.as_str(),
             Self::Division(p) => p.meta.name.as_str(),
             Self::Delay(p) => p.meta.name.as_str(),
+            Self::DelayIndex(p) => p.meta.name.as_str(),
             Self::Offset(p) => p.meta.name.as_str(),
             Self::DiscountFactor(p) => p.meta.name.as_str(),
             Self::Interpolated(p) => p.meta.name.as_str(),
@@ -201,6 +204,7 @@ impl Parameter {
             Self::TablesArray(p) => pywr_core::parameters::ParameterType::Parameter(p.add_to_model(network, args)?),
             Self::Python(p) => p.add_to_model(network, args)?,
             Self::Delay(p) => pywr_core::parameters::ParameterType::Parameter(p.add_to_model(network, args)?),
+            Self::DelayIndex(p) => pywr_core::parameters::ParameterType::Index(p.add_to_model(network, args)?),
             Self::Division(p) => pywr_core::parameters::ParameterType::Parameter(p.add_to_model(network, args)?),
             Self::Offset(p) => pywr_core::parameters::ParameterType::Parameter(p.add_to_model(network, args)?),
             Self::DiscountFactor(p) => pywr_core::parameters::ParameterType::Parameter(p.add_to_model(network, args)?),
@@ -243,6 +247,7 @@ impl VisitMetrics for Parameter {
             Self::TablesArray(p) => p.visit_metrics(visitor),
             Self::Python(p) => p.visit_metrics(visitor),
             Self::Delay(p) => p.visit_metrics(visitor),
+            Self::DelayIndex(p) => p.visit_metrics(visitor),
             Self::Division(p) => p.visit_metrics(visitor),
             Self::Offset(p) => p.visit_metrics(visitor),
             Self::DiscountFactor(p) => p.visit_metrics(visitor),
@@ -279,6 +284,7 @@ impl VisitMetrics for Parameter {
             Self::TablesArray(p) => p.visit_metrics_mut(visitor),
             Self::Python(p) => p.visit_metrics_mut(visitor),
             Self::Delay(p) => p.visit_metrics_mut(visitor),
+            Self::DelayIndex(p) => p.visit_metrics_mut(visitor),
             Self::Division(p) => p.visit_metrics_mut(visitor),
             Self::Offset(p) => p.visit_metrics_mut(visitor),
             Self::DiscountFactor(p) => p.visit_metrics_mut(visitor),
@@ -317,6 +323,7 @@ impl VisitPaths for Parameter {
             Self::TablesArray(p) => p.visit_paths(visitor),
             Self::Python(p) => p.visit_paths(visitor),
             Self::Delay(p) => p.visit_paths(visitor),
+            Self::DelayIndex(p) => p.visit_paths(visitor),
             Self::Division(p) => p.visit_paths(visitor),
             Self::Offset(p) => p.visit_paths(visitor),
             Self::DiscountFactor(p) => p.visit_paths(visitor),
@@ -353,6 +360,7 @@ impl VisitPaths for Parameter {
             Self::TablesArray(p) => p.visit_paths_mut(visitor),
             Self::Python(p) => p.visit_paths_mut(visitor),
             Self::Delay(p) => p.visit_paths_mut(visitor),
+            Self::DelayIndex(p) => p.visit_paths_mut(visitor),
             Self::Division(p) => p.visit_paths_mut(visitor),
             Self::Offset(p) => p.visit_paths_mut(visitor),
             Self::DiscountFactor(p) => p.visit_paths_mut(visitor),

--- a/pywr-schema/src/parameters/rolling.rs
+++ b/pywr-schema/src/parameters/rolling.rs
@@ -12,13 +12,13 @@ use pywr_schema_macros::PywrVisitAll;
 use pywr_v1_schema::parameters::RollingMeanFlowNodeParameter as RollingMeanFlowNodeParameterV1;
 use schemars::JsonSchema;
 
-/// A parameter that delays a value from the network by a number of time-steps.
+/// A parameter that computes a rolling value based on a specified metric over a defined window size.
 ///
-/// This parameter computes a rolling value based on a specified metric over a defined window size.
-/// The rolling function can be configured to use different aggregation functions. If the
-/// `min_values` is not specified, it defaults to the `window_size`, meaning that the rolling
-/// value will only be computed once enough values are available. Prior to the first
-/// `min_values` being reached, the parameter will return the `initial_value`.
+/// The rolling function can be configured to use different aggregation functions
+/// (see [`AggFunc`] for more details). If the `min_values` is not specified, it defaults to the
+/// `window_size`, meaning that the rolling value will only be computed once enough values are
+/// available. Prior to the first `min_values` being reached, the parameter will return the
+/// `initial_value`.
 #[derive(serde::Deserialize, serde::Serialize, Debug, Clone, JsonSchema, PywrVisitAll)]
 #[serde(deny_unknown_fields)]
 pub struct RollingParameter {
@@ -50,13 +50,13 @@ impl RollingParameter {
     }
 }
 
-/// A parameter that delays a value from the network by a number of time-steps.
+/// A parameter that computes a rolling value based on a specified index metric over a defined window size.
 ///
-/// This parameter computes a rolling value based on a specified index metric over a defined window
-/// size. The rolling function can be configured to use different aggregation functions. If the
-/// `min_values` is not specified, it defaults to the `window_size`, meaning that the rolling
-/// value will only be computed once enough values are available. Prior to the first
-/// `min_values` being reached, the parameter will return the `initial_value`.
+/// The rolling function can be configured to use different aggregation functions
+/// (see [`IndexAggFunc`] for more details). If the `min_values` is not specified, it defaults
+/// to the `window_size`, meaning that the rolling value will only be computed once enough values
+/// are available. Prior to the first `min_values` being reached, the parameter will return the
+/// `initial_value`.
 #[derive(serde::Deserialize, serde::Serialize, Debug, Clone, JsonSchema, PywrVisitAll)]
 #[serde(deny_unknown_fields)]
 pub struct RollingIndexParameter {

--- a/pywr-schema/src/parameters/rolling.rs
+++ b/pywr-schema/src/parameters/rolling.rs
@@ -1,0 +1,150 @@
+#[cfg(feature = "core")]
+use crate::error::SchemaError;
+use crate::metric::{IndexMetric, Metric, NodeReference};
+#[cfg(feature = "core")]
+use crate::model::LoadArgs;
+use crate::parameters::{AggFunc, IndexAggFunc, ParameterMeta};
+use crate::v1::IntoV2;
+use crate::{ComponentConversionError, ConversionData, ConversionError, TryFromV1};
+#[cfg(feature = "core")]
+use pywr_core::parameters::ParameterIndex;
+use pywr_schema_macros::PywrVisitAll;
+use pywr_v1_schema::parameters::RollingMeanFlowNodeParameter as RollingMeanFlowNodeParameterV1;
+use schemars::JsonSchema;
+
+/// A parameter that delays a value from the network by a number of time-steps.
+///
+/// This parameter computes a rolling value based on a specified metric over a defined window size.
+/// The rolling function can be configured to use different aggregation functions. If the
+/// `min_values` is not specified, it defaults to the `window_size`, meaning that the rolling
+/// value will only be computed once enough values are available. Prior to the first
+/// `min_values` being reached, the parameter will return the `initial_value`.
+#[derive(serde::Deserialize, serde::Serialize, Debug, Clone, JsonSchema, PywrVisitAll)]
+#[serde(deny_unknown_fields)]
+pub struct RollingParameter {
+    pub meta: ParameterMeta,
+    pub metric: Metric,
+    pub window_size: u64,
+    pub initial_value: f64,
+    pub min_values: Option<u64>,
+    pub agg_func: AggFunc,
+}
+
+#[cfg(feature = "core")]
+impl RollingParameter {
+    pub fn add_to_model(
+        &self,
+        network: &mut pywr_core::network::Network,
+        args: &LoadArgs,
+    ) -> Result<ParameterIndex<f64>, SchemaError> {
+        let metric = self.metric.load(network, args, None)?;
+        let p = pywr_core::parameters::RollingParameter::new(
+            self.meta.name.as_str().into(),
+            metric,
+            self.window_size as usize,
+            self.initial_value,
+            self.min_values.unwrap_or(self.window_size) as usize,
+            self.agg_func.into(),
+        );
+        Ok(network.add_parameter(Box::new(p))?)
+    }
+}
+
+/// A parameter that delays a value from the network by a number of time-steps.
+///
+/// This parameter computes a rolling value based on a specified index metric over a defined window
+/// size. The rolling function can be configured to use different aggregation functions. If the
+/// `min_values` is not specified, it defaults to the `window_size`, meaning that the rolling
+/// value will only be computed once enough values are available. Prior to the first
+/// `min_values` being reached, the parameter will return the `initial_value`.
+#[derive(serde::Deserialize, serde::Serialize, Debug, Clone, JsonSchema, PywrVisitAll)]
+#[serde(deny_unknown_fields)]
+pub struct RollingIndexParameter {
+    pub meta: ParameterMeta,
+    pub metric: IndexMetric,
+    pub window_size: u64,
+    pub initial_value: u64,
+    pub min_values: Option<u64>,
+    pub agg_func: IndexAggFunc,
+}
+
+#[cfg(feature = "core")]
+impl RollingIndexParameter {
+    pub fn add_to_model(
+        &self,
+        network: &mut pywr_core::network::Network,
+        args: &LoadArgs,
+    ) -> Result<ParameterIndex<u64>, SchemaError> {
+        let metric = self.metric.load(network, args, None)?;
+        let p = pywr_core::parameters::RollingParameter::new(
+            self.meta.name.as_str().into(),
+            metric,
+            self.window_size as usize,
+            self.initial_value,
+            self.min_values.unwrap_or(self.window_size) as usize,
+            self.agg_func.into(),
+        );
+        Ok(network.add_index_parameter(Box::new(p))?)
+    }
+}
+
+impl TryFromV1<RollingMeanFlowNodeParameterV1> for RollingParameter {
+    type Error = ComponentConversionError;
+
+    fn try_from_v1(
+        v1: RollingMeanFlowNodeParameterV1,
+        parent_node: Option<&str>,
+        conversion_data: &mut ConversionData,
+    ) -> Result<Self, Self::Error> {
+        let meta: ParameterMeta = v1.meta.into_v2(parent_node, conversion_data);
+
+        let window_size = match (v1.timesteps, v1.days) {
+            (Some(timesteps), None) => timesteps as u64,
+            (None, Some(_)) => {
+                return Err(ComponentConversionError::Parameter {
+                        attr: "days".to_string(),
+                        name: meta.name.clone(),
+                        error: ConversionError::UnsupportedFeature {
+                            feature: "`RollingMeanFlowNodeParameter` days window size must be specified as a number of time-steps. Use `window_size` in the updated schema, or convert a v1.x parameter with the `timesteps` attribute.".to_string(),
+                        },
+                    });
+            }
+            (Some(_), Some(_)) => {
+                return Err(ComponentConversionError::Parameter {
+                    attr: "timesteps".to_string(),
+                    name: meta.name.clone(),
+                    error: ConversionError::UnsupportedFeature {
+                        feature: "`RollingMeanFlowNodeParameter` cannot have both `timesteps` and `days` specified. Use `window_size` in the updated schema, or correct the v1.x definition.".to_string(),
+                    },
+                });
+            }
+            (None, None) => {
+                return Err(ComponentConversionError::Parameter {
+                    attr: "timesteps".to_string(),
+                    name: meta.name.clone(),
+                    error: ConversionError::UnsupportedFeature {
+                        feature: "`RollingMeanFlowNodeParameter` must have `timesteps` specified. Use `window_size` in the updated schema.".to_string(),
+                    },
+                });
+            }
+        };
+
+        // Convert the node reference to a metric
+        let node_ref = NodeReference {
+            name: v1.node,
+            attribute: None,
+        };
+        let metric = Metric::Node(node_ref);
+
+        // pywr 1 does not support interpolation
+        let p = Self {
+            meta,
+            metric,
+            window_size,
+            initial_value: v1.initial_flow.unwrap_or_default(),
+            min_values: None,
+            agg_func: AggFunc::Mean,
+        };
+        Ok(p)
+    }
+}


### PR DESCRIPTION
Add a rolling parameter. Add a generic rolling parametr to core for use with f64 and u64 values. These two variants are also added to the schema.

Some additional trait implementations and test utility functions have been added to make this work. These mirror the f64 implementations.

One indexing bug is also corrected.