### PR TITLE
chore: Remove groups from dependabot config.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,11 +4,6 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
-    groups:
-      minor-patch:
-        update-types:
-          - "minor"
-          - "patch"
   - package-ecosystem: "github-actions"
     # Workflow files stored in the
     # default location of `.github/workflows`


### PR DESCRIPTION
This avoids one dependency blocking the update of others. E.g. polars.