### PR TITLE
refactor: Use private enums for node attributes.

### DIFF
--- a/pywr-schema/src/error.rs
+++ b/pywr-schema/src/error.rs
@@ -24,12 +24,8 @@ pub enum SchemaError {
     // Use this error when a node is not found in a pywr-core network (i.e. during building the network).
     #[error("Node with name `{name}` and sub-name `{}` not found in the network.", .sub_name.as_deref().unwrap_or("None"))]
     CoreNodeNotFound { name: String, sub_name: Option<String> },
-    #[error("node ({ty}) with name {name} does not support attribute {attr}")]
-    NodeAttributeNotSupported {
-        ty: String,
-        name: String,
-        attr: NodeAttribute,
-    },
+    #[error("Attribute `{attr}` not supported.")]
+    NodeAttributeNotSupported { attr: NodeAttribute },
     // Use this error when a parameter is not found in the schema (i.e. while parsing the schema).
     #[error("Parameter `{name}` not found in the schema.")]
     ParameterNotFound { name: String, key: Option<String> },

--- a/pywr-schema/src/model.rs
+++ b/pywr-schema/src/model.rs
@@ -679,7 +679,7 @@ pub enum PywrNetworkRef {
 /// JSON file. The schema is used to "build" a [`pywr_core::models::Model`] which can then be
 /// "run" to produce results. The purpose of the schema is to provide a higher level and more
 /// user friendly interface to model definition than the core model itself. This allows
-/// abstractions, such as [`crate::nodes::WaterTreatmentWorks`], to be created and used in the
+/// abstractions, such as [`crate::nodes::WaterTreatmentWorksNode`], to be created and used in the
 /// schema without the user needing to know the details of how this is implemented in the core
 /// model.
 ///

--- a/pywr-schema/src/nodes/attributes.rs
+++ b/pywr-schema/src/nodes/attributes.rs
@@ -1,0 +1,84 @@
+use pywr_schema_macros::PywrVisitAll;
+use schemars::JsonSchema;
+use strum_macros::{Display, EnumIter};
+
+/// All possible attributes that could be produced by a node.
+///
+///
+#[derive(
+    serde::Deserialize, serde::Serialize, Debug, Clone, Copy, Display, JsonSchema, PywrVisitAll, PartialEq, EnumIter,
+)]
+pub enum NodeAttribute {
+    Inflow,
+    Outflow,
+    Volume,
+    MaxVolume,
+    ProportionalVolume,
+    Loss,
+    Deficit,
+    Power,
+    /// The compensation flow.
+    Compensation,
+    /// The rainfall volume.
+    Rainfall,
+    /// The evaporation volume.
+    Evaporation,
+}
+
+/// Macro to generate a subset enum of `NodeAttribute` with conversion implementations.
+///
+/// Usage:
+/// ```
+/// use pywr_schema::node_attribute_subset_enum;
+///
+/// node_attribute_subset_enum! {
+///     pub enum MySubset {
+///         Inflow,
+///         Outflow,
+///         Volume,
+///     }
+/// }
+/// ```
+///
+/// This generates a `MySubset` enum and implements:
+/// - `From<MySubset> for NodeAttribute`
+/// - `TryFrom<NodeAttribute> for MySubset`
+///
+#[macro_export]
+macro_rules! node_attribute_subset_enum {
+    (
+        $(#[$meta:meta])* $vis:vis enum $name:ident {
+            $($variant:ident $( ( $($field:ty),* ) )? ),* $(,)?
+        }
+    ) => {
+        $(#[$meta])*
+        #[derive(Debug, Clone, PartialEq, Eq)]
+        $vis enum $name {
+            $( $variant $( ( $($field),* ) )? ),*
+        }
+
+        impl std::convert::From<$name> for $crate::nodes::NodeAttribute {
+            fn from(attr: $name) -> $crate::nodes::NodeAttribute {
+                match attr {
+                    $(
+                        $name::$variant => $crate::nodes::NodeAttribute::$variant,
+                    )*
+                }
+            }
+        }
+
+        impl std::convert::TryFrom<$crate::nodes::NodeAttribute> for $name {
+            type Error = $crate::SchemaError;
+            fn try_from(attr: $crate::nodes::NodeAttribute) -> Result<$name, Self::Error> {
+                match attr {
+                    $(
+                        $crate::nodes::NodeAttribute::$variant => Ok($name::$variant),
+                    )*
+                    _ => Err(SchemaError::NodeAttributeNotSupported {
+                        attr,
+                    })
+                }
+            }
+        }
+    };
+}

--- a/pywr-schema/src/nodes/attributes.rs
+++ b/pywr-schema/src/nodes/attributes.rs
@@ -74,7 +74,7 @@ macro_rules! node_attribute_subset_enum {
                     $(
                         $crate::nodes::NodeAttribute::$variant => Ok($name::$variant),
                     )*
-                    _ => Err(SchemaError::NodeAttributeNotSupported {
+                    _ => Err($crate::SchemaError::NodeAttributeNotSupported {
                         attr,
                     })
                 }

--- a/pywr-schema/src/nodes/mod.rs
+++ b/pywr-schema/src/nodes/mod.rs
@@ -1,4 +1,5 @@
 mod annual_virtual_storage;
+mod attributes;
 mod core;
 mod delay;
 mod loss_link;
@@ -22,15 +23,15 @@ use crate::metric::Metric;
 #[cfg(feature = "core")]
 use crate::model::LoadArgs;
 use crate::model::PywrNetwork;
+pub use crate::nodes::placeholder::PlaceholderNode;
 pub use crate::nodes::reservoir::{
     Bathymetry, BathymetryType, Evaporation, Leakage, Rainfall, ReservoirNode, SpillNodeType,
 };
-
-pub use crate::nodes::placeholder::PlaceholderNode;
 use crate::parameters::Parameter;
 use crate::v1::{ConversionData, TryFromV1, TryIntoV2};
 use crate::visit::{VisitMetrics, VisitPaths};
 pub use annual_virtual_storage::{AnnualReset, AnnualVirtualStorageNode};
+pub use attributes::NodeAttribute;
 pub use core::{
     AggregatedNode, AggregatedStorageNode, CatchmentNode, InputNode, LinkNode, OutputNode, Relationship,
     SoftConstraint, StorageInitialVolume, StorageNode,
@@ -55,7 +56,7 @@ use std::path::{Path, PathBuf};
 use strum_macros::{Display, EnumDiscriminants, EnumIter, EnumString, IntoStaticStr};
 pub use turbine::{TargetType, TurbineNode};
 pub use virtual_storage::VirtualStorageNode;
-pub use water_treatment_works::WaterTreatmentWorks;
+pub use water_treatment_works::WaterTreatmentWorksNode;
 
 #[derive(serde::Deserialize, serde::Serialize, Debug, Clone, Copy, JsonSchema, PywrVisitAll)]
 pub struct NodePosition {
@@ -91,29 +92,6 @@ impl From<NodeMetaV1> for NodeMeta {
             position: v1.position.map(|p| p.into()),
         }
     }
-}
-
-/// All possible attributes that could be produced by a node.
-///
-///
-#[derive(
-    serde::Deserialize, serde::Serialize, Debug, Clone, Copy, Display, JsonSchema, PywrVisitAll, PartialEq, EnumIter,
-)]
-pub enum NodeAttribute {
-    Inflow,
-    Outflow,
-    Volume,
-    MaxVolume,
-    ProportionalVolume,
-    Loss,
-    Deficit,
-    Power,
-    /// The compensation flow out of a [`ReservoirNode`]
-    Compensation,
-    /// The rainfall volume into a [`ReservoirNode`]
-    Rainfall,
-    /// The evaporation volume out of a [`ReservoirNode`]
-    Evaporation,
 }
 
 pub struct NodeBuilder {
@@ -218,7 +196,7 @@ impl NodeBuilder {
                 meta,
                 ..Default::default()
             }),
-            NodeType::WaterTreatmentWorks => Node::WaterTreatmentWorks(WaterTreatmentWorks {
+            NodeType::WaterTreatmentWorks => Node::WaterTreatmentWorks(WaterTreatmentWorksNode {
                 meta,
                 ..Default::default()
             }),
@@ -282,7 +260,7 @@ pub enum Node {
     PiecewiseStorage(PiecewiseStorageNode),
     River(RiverNode),
     RiverSplitWithGauge(RiverSplitWithGaugeNode),
-    WaterTreatmentWorks(WaterTreatmentWorks),
+    WaterTreatmentWorks(WaterTreatmentWorksNode),
     Aggregated(AggregatedNode),
     AggregatedStorage(AggregatedStorageNode),
     VirtualStorage(VirtualStorageNode),

--- a/pywr-schema/src/nodes/piecewise_link.rs
+++ b/pywr-schema/src/nodes/piecewise_link.rs
@@ -4,6 +4,7 @@ use crate::error::SchemaError;
 use crate::metric::Metric;
 #[cfg(feature = "core")]
 use crate::model::LoadArgs;
+use crate::node_attribute_subset_enum;
 use crate::nodes::{NodeAttribute, NodeMeta};
 use crate::parameters::Parameter;
 use crate::v1::{ConversionData, TryFromV1, try_convert_node_attr};
@@ -19,6 +20,15 @@ pub struct PiecewiseLinkStep {
     pub max_flow: Option<Metric>,
     pub min_flow: Option<Metric>,
     pub cost: Option<Metric>,
+}
+
+// This macro generates a subset enum for the `PiecewiseLinkNode` attributes.
+// It allows for easy conversion between the enum and the `NodeAttribute` type.
+node_attribute_subset_enum! {
+    enum PiecewiseLinkNodeAttribute {
+        Inflow,
+        Outflow,
+    }
 }
 
 #[doc = svgbobdoc::transform!(
@@ -53,7 +63,7 @@ pub struct PiecewiseLinkNode {
 }
 
 impl PiecewiseLinkNode {
-    const DEFAULT_ATTRIBUTE: NodeAttribute = NodeAttribute::Outflow;
+    const DEFAULT_ATTRIBUTE: PiecewiseLinkNodeAttribute = PiecewiseLinkNodeAttribute::Outflow;
 
     fn step_sub_name(i: usize) -> Option<String> {
         Some(format!("step-{i:02}"))
@@ -75,7 +85,7 @@ impl PiecewiseLinkNode {
     }
 
     pub fn default_metric(&self) -> NodeAttribute {
-        Self::DEFAULT_ATTRIBUTE
+        Self::DEFAULT_ATTRIBUTE.into()
     }
 }
 
@@ -139,7 +149,10 @@ impl PiecewiseLinkNode {
         attribute: Option<NodeAttribute>,
     ) -> Result<MetricF64, SchemaError> {
         // Use the default attribute if none is specified
-        let attr = attribute.unwrap_or(Self::DEFAULT_ATTRIBUTE);
+        let attr = match attribute {
+            Some(attr) => attr.try_into()?,
+            None => Self::DEFAULT_ATTRIBUTE,
+        };
 
         let indices = self
             .steps
@@ -156,21 +169,14 @@ impl PiecewiseLinkNode {
             .collect::<Result<Vec<_>, _>>()?;
 
         let metric = match attr {
-            NodeAttribute::Inflow => MetricF64::MultiNodeInFlow {
+            PiecewiseLinkNodeAttribute::Inflow => MetricF64::MultiNodeInFlow {
                 indices,
                 name: self.meta.name.to_string(),
             },
-            NodeAttribute::Outflow => MetricF64::MultiNodeOutFlow {
+            PiecewiseLinkNodeAttribute::Outflow => MetricF64::MultiNodeOutFlow {
                 indices,
                 name: self.meta.name.to_string(),
             },
-            _ => {
-                return Err(SchemaError::NodeAttributeNotSupported {
-                    ty: "PiecewiseLinkNode".to_string(),
-                    name: self.meta.name.clone(),
-                    attr,
-                });
-            }
         };
 
         Ok(metric)

--- a/pywr-schema/src/nodes/river_gauge.rs
+++ b/pywr-schema/src/nodes/river_gauge.rs
@@ -4,6 +4,7 @@ use crate::error::SchemaError;
 use crate::metric::Metric;
 #[cfg(feature = "core")]
 use crate::model::LoadArgs;
+use crate::node_attribute_subset_enum;
 use crate::nodes::{NodeAttribute, NodeMeta};
 use crate::parameters::Parameter;
 use crate::v1::{ConversionData, TryFromV1, try_convert_node_attr};
@@ -12,6 +13,15 @@ use pywr_core::metric::MetricF64;
 use pywr_schema_macros::PywrVisitAll;
 use pywr_v1_schema::nodes::RiverGaugeNode as RiverGaugeNodeV1;
 use schemars::JsonSchema;
+
+// This macro generates a subset enum for the `RiverGaugeNode` attributes.
+// It allows for easy conversion between the enum and the `NodeAttribute` type.
+node_attribute_subset_enum! {
+    enum RiverGaugeNodeAttribute {
+        Inflow,
+        Outflow,
+    }
+}
 
 #[doc = svgbobdoc::transform!(
 /// This is used to represent a minimum residual flow (MRF) at a gauging station.
@@ -40,7 +50,7 @@ pub struct RiverGaugeNode {
 }
 
 impl RiverGaugeNode {
-    const DEFAULT_ATTRIBUTE: NodeAttribute = NodeAttribute::Outflow;
+    const DEFAULT_ATTRIBUTE: RiverGaugeNodeAttribute = RiverGaugeNodeAttribute::Outflow;
 
     fn mrf_sub_name() -> Option<&'static str> {
         Some("mrf")
@@ -65,7 +75,7 @@ impl RiverGaugeNode {
     }
 
     pub fn default_metric(&self) -> NodeAttribute {
-        Self::DEFAULT_ATTRIBUTE
+        Self::DEFAULT_ATTRIBUTE.into()
     }
 }
 
@@ -126,7 +136,10 @@ impl RiverGaugeNode {
         attribute: Option<NodeAttribute>,
     ) -> Result<MetricF64, SchemaError> {
         // Use the default attribute if none is specified
-        let attr = attribute.unwrap_or(Self::DEFAULT_ATTRIBUTE);
+        let attr = match attribute {
+            Some(attr) => attr.try_into()?,
+            None => Self::DEFAULT_ATTRIBUTE,
+        };
 
         let indices = vec![
             network
@@ -144,21 +157,14 @@ impl RiverGaugeNode {
         ];
 
         let metric = match attr {
-            NodeAttribute::Inflow => MetricF64::MultiNodeInFlow {
+            RiverGaugeNodeAttribute::Inflow => MetricF64::MultiNodeInFlow {
                 indices,
                 name: self.meta.name.to_string(),
             },
-            NodeAttribute::Outflow => MetricF64::MultiNodeOutFlow {
+            RiverGaugeNodeAttribute::Outflow => MetricF64::MultiNodeOutFlow {
                 indices,
                 name: self.meta.name.to_string(),
             },
-            _ => {
-                return Err(SchemaError::NodeAttributeNotSupported {
-                    ty: "RiverGaugeNode".to_string(),
-                    name: self.meta.name.clone(),
-                    attr,
-                });
-            }
         };
 
         Ok(metric)


### PR DESCRIPTION
Use a macro to generate a private enum for each node that defines which variants of `NodeAttribute` are supported for this node. This improves the pattern matching in `create_metric`.