### PR TITLE
feat: Make schema enum definitions more consistent.

### DIFF
--- a/pywr-python/src/lib.rs
+++ b/pywr-python/src/lib.rs
@@ -13,7 +13,7 @@ use pywr_core::solvers::{HighsSolver, HighsSolverSettings, HighsSolverSettingsBu
 #[cfg(feature = "ipm-simd")]
 use pywr_core::solvers::{SimdIpmF64Solver, SimdIpmSolverSettings, SimdIpmSolverSettingsBuilder};
 use pywr_core::PywrError;
-use pywr_schema::model::DateType;
+use pywr_schema::model::Date;
 use pywr_schema::{ComponentConversionError, ConversionData, ConversionError, TryIntoV2};
 use std::fmt;
 use std::path::PathBuf;
@@ -64,8 +64,8 @@ pub struct Schema {
 impl Schema {
     #[new]
     fn new(title: &str, start: NaiveDateTime, end: NaiveDateTime) -> Self {
-        let start = DateType::DateTime(start);
-        let end = DateType::DateTime(end);
+        let start = Date::DateTime(start);
+        let end = Date::DateTime(end);
 
         Self {
             schema: pywr_schema::PywrModel::new(title, &start, &end),

--- a/pywr-python/tests/models/simple-custom-parameter/model.json
+++ b/pywr-python/tests/models/simple-custom-parameter/model.json
@@ -61,6 +61,7 @@
         },
         "type": "Python",
         "source": {
+          "type": "Path",
           "path": "custom.py"
         },
         "object": "CustomParameter",

--- a/pywr-python/tests/models/simple-storage-timeseries/model.json
+++ b/pywr-python/tests/models/simple-storage-timeseries/model.json
@@ -29,7 +29,8 @@
           "value": -1.0
         },
         "initial_volume": {
-          "Absolute": 500.0
+          "type": "Absolute",
+          "value": 500.0
         },
         "max_volume": {
           "type": "Constant",

--- a/pywr-python/tests/models/simple-storage-timeseries/model.json
+++ b/pywr-python/tests/models/simple-storage-timeseries/model.json
@@ -30,7 +30,7 @@
         },
         "initial_volume": {
           "type": "Absolute",
-          "value": 500.0
+          "volume": 500.0
         },
         "max_volume": {
           "type": "Constant",

--- a/pywr-schema/src/metric_sets/mod.rs
+++ b/pywr-schema/src/metric_sets/mod.rs
@@ -9,12 +9,15 @@ use pywr_schema_macros::PywrVisitPaths;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::num::NonZeroUsize;
+use strum_macros::{Display, EnumDiscriminants, EnumIter, EnumString, IntoStaticStr};
 
 /// Aggregation function to apply over metric values.
 #[derive(
-    serde::Deserialize, serde::Serialize, Debug, Copy, Clone, JsonSchema, PywrVisitPaths, strum_macros::Display,
+    serde::Deserialize, serde::Serialize, Debug, Copy, Clone, JsonSchema, PywrVisitPaths, Display, EnumDiscriminants,
 )]
-#[serde(tag = "type")]
+#[serde(tag = "type", deny_unknown_fields)]
+#[strum_discriminants(derive(Display, IntoStaticStr, EnumString, EnumIter))]
+#[strum_discriminants(name(MetricAggFuncType))]
 pub enum MetricAggFunc {
     Sum,
     Max,
@@ -36,8 +39,10 @@ impl From<MetricAggFunc> for pywr_core::recorders::AggregationFunction {
     }
 }
 
-#[derive(serde::Deserialize, serde::Serialize, Debug, Copy, Clone, JsonSchema, strum_macros::Display)]
-#[serde(tag = "type")]
+#[derive(serde::Deserialize, serde::Serialize, Debug, Copy, Clone, JsonSchema, Display, EnumDiscriminants)]
+#[serde(tag = "type", deny_unknown_fields)]
+#[strum_discriminants(derive(Display, IntoStaticStr, EnumString, EnumIter))]
+#[strum_discriminants(name(MetricAggFrequencyType))]
 pub enum MetricAggFrequency {
     Monthly,
     Annual,

--- a/pywr-schema/src/model.rs
+++ b/pywr-schema/src/model.rs
@@ -23,6 +23,7 @@ use pywr_core::{models::ModelDomain, timestep::TimestepDuration, PywrError};
 use schemars::JsonSchema;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
+use strum_macros::{Display, EnumDiscriminants, EnumIter, EnumString, IntoStaticStr};
 
 #[derive(serde::Deserialize, serde::Serialize, Clone, JsonSchema)]
 pub struct Metadata {
@@ -53,8 +54,10 @@ impl From<pywr_v1_schema::model::Metadata> for Metadata {
     }
 }
 
-#[derive(serde::Deserialize, serde::Serialize, Clone, Debug, JsonSchema, strum_macros::Display)]
+#[derive(serde::Deserialize, serde::Serialize, Clone, Debug, JsonSchema, Display, EnumDiscriminants)]
 #[serde(untagged)]
+#[strum_discriminants(derive(Display, IntoStaticStr, EnumString, EnumIter))]
+#[strum_discriminants(name(TimestepType))]
 pub enum Timestep {
     Days(i64),
     Frequency(String),
@@ -69,14 +72,16 @@ impl From<pywr_v1_schema::model::Timestep> for Timestep {
     }
 }
 
-#[derive(serde::Deserialize, serde::Serialize, Clone, Copy, Debug, JsonSchema, strum_macros::Display)]
+#[derive(serde::Deserialize, serde::Serialize, Clone, Copy, Debug, JsonSchema, Display, EnumDiscriminants)]
 #[serde(untagged)]
-pub enum DateType {
+#[strum_discriminants(derive(Display, IntoStaticStr, EnumString, EnumIter))]
+#[strum_discriminants(name(DateType))]
+pub enum Date {
     Date(NaiveDate),
     DateTime(NaiveDateTime),
 }
 
-impl From<pywr_v1_schema::model::DateType> for DateType {
+impl From<pywr_v1_schema::model::DateType> for Date {
     fn from(v1: pywr_v1_schema::model::DateType) -> Self {
         match v1 {
             pywr_v1_schema::model::DateType::Date(date) => Self::Date(date),
@@ -87,16 +92,16 @@ impl From<pywr_v1_schema::model::DateType> for DateType {
 
 #[derive(serde::Deserialize, serde::Serialize, Clone, Debug, JsonSchema)]
 pub struct Timestepper {
-    pub start: DateType,
-    pub end: DateType,
+    pub start: Date,
+    pub end: Date,
     pub timestep: Timestep,
 }
 
 impl Default for Timestepper {
     fn default() -> Self {
         Self {
-            start: DateType::Date(NaiveDate::from_ymd_opt(2000, 1, 1).expect("Invalid date")),
-            end: DateType::Date(NaiveDate::from_ymd_opt(2000, 12, 31).expect("Invalid date")),
+            start: Date::Date(NaiveDate::from_ymd_opt(2000, 1, 1).expect("Invalid date")),
+            end: Date::Date(NaiveDate::from_ymd_opt(2000, 12, 31).expect("Invalid date")),
             timestep: Timestep::Days(1),
         }
     }
@@ -121,13 +126,13 @@ impl From<Timestepper> for pywr_core::timestep::Timestepper {
         };
 
         let start = match ts.start {
-            DateType::Date(date) => NaiveDateTime::new(date, NaiveTime::default()),
-            DateType::DateTime(date_time) => date_time,
+            Date::Date(date) => NaiveDateTime::new(date, NaiveTime::default()),
+            Date::DateTime(date_time) => date_time,
         };
 
         let end = match ts.end {
-            DateType::Date(date) => NaiveDateTime::new(date, NaiveTime::default()),
-            DateType::DateTime(date_time) => date_time,
+            Date::Date(date) => NaiveDateTime::new(date, NaiveTime::default()),
+            Date::DateTime(date_time) => date_time,
         };
 
         Self::new(start, end, timestep)
@@ -153,8 +158,10 @@ pub struct ScenarioGroupLabels {
     pub labels: Vec<String>,
 }
 
-#[derive(serde::Deserialize, serde::Serialize, Clone, JsonSchema)]
-#[serde(tag = "type")]
+#[derive(serde::Deserialize, serde::Serialize, Clone, JsonSchema, Display, EnumDiscriminants)]
+#[serde(tag = "type", deny_unknown_fields)]
+#[strum_discriminants(derive(Display, IntoStaticStr, EnumString, EnumIter))]
+#[strum_discriminants(name(ScenarioGroupSubsetType))]
 pub enum ScenarioGroupSubset {
     Slice(ScenarioGroupSlice),
     Indices(ScenarioGroupIndices),
@@ -206,8 +213,10 @@ impl TryInto<pywr_core::scenario::ScenarioGroup> for ScenarioGroup {
     }
 }
 
-#[derive(serde::Deserialize, serde::Serialize, Clone, JsonSchema)]
+#[derive(serde::Deserialize, serde::Serialize, Clone, JsonSchema, Display, EnumDiscriminants)]
 #[serde(untagged)]
+#[strum_discriminants(derive(Display, IntoStaticStr, EnumString, EnumIter))]
+#[strum_discriminants(name(ScenarioLabelOrIndexType))]
 pub enum ScenarioLabelOrIndex {
     Label(String),
     Index(usize),
@@ -662,8 +671,10 @@ impl PywrNetwork {
     }
 }
 
-#[derive(serde::Deserialize, serde::Serialize, Clone, strum_macros::Display)]
+#[derive(serde::Deserialize, serde::Serialize, Clone, Display, EnumDiscriminants)]
 #[serde(untagged)]
+#[strum_discriminants(derive(Display, IntoStaticStr, EnumString, EnumIter))]
+#[strum_discriminants(name(PywrNetworkRefType))]
 pub enum PywrNetworkRef {
     Path(PathBuf),
     Inline(PywrNetwork),
@@ -726,7 +737,7 @@ impl VisitMetrics for PywrModel {
 }
 
 impl PywrModel {
-    pub fn new(title: &str, start: &DateType, end: &DateType) -> Self {
+    pub fn new(title: &str, start: &Date, end: &Date) -> Self {
         Self {
             metadata: Metadata {
                 title: title.to_string(),
@@ -1071,14 +1082,14 @@ mod tests {
         let timestep: Timestepper = serde_json::from_str(timestepper_str).unwrap();
 
         match timestep.start {
-            super::DateType::Date(date) => {
+            super::Date::Date(date) => {
                 assert_eq!(date, chrono::NaiveDate::from_ymd_opt(2015, 1, 1).unwrap());
             }
             _ => panic!("Expected a date"),
         }
 
         match timestep.end {
-            super::DateType::Date(date) => {
+            super::Date::Date(date) => {
                 assert_eq!(date, chrono::NaiveDate::from_ymd_opt(2015, 12, 31).unwrap());
             }
             _ => panic!("Expected a date"),
@@ -1098,7 +1109,7 @@ mod tests {
         let timestep: Timestepper = serde_json::from_str(timestepper_str).unwrap();
 
         match timestep.start {
-            super::DateType::DateTime(date_time) => {
+            super::Date::DateTime(date_time) => {
                 assert_eq!(
                     date_time,
                     chrono::NaiveDate::from_ymd_opt(2015, 1, 1)
@@ -1111,7 +1122,7 @@ mod tests {
         }
 
         match timestep.end {
-            super::DateType::DateTime(date_time) => {
+            super::Date::DateTime(date_time) => {
                 assert_eq!(
                     date_time,
                     chrono::NaiveDate::from_ymd_opt(2015, 1, 1)

--- a/pywr-schema/src/nodes/core.rs
+++ b/pywr-schema/src/nodes/core.rs
@@ -20,6 +20,7 @@ use pywr_v1_schema::nodes::{
     ReservoirNode as ReservoirNodeV1, StorageNode as StorageNodeV1,
 };
 use schemars::JsonSchema;
+use strum_macros::{Display, EnumDiscriminants, EnumIter, EnumString, IntoStaticStr};
 
 #[derive(serde::Deserialize, serde::Serialize, Clone, Default, Debug, JsonSchema, PywrVisitAll)]
 #[serde(deny_unknown_fields)]
@@ -703,8 +704,20 @@ impl TryFromV1<OutputNodeV1> for OutputNode {
 }
 
 #[derive(
-    serde::Deserialize, serde::Serialize, Clone, PartialEq, Copy, Debug, JsonSchema, PywrVisitAll, strum_macros::Display,
+    serde::Deserialize,
+    serde::Serialize,
+    Clone,
+    PartialEq,
+    Copy,
+    Debug,
+    JsonSchema,
+    PywrVisitAll,
+    Display,
+    EnumDiscriminants,
 )]
+#[serde(tag = "type", content = "value", deny_unknown_fields)]
+#[strum_discriminants(derive(Display, IntoStaticStr, EnumString, EnumIter))]
+#[strum_discriminants(name(StorageInitialVolumeType))]
 pub enum StorageInitialVolume {
     Absolute(f64),
     Proportional(f64),
@@ -999,8 +1012,10 @@ impl TryFromV1<CatchmentNodeV1> for CatchmentNode {
     }
 }
 
-#[derive(serde::Deserialize, serde::Serialize, Clone, Debug, JsonSchema, PywrVisitAll, strum_macros::Display)]
+#[derive(serde::Deserialize, serde::Serialize, Clone, Debug, JsonSchema, PywrVisitAll, Display, EnumDiscriminants)]
 #[serde(tag = "type", deny_unknown_fields)]
+#[strum_discriminants(derive(Display, IntoStaticStr, EnumString, EnumIter))]
+#[strum_discriminants(name(RelationshipType))]
 pub enum Relationship {
     Proportion {
         factors: Vec<Metric>,
@@ -1342,7 +1357,8 @@ mod tests {
                   "value": 10.0
                 },
                 "initial_volume": {
-                    "Absolute": 12.0
+                  "type": "Absolute",
+                  "value": 12.0
                 }
             }
             "#;
@@ -1364,7 +1380,8 @@ mod tests {
                   "value": 15.0
                 },
                 "initial_volume": {
-                    "Proportional": 0.5
+                  "type": "Proportional",
+                  "value": 0.5
                 }
             }
             "#;

--- a/pywr-schema/src/nodes/core.rs
+++ b/pywr-schema/src/nodes/core.rs
@@ -715,17 +715,17 @@ impl TryFromV1<OutputNodeV1> for OutputNode {
     Display,
     EnumDiscriminants,
 )]
-#[serde(tag = "type", content = "value", deny_unknown_fields)]
+#[serde(tag = "type", deny_unknown_fields)]
 #[strum_discriminants(derive(Display, IntoStaticStr, EnumString, EnumIter))]
 #[strum_discriminants(name(StorageInitialVolumeType))]
 pub enum StorageInitialVolume {
-    Absolute(f64),
-    Proportional(f64),
+    Absolute { volume: f64 },
+    Proportional { proportion: f64 },
 }
 
 impl Default for StorageInitialVolume {
     fn default() -> Self {
-        StorageInitialVolume::Proportional(1.0)
+        StorageInitialVolume::Proportional { proportion: 1.0 }
     }
 }
 
@@ -733,8 +733,8 @@ impl Default for StorageInitialVolume {
 impl From<StorageInitialVolume> for CoreStorageInitialVolume {
     fn from(v: StorageInitialVolume) -> Self {
         match v {
-            StorageInitialVolume::Absolute(v) => CoreStorageInitialVolume::Absolute(v),
-            StorageInitialVolume::Proportional(v) => CoreStorageInitialVolume::Proportional(v),
+            StorageInitialVolume::Absolute { volume } => CoreStorageInitialVolume::Absolute(volume),
+            StorageInitialVolume::Proportional { proportion } => CoreStorageInitialVolume::Proportional(proportion),
         }
     }
 }
@@ -1358,14 +1358,14 @@ mod tests {
                 },
                 "initial_volume": {
                   "type": "Absolute",
-                  "value": 12.0
+                  "volume": 12.0
                 }
             }
             "#;
 
         let storage: StorageNode = serde_json::from_str(data).unwrap();
 
-        assert_eq!(storage.initial_volume, StorageInitialVolume::Absolute(12.0));
+        assert_eq!(storage.initial_volume, StorageInitialVolume::Absolute { volume: 12.0 });
     }
 
     #[test]
@@ -1381,13 +1381,16 @@ mod tests {
                 },
                 "initial_volume": {
                   "type": "Proportional",
-                  "value": 0.5
+                  "proportion": 0.5
                 }
             }
             "#;
 
         let storage: StorageNode = serde_json::from_str(data).unwrap();
 
-        assert_eq!(storage.initial_volume, StorageInitialVolume::Proportional(0.5));
+        assert_eq!(
+            storage.initial_volume,
+            StorageInitialVolume::Proportional { proportion: 0.5 }
+        );
     }
 }

--- a/pywr-schema/src/nodes/loss_link.rs
+++ b/pywr-schema/src/nodes/loss_link.rs
@@ -12,14 +12,17 @@ use pywr_core::{aggregated_node::Relationship, metric::MetricF64};
 use pywr_schema_macros::PywrVisitAll;
 use pywr_v1_schema::nodes::LossLinkNode as LossLinkNodeV1;
 use schemars::JsonSchema;
+use strum_macros::{Display, EnumDiscriminants, EnumIter, EnumString, IntoStaticStr};
 
 /// The type of loss factor applied.
 ///
 /// Gross losses are typically applied as a proportion of the total flow into a node, whereas
 /// net losses are applied as a proportion of the net flow. Please see the documentation for
 /// specific nodes (e.g. [`LossLinkNode`]) to understand how the loss factor is applied.
-#[derive(serde::Deserialize, serde::Serialize, Clone, Debug, JsonSchema, PywrVisitAll, strum_macros::Display)]
+#[derive(serde::Deserialize, serde::Serialize, Clone, Debug, JsonSchema, PywrVisitAll, Display, EnumDiscriminants)]
 #[serde(tag = "type", deny_unknown_fields)]
+#[strum_discriminants(derive(Display, IntoStaticStr, EnumString, EnumIter))]
+#[strum_discriminants(name(LossFactorType))]
 pub enum LossFactor {
     Gross { factor: Metric },
     Net { factor: Metric },

--- a/pywr-schema/src/nodes/mod.rs
+++ b/pywr-schema/src/nodes/mod.rs
@@ -45,7 +45,7 @@ pub use river_split_with_gauge::{RiverSplit, RiverSplitWithGaugeNode};
 pub use rolling_virtual_storage::{RollingVirtualStorageNode, RollingWindow};
 use schemars::JsonSchema;
 use std::path::{Path, PathBuf};
-use strum_macros::{Display, EnumDiscriminants, EnumString, IntoStaticStr, VariantNames};
+use strum_macros::{Display, EnumDiscriminants, EnumIter, EnumString, IntoStaticStr};
 pub use turbine::{TargetType, TurbineNode};
 pub use virtual_storage::VirtualStorageNode;
 pub use water_treatment_works::WaterTreatmentWorks;
@@ -89,7 +89,9 @@ impl From<NodeMetaV1> for NodeMeta {
 /// All possible attributes that could be produced by a node.
 ///
 ///
-#[derive(serde::Deserialize, serde::Serialize, Debug, Clone, Copy, Display, JsonSchema, PywrVisitAll, PartialEq)]
+#[derive(
+    serde::Deserialize, serde::Serialize, Debug, Clone, Copy, Display, JsonSchema, PywrVisitAll, PartialEq, EnumIter,
+)]
 pub enum NodeAttribute {
     Inflow,
     Outflow,
@@ -238,9 +240,9 @@ impl NodeBuilder {
     }
 }
 
-#[derive(serde::Deserialize, serde::Serialize, Clone, EnumDiscriminants, Debug, JsonSchema, strum_macros::Display)]
-#[serde(tag = "type")]
-#[strum_discriminants(derive(Display, IntoStaticStr, EnumString, VariantNames))]
+#[derive(serde::Deserialize, serde::Serialize, Clone, EnumDiscriminants, Debug, JsonSchema, Display)]
+#[serde(tag = "type", deny_unknown_fields)]
+#[strum_discriminants(derive(Display, IntoStaticStr, EnumString, EnumIter))]
 // This creates a separate enum called `NodeType` that is available in this module.
 #[strum_discriminants(name(NodeType))]
 pub enum Node {

--- a/pywr-schema/src/nodes/turbine.rs
+++ b/pywr-schema/src/nodes/turbine.rs
@@ -13,8 +13,11 @@ use pywr_core::{
 };
 use pywr_schema_macros::PywrVisitAll;
 use schemars::JsonSchema;
+use strum_macros::EnumIter;
 
-#[derive(serde::Deserialize, serde::Serialize, Clone, Debug, strum_macros::Display, JsonSchema, PywrVisitAll)]
+#[derive(
+    serde::Deserialize, serde::Serialize, Clone, Debug, strum_macros::Display, JsonSchema, PywrVisitAll, EnumIter,
+)]
 pub enum TargetType {
     // set flow derived from the hydropower target as a max_flow
     MaxFlow,

--- a/pywr-schema/src/outputs/csv.rs
+++ b/pywr-schema/src/outputs/csv.rs
@@ -9,19 +9,23 @@ use std::num::NonZeroU32;
 #[cfg(feature = "core")]
 use std::path::Path;
 use std::path::PathBuf;
+use strum_macros::{Display, EnumDiscriminants, EnumIter, EnumString, IntoStaticStr};
 
 #[derive(
-    serde::Deserialize, serde::Serialize, Debug, Clone, Default, JsonSchema, PywrVisitPaths, strum_macros::Display,
+    serde::Deserialize, serde::Serialize, Debug, Clone, Default, JsonSchema, PywrVisitPaths, Display, EnumIter,
 )]
-#[serde(rename_all = "lowercase")]
 pub enum CsvFormat {
     Wide,
     #[default]
     Long,
 }
 
-#[derive(serde::Deserialize, serde::Serialize, Debug, Clone, JsonSchema, PywrVisitPaths, strum_macros::Display)]
+#[derive(
+    serde::Deserialize, serde::Serialize, Debug, Clone, JsonSchema, PywrVisitPaths, Display, EnumDiscriminants,
+)]
 #[serde(untagged)]
+#[strum_discriminants(derive(Display, IntoStaticStr, EnumString, EnumIter))]
+#[strum_discriminants(name(CsvMetricSetType))]
 pub enum CsvMetricSet {
     Single(String),
     Multiple(Vec<String>),

--- a/pywr-schema/src/outputs/memory.rs
+++ b/pywr-schema/src/outputs/memory.rs
@@ -5,6 +5,7 @@ use crate::SchemaError;
 use pywr_core::recorders::MemoryRecorder;
 use pywr_schema_macros::PywrVisitPaths;
 use schemars::JsonSchema;
+use strum_macros::{Display, EnumIter};
 
 #[derive(serde::Deserialize, serde::Serialize, Debug, Clone, JsonSchema, PywrVisitPaths)]
 pub struct MemoryAggregation {
@@ -24,9 +25,7 @@ impl From<MemoryAggregation> for pywr_core::recorders::Aggregation {
     }
 }
 
-#[derive(
-    serde::Deserialize, serde::Serialize, Debug, Copy, Clone, JsonSchema, PywrVisitPaths, strum_macros::Display,
-)]
+#[derive(serde::Deserialize, serde::Serialize, Debug, Copy, Clone, JsonSchema, PywrVisitPaths, Display, EnumIter)]
 pub enum MemoryAggregationOrder {
     MetricTimeScenario,
     TimeMetricScenario,

--- a/pywr-schema/src/outputs/mod.rs
+++ b/pywr-schema/src/outputs/mod.rs
@@ -11,9 +11,14 @@ use pywr_schema_macros::PywrVisitPaths;
 use schemars::JsonSchema;
 #[cfg(feature = "core")]
 use std::path::Path;
+use strum_macros::{Display, EnumDiscriminants, EnumIter, EnumString, IntoStaticStr};
 
-#[derive(serde::Deserialize, serde::Serialize, Debug, Clone, JsonSchema, PywrVisitPaths, strum_macros::Display)]
+#[derive(
+    serde::Deserialize, serde::Serialize, Debug, Clone, JsonSchema, PywrVisitPaths, Display, EnumDiscriminants,
+)]
 #[serde(tag = "type")]
+#[strum_discriminants(derive(Display, IntoStaticStr, EnumString, EnumIter))]
+#[strum_discriminants(name(OutputType))]
 pub enum Output {
     CSV(CsvOutput),
     HDF5(Hdf5Output),

--- a/pywr-schema/src/parameters/aggregated.rs
+++ b/pywr-schema/src/parameters/aggregated.rs
@@ -15,6 +15,7 @@ use pywr_v1_schema::parameters::{
 };
 use schemars::JsonSchema;
 use std::collections::HashMap;
+use strum_macros::{Display, EnumIter};
 
 // TODO complete these
 /// Aggregation functions for float values.
@@ -22,8 +23,7 @@ use std::collections::HashMap;
 /// This enum defines the possible aggregation functions that can be applied to index metrics.
 /// They are mapped to the corresponding functions in the `pywr_core::parameters::AggFunc` enum
 /// when used in the core library.
-#[derive(serde::Deserialize, serde::Serialize, Debug, Copy, Clone, strum_macros::Display, JsonSchema, PywrVisitAll)]
-#[serde(rename_all = "lowercase")]
+#[derive(serde::Deserialize, serde::Serialize, Debug, Copy, Clone, Display, JsonSchema, PywrVisitAll, EnumIter)]
 pub enum AggFunc {
     /// Sum of all values.
     Sum,
@@ -146,8 +146,7 @@ impl TryFromV1<AggregatedParameterV1> for AggregatedParameter {
 /// This enum defines the possible aggregation functions that can be applied to index metrics.
 /// They are mapped to the corresponding functions in the `pywr_core::parameters::AggIndexFunc` enum
 /// when used in the core library.
-#[derive(serde::Deserialize, serde::Serialize, Debug, Copy, Clone, strum_macros::Display, JsonSchema, PywrVisitAll)]
-#[serde(rename_all = "lowercase")]
+#[derive(serde::Deserialize, serde::Serialize, Debug, Copy, Clone, Display, JsonSchema, PywrVisitAll, EnumIter)]
 pub enum IndexAggFunc {
     /// Sum of all values.
     Sum,
@@ -275,7 +274,7 @@ mod tests {
                     "name": "my-agg-param",
                     "comment": "Take the minimum of two parameters"
                 },
-                "agg_func": "min",
+                "agg_func": "Min",
                 "metrics": [
                   {
                     "type": "Parameter",

--- a/pywr-schema/src/parameters/core.rs
+++ b/pywr-schema/src/parameters/core.rs
@@ -15,6 +15,7 @@ use pywr_v1_schema::parameters::{
     NegativeMinParameter as NegativeMinParameterV1, NegativeParameter as NegativeParameterV1,
 };
 use schemars::JsonSchema;
+use strum_macros::{Display, EnumDiscriminants, EnumIter, EnumString, IntoStaticStr};
 
 /// Activation function or transformation to apply to variable value.
 ///
@@ -23,8 +24,12 @@ use schemars::JsonSchema;
 /// algorithms to represent a, for example, binary-like variable in a continuous domain. Each
 /// activation function requires different data to parameterize the function's behaviour.
 ///
-#[derive(serde::Deserialize, serde::Serialize, Debug, Clone, Copy, JsonSchema, PywrVisitAll, strum_macros::Display)]
+#[derive(
+    serde::Deserialize, serde::Serialize, Debug, Clone, Copy, JsonSchema, PywrVisitAll, Display, EnumDiscriminants,
+)]
 #[serde(tag = "type", deny_unknown_fields)]
+#[strum_discriminants(derive(Display, IntoStaticStr, EnumString, EnumIter))]
+#[strum_discriminants(name(ActivationFunctionType))]
 pub enum ActivationFunction {
     /// A unit or null transformation.
     ///

--- a/pywr-schema/src/parameters/doc_examples/aggregated_1.json
+++ b/pywr-schema/src/parameters/doc_examples/aggregated_1.json
@@ -3,7 +3,7 @@
     "name": "my-aggregated-value"
   },
   "type": "Aggregated",
-  "agg_func": "sum",
+  "agg_func": "Sum",
   "metrics": [
     {
       "type": "Constant",

--- a/pywr-schema/src/parameters/doc_examples/rbf_1.json
+++ b/pywr-schema/src/parameters/doc_examples/rbf_1.json
@@ -18,8 +18,7 @@
     ]
   ],
   "function": {
-    "Gaussian": {
-      "epsilon": 3.0
-    }
+    "type": "Gaussian",
+    "epsilon": 3.0
   }
 }

--- a/pywr-schema/src/parameters/doc_examples/rbf_2.json
+++ b/pywr-schema/src/parameters/doc_examples/rbf_2.json
@@ -18,9 +18,8 @@
     ]
   ],
   "function": {
-    "Gaussian": {
-      "epsilon": 3.0
-    }
+    "type": "Gaussian",
+    "epsilon": 3.0
   },
   "variable": {
     "is_active": true,

--- a/pywr-schema/src/parameters/mod.rs
+++ b/pywr-schema/src/parameters/mod.rs
@@ -69,7 +69,7 @@ use pywr_v1_schema::parameters::{
 pub use rolling::{RollingIndexParameter, RollingParameter};
 use schemars::JsonSchema;
 use std::path::{Path, PathBuf};
-use strum_macros::{Display, EnumDiscriminants, EnumString, IntoStaticStr, VariantNames};
+use strum_macros::{Display, EnumDiscriminants, EnumIter, EnumString, IntoStaticStr};
 pub use tables::TablesArrayParameter;
 pub use thresholds::ThresholdParameter;
 
@@ -82,7 +82,7 @@ pub struct ParameterMeta {
 
 #[derive(serde::Deserialize, serde::Serialize, Debug, EnumDiscriminants, Clone, JsonSchema, Display)]
 #[serde(tag = "type")]
-#[strum_discriminants(derive(Display, IntoStaticStr, EnumString, VariantNames))]
+#[strum_discriminants(derive(Display, IntoStaticStr, EnumString, EnumIter))]
 // This creates a separate enum called `ParameterType` that is available in this module.
 #[strum_discriminants(name(ParameterType))]
 pub enum Parameter {
@@ -540,11 +540,13 @@ impl TryFromV1<ParameterV1> for ParameterOrTimeseriesRef {
     }
 }
 
-/// An non-variable constant floating-point (f64) value
+/// A non-variable constant floating-point (f64) value
 ///
 /// This value can be a literal float or an external reference to an input table.
-#[derive(serde::Deserialize, serde::Serialize, Debug, Clone, JsonSchema, Display)]
+#[derive(serde::Deserialize, serde::Serialize, Debug, Clone, JsonSchema, Display, EnumDiscriminants)]
 #[serde(untagged)]
+#[strum_discriminants(derive(Display, IntoStaticStr, EnumString, EnumIter))]
+#[strum_discriminants(name(ConstantValueType))]
 pub enum ConstantValue<T> {
     Literal(T),
     Table(TableDataRef),
@@ -650,8 +652,12 @@ impl TryFrom<ParameterValueV1> for ConstantValue<f64> {
 /// An non-variable vector of constant floating-point (f64) values
 ///
 /// This value can be a literal vector of floats or an external reference to an input table.
-#[derive(serde::Deserialize, serde::Serialize, Debug, Clone, JsonSchema, PywrVisitAll, Display)]
+#[derive(
+    serde::Deserialize, serde::Serialize, Debug, Clone, JsonSchema, PywrVisitAll, Display, EnumDiscriminants, PartialEq,
+)]
 #[serde(untagged)]
+#[strum_discriminants(derive(Display, IntoStaticStr, EnumString, EnumIter))]
+#[strum_discriminants(name(ConstantFloatVecType))]
 pub enum ConstantFloatVec {
     Literal(Vec<f64>),
     Table(TableDataRef),
@@ -674,8 +680,12 @@ impl ConstantFloatVec {
     }
 }
 
-#[derive(serde::Deserialize, serde::Serialize, Debug, Clone, JsonSchema, PywrVisitAll, Display, PartialEq)]
+#[derive(
+    serde::Deserialize, serde::Serialize, Debug, Clone, JsonSchema, PywrVisitAll, Display, PartialEq, EnumDiscriminants,
+)]
 #[serde(untagged)]
+#[strum_discriminants(derive(Display, IntoStaticStr, EnumString, EnumIter))]
+#[strum_discriminants(name(TableIndexType))]
 pub enum TableIndex {
     Single(String),
     Multi(Vec<String>),

--- a/pywr-schema/src/parameters/profiles.rs
+++ b/pywr-schema/src/parameters/profiles.rs
@@ -15,6 +15,7 @@ use pywr_v1_schema::parameters::{
     WeeklyProfileParameter as WeeklyProfileParameterV1,
 };
 use schemars::JsonSchema;
+use strum_macros::{Display, EnumDiscriminants, EnumIter, EnumString, IntoStaticStr};
 
 #[derive(serde::Deserialize, serde::Serialize, Debug, Clone, JsonSchema, PywrVisitAll)]
 #[serde(deny_unknown_fields)]
@@ -56,7 +57,7 @@ impl TryFromV1<DailyProfileParameterV1> for DailyProfileParameter {
     }
 }
 
-#[derive(serde::Deserialize, serde::Serialize, Debug, Copy, Clone, strum_macros::Display, JsonSchema, PywrVisitAll)]
+#[derive(serde::Deserialize, serde::Serialize, Debug, Copy, Clone, Display, JsonSchema, PywrVisitAll, EnumIter)]
 pub enum MonthlyInterpDay {
     First,
     Last,
@@ -185,8 +186,12 @@ impl FromV1<UniformDrawdownProfileParameterV1> for UniformDrawdownProfileParamet
 }
 
 /// Distance functions for radial basis function interpolation.
-#[derive(serde::Deserialize, serde::Serialize, Debug, Copy, Clone, JsonSchema, PywrVisitAll, strum_macros::Display)]
-#[serde(deny_unknown_fields)]
+#[derive(
+    serde::Deserialize, serde::Serialize, Debug, Copy, Clone, JsonSchema, PywrVisitAll, Display, EnumDiscriminants,
+)]
+#[serde(tag = "type", deny_unknown_fields)]
+#[strum_discriminants(derive(Display, IntoStaticStr, EnumString, EnumIter))]
+#[strum_discriminants(name(RadialBasisFunctionType))]
 pub enum RadialBasisFunction {
     Linear,
     Cubic,
@@ -437,7 +442,7 @@ impl TryFromV1<RbfProfileParameterV1> for RbfProfileParameter {
     }
 }
 
-#[derive(serde::Deserialize, serde::Serialize, Debug, Copy, Clone, JsonSchema, PywrVisitAll, strum_macros::Display)]
+#[derive(serde::Deserialize, serde::Serialize, Debug, Copy, Clone, JsonSchema, PywrVisitAll, Display, EnumIter)]
 pub enum WeeklyInterpDay {
     First,
     Last,

--- a/pywr-schema/src/parameters/python.rs
+++ b/pywr-schema/src/parameters/python.rs
@@ -24,17 +24,19 @@ use std::collections::HashMap;
 #[cfg(all(feature = "core", feature = "pyo3"))]
 use std::ffi::CString;
 use std::path::{Path, PathBuf};
+use strum_macros::{Display, EnumDiscriminants, EnumIter, EnumString, IntoStaticStr};
 
-#[derive(serde::Deserialize, serde::Serialize, Debug, Clone, JsonSchema, strum_macros::Display)]
-#[serde(rename_all = "lowercase")]
+#[derive(serde::Deserialize, serde::Serialize, Debug, Clone, JsonSchema, Display, EnumDiscriminants)]
+#[serde(tag = "type", deny_unknown_fields)]
+#[strum_discriminants(derive(Display, IntoStaticStr, EnumString, EnumIter))]
+#[strum_discriminants(name(PythonSourceType))]
 pub enum PythonSource {
-    Module(String),
-    Path(PathBuf),
+    Module { module: String },
+    Path { path: PathBuf },
 }
 
 /// The expected return type of the Python parameter.
-#[derive(serde::Deserialize, serde::Serialize, Debug, Clone, Default, JsonSchema, strum_macros::Display)]
-#[serde(rename_all = "lowercase")]
+#[derive(serde::Deserialize, serde::Serialize, Debug, Clone, Default, JsonSchema, Display, EnumIter)]
 pub enum PythonReturnType {
     #[default]
     Float,
@@ -164,8 +166,8 @@ impl VisitMetrics for PythonParameter {
 impl VisitPaths for PythonParameter {
     fn visit_paths<F: FnMut(&Path)>(&self, visitor: &mut F) {
         match &self.source {
-            PythonSource::Module(_) => {}
-            PythonSource::Path(path) => {
+            PythonSource::Module { .. } => {}
+            PythonSource::Path { path } => {
                 visitor(path);
             }
         }
@@ -177,8 +179,8 @@ impl VisitPaths for PythonParameter {
 
     fn visit_paths_mut<F: FnMut(&mut PathBuf)>(&mut self, visitor: &mut F) {
         match &mut self.source {
-            PythonSource::Module(_) => {}
-            PythonSource::Path(path) => {
+            PythonSource::Module { .. } => {}
+            PythonSource::Path { path } => {
                 visitor(path);
             }
         }
@@ -215,9 +217,9 @@ impl PythonParameter {
 
         let object = Python::with_gil(|py| {
             let module = match &self.source {
-                PythonSource::Module(module) => PyModule::import(py, module.as_str()),
-                PythonSource::Path(original_path) => {
-                    let path = &make_path(original_path, args.data_path);
+                PythonSource::Module { module } => PyModule::import(py, module.as_str()),
+                PythonSource::Path { path } => {
+                    let path = &make_path(path, args.data_path);
                     let code = CString::new(std::fs::read_to_string(path).map_err(|error| SchemaError::IO {
                         path: path.to_path_buf(),
                         error,
@@ -318,6 +320,7 @@ mod tests {
                     "name": "my-float-parameter"
                 },
                 "source": {
+                    "type": "Path",
                     "path": py_fn
                 },
                 "object": "FloatParameter",
@@ -364,9 +367,10 @@ mod tests {
                     "name": "my-int-parameter"
                 },
                 "source": {
+                    "type": "Path",
                     "path": py_fn
                 },
-                "return_type": "int",
+                "return_type": "Int",
                 "object": "FloatParameter",
                 "args": [0, ],
                 "kwargs": {},

--- a/pywr-schema/src/parameters/thresholds.rs
+++ b/pywr-schema/src/parameters/thresholds.rs
@@ -15,8 +15,9 @@ use pywr_v1_schema::parameters::{
     Predicate as PredicateV1, StorageThresholdParameter as StorageThresholdParameterV1,
 };
 use schemars::JsonSchema;
+use strum_macros::{Display, EnumIter};
 
-#[derive(serde::Deserialize, serde::Serialize, Debug, Clone, Copy, JsonSchema, PywrVisitAll, strum_macros::Display)]
+#[derive(serde::Deserialize, serde::Serialize, Debug, Clone, Copy, JsonSchema, PywrVisitAll, Display, EnumIter)]
 pub enum Predicate {
     #[serde(alias = "<")]
     LT,

--- a/pywr-schema/src/v1.rs
+++ b/pywr-schema/src/v1.rs
@@ -176,10 +176,10 @@ pub fn try_convert_initial_storage(
     v1_initial_volume: Option<f64>,
     v1_initial_volume_pc: Option<f64>,
 ) -> Result<StorageInitialVolume, ComponentConversionError> {
-    let initial_volume = if let Some(v) = v1_initial_volume {
-        StorageInitialVolume::Absolute(v)
-    } else if let Some(v) = v1_initial_volume_pc {
-        StorageInitialVolume::Proportional(v)
+    let initial_volume = if let Some(volume) = v1_initial_volume {
+        StorageInitialVolume::Absolute { volume }
+    } else if let Some(proportion) = v1_initial_volume_pc {
+        StorageInitialVolume::Proportional { proportion }
     } else {
         return Err(ComponentConversionError::Node {
             attr: attr.to_string(),

--- a/pywr-schema/tests/30-day-licence.json
+++ b/pywr-schema/tests/30-day-licence.json
@@ -57,7 +57,7 @@
         },
         "initial_volume": {
           "type": "Proportional",
-          "value": 0.0
+          "proportion": 0.0
         },
         "window": {
           "type": "Days",

--- a/pywr-schema/tests/30-day-licence.json
+++ b/pywr-schema/tests/30-day-licence.json
@@ -56,10 +56,12 @@
           "value": 300
         },
         "initial_volume": {
-          "Proportional": 0.0
+          "type": "Proportional",
+          "value": 0.0
         },
         "window": {
-          "Days": 30
+          "type": "Days",
+          "days": 30
         }
       }
     ],

--- a/pywr-schema/tests/csv1.json
+++ b/pywr-schema/tests/csv1.json
@@ -76,14 +76,14 @@
       {
         "name": "my-outputs",
         "type": "CSV",
-        "format": "long",
+        "format": "Long",
         "filename": "csv1-outputs-long.csv",
         "metric_set": "nodes"
       },
       {
         "name": "my-outputs",
         "type": "CSV",
-        "format": "wide",
+        "format": "Wide",
         "filename": "csv1-outputs-wide.csv",
         "metric_set": "nodes"
       }

--- a/pywr-schema/tests/csv2.json
+++ b/pywr-schema/tests/csv2.json
@@ -84,14 +84,14 @@
       {
         "name": "monthly-avg-outputs",
         "type": "CSV",
-        "format": "long",
+        "format": "Long",
         "filename": "csv2-outputs-long.csv",
         "metric_set": "nodes"
       },
       {
         "name": "monthly-avg-outputs",
         "type": "CSV",
-        "format": "wide",
+        "format": "Wide",
         "filename": "csv2-outputs-wide.csv",
         "metric_set": "nodes"
       }

--- a/pywr-schema/tests/csv3.json
+++ b/pywr-schema/tests/csv3.json
@@ -101,7 +101,7 @@
       {
         "name": "monthly-avg-outputs",
         "type": "CSV",
-        "format": "long",
+        "format": "Long",
         "filename": "csv3-outputs-long.csv",
         "metric_set": [
           "nodes-monthly-mean",

--- a/pywr-schema/tests/delay1.json
+++ b/pywr-schema/tests/delay1.json
@@ -75,7 +75,7 @@
       {
         "name": "nodes",
         "type": "CSV",
-        "format": "long",
+        "format": "Long",
         "filename": "delay1-expected.csv",
         "metric_set": "nodes"
       }

--- a/pywr-schema/tests/local-parameter1.json
+++ b/pywr-schema/tests/local-parameter1.json
@@ -76,7 +76,7 @@
       {
         "name": "node-outputs",
         "type": "CSV",
-        "format": "long",
+        "format": "Long",
         "filename": "local-parameter1-expected.csv",
         "metric_set": [
           "nodes"

--- a/pywr-schema/tests/loss_link1.json
+++ b/pywr-schema/tests/loss_link1.json
@@ -174,7 +174,7 @@
       {
         "name": "node-outputs",
         "type": "CSV",
-        "format": "long",
+        "format": "Long",
         "filename": "loss_link1-expected.csv",
         "metric_set": [
           "nodes"

--- a/pywr-schema/tests/loss_link2.json
+++ b/pywr-schema/tests/loss_link2.json
@@ -104,7 +104,7 @@
       {
         "name": "node-outputs",
         "type": "CSV",
-        "format": "long",
+        "format": "Long",
         "filename": "loss_link2-expected.csv",
         "metric_set": [
           "nodes"

--- a/pywr-schema/tests/mutual-exclusivity1.json
+++ b/pywr-schema/tests/mutual-exclusivity1.json
@@ -132,7 +132,7 @@
       {
         "name": "node-outputs",
         "type": "CSV",
-        "format": "long",
+        "format": "Long",
         "filename": "mutual-exclusivity1.csv",
         "metric_set": [
           "nodes"

--- a/pywr-schema/tests/mutual-exclusivity2.json
+++ b/pywr-schema/tests/mutual-exclusivity2.json
@@ -149,7 +149,7 @@
       {
         "name": "node-outputs",
         "type": "CSV",
-        "format": "long",
+        "format": "Long",
         "filename": "mutual-exclusivity2.csv",
         "metric_set": [
           "nodes"

--- a/pywr-schema/tests/mutual-exclusivity3.json
+++ b/pywr-schema/tests/mutual-exclusivity3.json
@@ -152,7 +152,7 @@
       {
         "name": "node-outputs",
         "type": "CSV",
-        "format": "long",
+        "format": "Long",
         "filename": "mutual-exclusivity3.csv",
         "metric_set": [
           "nodes"

--- a/pywr-schema/tests/piecewise_link1.json
+++ b/pywr-schema/tests/piecewise_link1.json
@@ -108,7 +108,7 @@
       {
         "name": "node-outputs",
         "type": "CSV",
-        "format": "long",
+        "format": "Long",
         "filename": "piecewise-link1-nodes.csv",
         "metric_set": [
           "nodes"
@@ -118,7 +118,7 @@
       {
         "name": "edge-outputs",
         "type": "CSV",
-        "format": "long",
+        "format": "Long",
         "filename": "piecewise-link1-edges.csv",
         "metric_set": [
           "edges"

--- a/pywr-schema/tests/piecewise_storage1.json
+++ b/pywr-schema/tests/piecewise_storage1.json
@@ -97,7 +97,7 @@
       {
         "name": "nodes",
         "type": "CSV",
-        "format": "long",
+        "format": "Long",
         "filename": "piecewise_storage1-expected.csv",
         "metric_set": "nodes",
         "decimal_places": 1

--- a/pywr-schema/tests/piecewise_storage2.json
+++ b/pywr-schema/tests/piecewise_storage2.json
@@ -146,7 +146,7 @@
       {
         "name": "nodes",
         "type": "CSV",
-        "format": "long",
+        "format": "Long",
         "filename": "piecewise_storage2-expected.csv",
         "metric_set": "nodes",
         "decimal_places": 1

--- a/pywr-schema/tests/river_loss1.json
+++ b/pywr-schema/tests/river_loss1.json
@@ -102,7 +102,7 @@
       {
         "name": "node-outputs",
         "type": "CSV",
-        "format": "long",
+        "format": "Long",
         "filename": "river_loss1-expected.csv",
         "metric_set": [
           "nodes"

--- a/pywr-schema/tests/storage_max_volumes.json
+++ b/pywr-schema/tests/storage_max_volumes.json
@@ -27,7 +27,8 @@
         },
         "type": "Storage",
         "initial_volume": {
-          "Proportional": 0.5
+          "type": "Proportional",
+          "value": 0.5
         },
         "max_volume": {
           "type": "Constant",
@@ -40,7 +41,8 @@
         },
         "type": "Storage",
         "initial_volume": {
-          "Proportional": 0.5
+          "type": "Proportional",
+          "value": 0.5
         },
         "max_volume": {
           "type": "Parameter",
@@ -53,7 +55,8 @@
         },
         "type": "Storage",
         "initial_volume": {
-          "Proportional": 0.5
+          "type": "Proportional",
+          "value": 0.5
         },
         "max_volume": {
           "type": "Parameter",
@@ -113,7 +116,7 @@
           "name": "fifteen"
         },
         "type": "Aggregated",
-        "agg_func": "sum",
+        "agg_func": "Sum",
         "metrics": [
           {
             "type": "Parameter",

--- a/pywr-schema/tests/storage_max_volumes.json
+++ b/pywr-schema/tests/storage_max_volumes.json
@@ -28,7 +28,7 @@
         "type": "Storage",
         "initial_volume": {
           "type": "Proportional",
-          "value": 0.5
+          "proportion": 0.5
         },
         "max_volume": {
           "type": "Constant",
@@ -42,7 +42,7 @@
         "type": "Storage",
         "initial_volume": {
           "type": "Proportional",
-          "value": 0.5
+          "proportion": 0.5
         },
         "max_volume": {
           "type": "Parameter",
@@ -56,7 +56,7 @@
         "type": "Storage",
         "initial_volume": {
           "type": "Proportional",
-          "value": 0.5
+          "proportion": 0.5
         },
         "max_volume": {
           "type": "Parameter",

--- a/pywr-schema/tests/test_models.rs
+++ b/pywr-schema/tests/test_models.rs
@@ -146,7 +146,7 @@ fn convert_model(v1_path: &Path, v2_path: &Path) {
     let v1: pywr_v1_schema::PywrModel = serde_json::from_str(&v1_str).unwrap();
 
     let (v2, errors) = PywrModel::from_v1(v1);
-
+    println!("Conversion errors: {:?}", errors);
     assert_eq!(errors.len(), 0);
 
     let v2_converted: serde_json::Value = serde_json::from_str(&serde_json::to_string_pretty(&v2).unwrap()).unwrap();

--- a/pywr-schema/tests/timeseries.json
+++ b/pywr-schema/tests/timeseries.json
@@ -81,7 +81,7 @@
           "name": "factored_flow"
         },
         "type": "Aggregated",
-        "agg_func": "product",
+        "agg_func": "Product",
         "metrics": [
           {
             "type": "Timeseries",
@@ -121,7 +121,7 @@
       {
         "name": "nodes",
         "type": "CSV",
-        "format": "long",
+        "format": "Long",
         "filename": "timeseries-expected.csv",
         "metric_set": "nodes"
       }

--- a/pywr-schema/tests/timeseries2.json
+++ b/pywr-schema/tests/timeseries2.json
@@ -89,7 +89,7 @@
           "name": "factored_flow"
         },
         "type": "Aggregated",
-        "agg_func": "product",
+        "agg_func": "Product",
         "metrics": [
           {
             "type": "Timeseries",
@@ -133,7 +133,7 @@
       {
         "name": "nodes",
         "type": "CSV",
-        "format": "long",
+        "format": "Long",
         "filename": "timeseries2-expected.csv",
         "metric_set": "nodes"
       }

--- a/pywr-schema/tests/timeseries3.json
+++ b/pywr-schema/tests/timeseries3.json
@@ -94,7 +94,7 @@
           "name": "factored_flow"
         },
         "type": "Aggregated",
-        "agg_func": "product",
+        "agg_func": "Product",
         "metrics": [
           {
             "type": "Timeseries",
@@ -138,7 +138,7 @@
       {
         "name": "nodes",
         "type": "CSV",
-        "format": "long",
+        "format": "Long",
         "filename": "timeseries3-expected.csv",
         "metric_set": "nodes"
       }

--- a/pywr-schema/tests/timeseries4.json
+++ b/pywr-schema/tests/timeseries4.json
@@ -118,7 +118,7 @@
           "name": "factored_flow"
         },
         "type": "Aggregated",
-        "agg_func": "product",
+        "agg_func": "Product",
         "metrics": [
           {
             "type": "Timeseries",
@@ -162,7 +162,7 @@
       {
         "name": "nodes",
         "type": "CSV",
-        "format": "long",
+        "format": "Long",
         "filename": "timeseries4-expected.csv",
         "metric_set": "nodes"
       }

--- a/pywr-schema/tests/timeseries5.json
+++ b/pywr-schema/tests/timeseries5.json
@@ -118,7 +118,7 @@
           "name": "factored_flow"
         },
         "type": "Aggregated",
-        "agg_func": "product",
+        "agg_func": "Product",
         "metrics": [
           {
             "type": "Timeseries",
@@ -162,7 +162,7 @@
       {
         "name": "nodes",
         "type": "CSV",
-        "format": "long",
+        "format": "Long",
         "filename": "timeseries5-expected.csv",
         "metric_set": "nodes"
       }

--- a/pywr-schema/tests/timeseries_pandas.json
+++ b/pywr-schema/tests/timeseries_pandas.json
@@ -81,7 +81,7 @@
           "name": "factored_flow"
         },
         "type": "Aggregated",
-        "agg_func": "product",
+        "agg_func": "Product",
         "metrics": [
           {
             "type": "Timeseries",

--- a/pywr-schema/tests/v1/inline-parameter-converted.json
+++ b/pywr-schema/tests/v1/inline-parameter-converted.json
@@ -101,7 +101,7 @@
         "variable": null
       },
       {
-        "agg_func": "product",
+        "agg_func": "Product",
         "meta": {
           "name": "demand1-p0"
         },

--- a/pywr-schema/tests/v1/timeseries-converted.json
+++ b/pywr-schema/tests/v1/timeseries-converted.json
@@ -122,7 +122,7 @@
         "meta": {
           "name": "factored_flow"
         },
-        "agg_func": "product",
+        "agg_func": "Product",
         "metrics": [
           {
             "type": "Timeseries",

--- a/pywr-schema/tests/wtw1.json
+++ b/pywr-schema/tests/wtw1.json
@@ -132,7 +132,7 @@
       {
         "name": "node-outputs",
         "type": "CSV",
-        "format": "long",
+        "format": "Long",
         "filename": "wtw1-expected.csv",
         "metric_set": [
           "nodes"

--- a/pywr-schema/tests/wtw2.json
+++ b/pywr-schema/tests/wtw2.json
@@ -104,7 +104,7 @@
       {
         "name": "node-outputs",
         "type": "CSV",
-        "format": "long",
+        "format": "Long",
         "filename": "wtw2-expected.csv",
         "metric_set": [
           "nodes"


### PR DESCRIPTION
- Make all non-simple enums internally tagged with "type" when serialised.
- Derive EnumIter for simple enums.
- Derive `EnumDiscriminants` with the name `Type` appended to the enum's name. This has required renaming some enums.
- Require case-sensitive type names.