### PR TITLE
refactor: Refactor Timeseris into a single enum.

### DIFF
--- a/pywr-python/tests/models/aggregated-node1/model.json
+++ b/pywr-python/tests/models/aggregated-node1/model.json
@@ -108,10 +108,8 @@
         "meta": {
           "name": "inflow"
         },
-        "provider": {
-          "type": "Polars",
-          "url": "inflow.csv"
-        }
+        "type": "Polars",
+        "url": "inflow.csv"
       }
     ],
     "metric_sets": [

--- a/pywr-python/tests/models/piecewise-link1/model.json
+++ b/pywr-python/tests/models/piecewise-link1/model.json
@@ -110,10 +110,8 @@
         "meta": {
           "name": "inflow"
         },
-        "provider": {
-          "type": "Polars",
-          "url": "inflow.csv"
-        }
+        "type": "Polars",
+        "url": "inflow.csv"
       }
     ],
     "metric_sets": [

--- a/pywr-python/tests/models/simple-custom-parameter/model.json
+++ b/pywr-python/tests/models/simple-custom-parameter/model.json
@@ -78,10 +78,8 @@
         "meta": {
           "name": "inflow"
         },
-        "provider": {
-          "type": "Polars",
-          "url": "inflow.csv"
-        }
+        "type": "Polars",
+        "url": "inflow.csv"
       }
     ],
     "metric_sets": [

--- a/pywr-python/tests/models/simple-timeseries/model.json
+++ b/pywr-python/tests/models/simple-timeseries/model.json
@@ -68,10 +68,8 @@
         "meta": {
           "name": "inflow"
         },
-        "provider": {
-          "type": "Polars",
-          "url": "inflow.csv"
-        }
+        "type": "Polars",
+        "url": "inflow.csv"
       }
     ],
     "metric_sets": [

--- a/pywr-schema/src/timeseries/mod.rs
+++ b/pywr-schema/src/timeseries/mod.rs
@@ -10,7 +10,7 @@ use crate::v1::{ConversionData, IntoV2, TryFromV1};
 use crate::visit::VisitPaths;
 #[cfg(feature = "core")]
 use ndarray::{Array2, ShapeError, s};
-pub use pandas::PandasDataset;
+pub use pandas::PandasTimeseries;
 #[cfg(feature = "core")]
 use polars::error::PolarsError;
 #[cfg(feature = "core")]
@@ -19,7 +19,7 @@ use polars::prelude::{
     DataType::{Float64, UInt64},
     Float64Type, IndexOrder, UInt64Type,
 };
-pub use polars_dataset::PolarsDataset;
+pub use polars_dataset::PolarsTimeseries;
 #[cfg(feature = "pyo3")]
 use pyo3::PyErr;
 #[cfg(feature = "core")]
@@ -84,44 +84,40 @@ pub enum TimeseriesError {
 #[serde(tag = "type")]
 #[strum_discriminants(derive(Display, IntoStaticStr, EnumString, EnumIter))]
 #[strum_discriminants(name(TimeseriesProviderType))]
-pub enum TimeseriesProvider {
-    Pandas(PandasDataset),
-    Polars(PolarsDataset),
-}
-
-#[derive(serde::Deserialize, serde::Serialize, Debug, Clone, JsonSchema)]
-#[serde(deny_unknown_fields)]
-pub struct Timeseries {
-    pub meta: ParameterMeta,
-    pub provider: TimeseriesProvider,
+pub enum Timeseries {
+    Pandas(PandasTimeseries),
+    Polars(PolarsTimeseries),
 }
 
 impl Timeseries {
     #[cfg(feature = "core")]
     pub fn load(&self, domain: &ModelDomain, data_path: Option<&Path>) -> Result<DataFrame, TimeseriesError> {
-        match &self.provider {
-            TimeseriesProvider::Polars(dataset) => dataset.load(self.meta.name.as_str(), data_path, domain),
-            TimeseriesProvider::Pandas(dataset) => dataset.load(self.meta.name.as_str(), data_path, domain),
+        match &self {
+            Timeseries::Polars(dataset) => dataset.load(data_path, domain),
+            Timeseries::Pandas(dataset) => dataset.load(data_path, domain),
         }
     }
 
     pub fn name(&self) -> &str {
-        &self.meta.name
+        match &self {
+            Timeseries::Polars(dataset) => dataset.meta.name.as_str(),
+            Timeseries::Pandas(dataset) => dataset.meta.name.as_str(),
+        }
     }
 }
 
 impl VisitPaths for Timeseries {
     fn visit_paths<F: FnMut(&Path)>(&self, visitor: &mut F) {
-        match &self.provider {
-            TimeseriesProvider::Polars(dataset) => dataset.visit_paths(visitor),
-            TimeseriesProvider::Pandas(dataset) => dataset.visit_paths(visitor),
+        match &self {
+            Timeseries::Polars(dataset) => dataset.visit_paths(visitor),
+            Timeseries::Pandas(dataset) => dataset.visit_paths(visitor),
         }
     }
 
     fn visit_paths_mut<F: FnMut(&mut PathBuf)>(&mut self, visitor: &mut F) {
-        match &mut self.provider {
-            TimeseriesProvider::Polars(dataset) => dataset.visit_paths_mut(visitor),
-            TimeseriesProvider::Pandas(dataset) => dataset.visit_paths_mut(visitor),
+        match self {
+            Timeseries::Polars(dataset) => dataset.visit_paths_mut(visitor),
+            Timeseries::Pandas(dataset) => dataset.visit_paths_mut(visitor),
         }
     }
 }
@@ -143,10 +139,10 @@ impl LoadedTimeseriesCollection {
         if let Some(timeseries_defs) = timeseries_defs {
             for ts in timeseries_defs {
                 let df = ts.load(domain, data_path)?;
-                if timeseries.contains_key(&ts.meta.name) {
-                    return Err(TimeseriesError::TimeseriesDataframeAlreadyExists(ts.meta.name.clone()));
+                if timeseries.contains_key(ts.name()) {
+                    return Err(TimeseriesError::TimeseriesDataframeAlreadyExists(ts.name().to_string()));
                 }
-                timeseries.insert(ts.meta.name.clone(), df);
+                timeseries.insert(ts.name().to_string(), df);
             }
         }
         Ok(Self { timeseries })
@@ -505,20 +501,18 @@ impl TryFromV1<DataFrameParameterV1> for ConvertedTimeseriesReference {
                 }
             }
 
-            let provider = PandasDataset {
+            let timeseries = PandasTimeseries {
+                meta: meta.clone(),
                 time_col,
                 url,
                 kwargs: Some(pandas_kwargs),
             };
 
             // The timeseries data that is extracted
-            let timeseries = Timeseries {
-                meta: meta.clone(),
-                provider: TimeseriesProvider::Pandas(provider),
-            };
+            let timeseries = Timeseries::Pandas(timeseries);
 
             // Only add if the timeseries does not already exist
-            if !conversion_data.timeseries.iter().any(|ts| ts.meta.name == meta.name) {
+            if !conversion_data.timeseries.iter().any(|ts| ts.name() == meta.name) {
                 conversion_data.timeseries.push(timeseries);
             }
         } else if let Some(table) = v1.table {

--- a/pywr-schema/src/timeseries/pandas.rs
+++ b/pywr-schema/src/timeseries/pandas.rs
@@ -1,6 +1,6 @@
+use crate::parameters::ParameterMeta;
 use crate::visit::VisitPaths;
 use schemars::JsonSchema;
-use serde_json::Value;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
@@ -11,14 +11,15 @@ use std::path::{Path, PathBuf};
 ///
 #[derive(serde::Deserialize, serde::Serialize, Debug, Clone, JsonSchema)]
 #[serde(deny_unknown_fields)]
-pub struct PandasDataset {
+pub struct PandasTimeseries {
+    pub meta: ParameterMeta,
     pub time_col: Option<String>,
     pub url: PathBuf,
     /// Keyword arguments to pass to the relevant Pandas load function.
-    pub kwargs: Option<HashMap<String, Value>>,
+    pub kwargs: Option<HashMap<String, serde_json::Value>>,
 }
 
-impl VisitPaths for PandasDataset {
+impl VisitPaths for PandasTimeseries {
     fn visit_paths<F: FnMut(&Path)>(&self, visitor: &mut F) {
         visitor(&self.url);
     }
@@ -30,13 +31,13 @@ impl VisitPaths for PandasDataset {
 
 #[cfg(all(feature = "core", not(feature = "pyo3")))]
 mod core {
-    use super::PandasDataset;
+    use super::PandasTimeseries;
     use crate::timeseries::TimeseriesError;
     use polars::frame::DataFrame;
     use pywr_core::models::ModelDomain;
     use std::path::Path;
 
-    impl PandasDataset {
+    impl PandasTimeseries {
         pub fn load(
             &self,
             _name: &str,
@@ -52,7 +53,7 @@ mod core {
 mod core {
     const PANDAS_LOAD_SCRIPT: &CStr = c_str!(include_str!("pandas_load.py"));
 
-    use super::PandasDataset;
+    use super::PandasTimeseries;
     use crate::parameters::try_json_value_into_py;
     use crate::timeseries::TimeseriesError;
     use crate::timeseries::align_and_resample::align_and_resample;
@@ -66,13 +67,8 @@ mod core {
     use std::ffi::CStr;
     use std::path::Path;
 
-    impl PandasDataset {
-        pub fn load(
-            &self,
-            name: &str,
-            data_path: Option<&Path>,
-            domain: &ModelDomain,
-        ) -> Result<DataFrame, TimeseriesError> {
+    impl PandasTimeseries {
+        pub fn load(&self, data_path: Option<&Path>, domain: &ModelDomain) -> Result<DataFrame, TimeseriesError> {
             // Prepare the Python interpreter if not already
             pyo3::prepare_freethreaded_python();
 
@@ -126,11 +122,11 @@ mod core {
             let mut df = df.0;
 
             df = match self.time_col {
-                Some(ref col) => align_and_resample(name, df, col, domain.time(), true)?,
+                Some(ref col) => align_and_resample(&self.meta.name, df, col, domain.time(), true)?,
                 None => {
                     // If a time col has not been provided assume it is the first column
                     let first_col = df.get_column_names()[0].to_string();
-                    align_and_resample(name, df, first_col.as_str(), domain.time(), true)?
+                    align_and_resample(&self.meta.name, df, first_col.as_str(), domain.time(), true)?
                 }
             };
 

--- a/pywr-schema/src/timeseries/polars_dataset.rs
+++ b/pywr-schema/src/timeseries/polars_dataset.rs
@@ -1,16 +1,18 @@
+use crate::parameters::ParameterMeta;
 use crate::visit::VisitPaths;
 use schemars::JsonSchema;
 use std::path::{Path, PathBuf};
 
 #[derive(serde::Deserialize, serde::Serialize, Debug, Clone, JsonSchema)]
 #[serde(deny_unknown_fields)]
-pub struct PolarsDataset {
+pub struct PolarsTimeseries {
+    pub meta: ParameterMeta,
     pub time_col: Option<String>,
     pub url: PathBuf,
     pub infer_schema_length: Option<usize>,
 }
 
-impl VisitPaths for PolarsDataset {
+impl VisitPaths for PolarsTimeseries {
     fn visit_paths<F: FnMut(&Path)>(&self, visitor: &mut F) {
         visitor(&self.url);
     }
@@ -22,20 +24,15 @@ impl VisitPaths for PolarsDataset {
 
 #[cfg(feature = "core")]
 mod core {
-    use super::PolarsDataset;
+    use super::PolarsTimeseries;
     use crate::timeseries::TimeseriesError;
     use crate::timeseries::align_and_resample::align_and_resample;
     use polars::{frame::DataFrame, prelude::*};
     use pywr_core::models::ModelDomain;
     use std::path::Path;
 
-    impl PolarsDataset {
-        pub fn load(
-            &self,
-            name: &str,
-            data_path: Option<&Path>,
-            domain: &ModelDomain,
-        ) -> Result<DataFrame, TimeseriesError> {
+    impl PolarsTimeseries {
+        pub fn load(&self, data_path: Option<&Path>, domain: &ModelDomain) -> Result<DataFrame, TimeseriesError> {
             let fp = if self.url.is_absolute() {
                 self.url.clone()
             } else if let Some(data_path) = data_path {
@@ -88,11 +85,11 @@ mod core {
             };
 
             df = match self.time_col {
-                Some(ref col) => align_and_resample(name, df, col, domain.time(), true)?,
+                Some(ref col) => align_and_resample(&self.meta.name, df, col, domain.time(), true)?,
                 None => {
                     // If a time col has not been provided assume it is the first column
                     let first_col = df.get_column_names()[0].to_string();
-                    align_and_resample(name, df, first_col.as_str(), domain.time(), true)?
+                    align_and_resample(&self.meta.name, df, first_col.as_str(), domain.time(), true)?
                 }
             };
 

--- a/pywr-schema/tests/timeseries.json
+++ b/pywr-schema/tests/timeseries.json
@@ -99,11 +99,9 @@
         "meta": {
           "name": "inflow"
         },
-        "provider": {
-          "type": "Polars",
-          "time_col": "date",
-          "url": "inflow.csv"
-        }
+        "type": "Polars",
+        "time_col": "date",
+        "url": "inflow.csv"
       }
     ],
     "metric_sets": [

--- a/pywr-schema/tests/timeseries2.json
+++ b/pywr-schema/tests/timeseries2.json
@@ -111,11 +111,9 @@
         "meta": {
           "name": "inflow"
         },
-        "provider": {
-          "type": "Polars",
-          "time_col": "date",
-          "url": "inflow2.csv"
-        }
+        "type": "Polars",
+        "time_col": "date",
+        "url": "inflow2.csv"
       }
     ],
     "metric_sets": [

--- a/pywr-schema/tests/timeseries3.json
+++ b/pywr-schema/tests/timeseries3.json
@@ -116,11 +116,9 @@
         "meta": {
           "name": "inflow"
         },
-        "provider": {
-          "type": "Polars",
-          "time_col": "date",
-          "url": "inflow2.csv"
-        }
+        "type": "Polars",
+        "time_col": "date",
+        "url": "inflow2.csv"
       }
     ],
     "metric_sets": [

--- a/pywr-schema/tests/timeseries4.json
+++ b/pywr-schema/tests/timeseries4.json
@@ -140,11 +140,9 @@
         "meta": {
           "name": "inflow"
         },
-        "provider": {
-          "type": "Polars",
-          "time_col": "date",
-          "url": "inflow2.csv"
-        }
+        "type": "Polars",
+        "time_col": "date",
+        "url": "inflow2.csv"
       }
     ],
     "metric_sets": [

--- a/pywr-schema/tests/timeseries5.json
+++ b/pywr-schema/tests/timeseries5.json
@@ -140,11 +140,9 @@
         "meta": {
           "name": "inflow"
         },
-        "provider": {
-          "type": "Polars",
-          "time_col": "date",
-          "url": "inflow2.csv"
-        }
+        "type": "Polars",
+        "time_col": "date",
+        "url": "inflow2.csv"
       }
     ],
     "metric_sets": [

--- a/pywr-schema/tests/v1/inline-parameter-converted.json
+++ b/pywr-schema/tests/v1/inline-parameter-converted.json
@@ -142,27 +142,23 @@
         "meta": {
           "name": "demand1-p2"
         },
-        "provider": {
-          "kwargs": {
-            "dayfirst": true
-          },
-          "time_col": null,
-          "type": "Pandas",
-          "url": "timeseries1.csv"
-        }
+        "kwargs": {
+          "dayfirst": true
+        },
+        "time_col": null,
+        "type": "Pandas",
+        "url": "timeseries1.csv"
       },
       {
         "meta": {
           "name": "demand1-p4"
         },
-        "provider": {
-          "kwargs": {
-            "dayfirst": true
-          },
-          "time_col": null,
-          "type": "Pandas",
-          "url": "timeseries2.csv"
-        }
+        "kwargs": {
+          "dayfirst": true
+        },
+        "time_col": null,
+        "type": "Pandas",
+        "url": "timeseries2.csv"
       }
     ]
   },

--- a/pywr-schema/tests/v1/timeseries-converted.json
+++ b/pywr-schema/tests/v1/timeseries-converted.json
@@ -145,13 +145,11 @@
         "meta": {
           "name": "inflow"
         },
-        "provider": {
-          "type": "Pandas",
-          "time_col": null,
-          "url": "inflow.csv",
-          "kwargs": {
-            "dayfirst": true
-          }
+        "type": "Pandas",
+        "time_col": null,
+        "url": "inflow.csv",
+        "kwargs": {
+          "dayfirst": true
         }
       }
     ],


### PR DESCRIPTION
Removes `TimeseriesProvider` and makes a single top-level enum
 similar to the other components (e.g. `Node`, `Parameter`).