### PR TITLE
feat: Add MultiThresholdParameter.

### DIFF
--- a/pywr-core/src/parameters/mod.rs
+++ b/pywr-core/src/parameters/mod.rs
@@ -16,6 +16,7 @@ mod interpolate;
 mod interpolated;
 mod max;
 mod min;
+mod multi_threshold;
 mod negative;
 mod negativemax;
 mod negativemin;
@@ -56,6 +57,7 @@ pub use interpolate::{InterpolationError, interpolate, linear_interpolation};
 pub use interpolated::InterpolatedParameter;
 pub use max::MaxParameter;
 pub use min::MinParameter;
+pub use multi_threshold::MultiThresholdParameter;
 pub use negative::NegativeParameter;
 pub use negativemax::NegativeMaxParameter;
 pub use negativemin::NegativeMinParameter;
@@ -285,6 +287,9 @@ impl<T> From<ConstParameterIndex<T>> for ParameterIndex<T> {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ParameterName {
     name: String,
+    // Optional sub-name for parameters that are part of multi-parameter groups
+    sub_name: Option<String>,
+    // Optional parent name for parameters that are added by a node
     parent: Option<String>,
 }
 
@@ -292,6 +297,15 @@ impl ParameterName {
     pub fn new(name: &str, parent: Option<&str>) -> Self {
         Self {
             name: name.to_string(),
+            sub_name: None,
+            parent: parent.map(|p| p.to_string()),
+        }
+    }
+
+    pub fn new_with_subname(name: &str, sub_name: Option<&str>, parent: Option<&str>) -> Self {
+        Self {
+            name: name.to_string(),
+            sub_name: sub_name.map(|s| s.to_string()),
             parent: parent.map(|p| p.to_string()),
         }
     }
@@ -320,6 +334,7 @@ impl From<&str> for ParameterName {
     fn from(name: &str) -> Self {
         Self {
             name: name.to_string(),
+            sub_name: None,
             parent: None,
         }
     }

--- a/pywr-core/src/parameters/multi_threshold.rs
+++ b/pywr-core/src/parameters/multi_threshold.rs
@@ -1,0 +1,181 @@
+use crate::metric::MetricF64;
+use crate::network::Network;
+use crate::parameters::errors::{ParameterCalculationError, ParameterSetupError};
+use crate::parameters::{
+    GeneralParameter, Parameter, ParameterMeta, ParameterName, ParameterState, Predicate, downcast_internal_state_mut,
+};
+use crate::scenario::ScenarioIndex;
+use crate::state::State;
+use crate::timestep::Timestep;
+
+pub struct MultiThresholdParameter {
+    meta: ParameterMeta,
+    metric: MetricF64,
+    thresholds: Vec<MetricF64>,
+    predicate: Predicate,
+    ratchet: bool,
+}
+
+impl MultiThresholdParameter {
+    pub fn new(
+        name: ParameterName,
+        metric: MetricF64,
+        thresholds: &[MetricF64],
+        predicate: Predicate,
+        ratchet: bool,
+    ) -> Self {
+        Self {
+            meta: ParameterMeta::new(name),
+            metric,
+            thresholds: thresholds.to_vec(),
+            predicate,
+            ratchet,
+        }
+    }
+}
+
+impl Parameter for MultiThresholdParameter {
+    fn meta(&self) -> &ParameterMeta {
+        &self.meta
+    }
+
+    fn setup(
+        &self,
+        _timesteps: &[Timestep],
+        _scenario_index: &ScenarioIndex,
+    ) -> Result<Option<Box<dyn ParameterState>>, ParameterSetupError> {
+        // Internal state is just a u64 indicating the previous highest value.
+        // Initially this is zero.
+        Ok(Some(Box::new(0_u64)))
+    }
+}
+
+impl GeneralParameter<u64> for MultiThresholdParameter {
+    fn compute(
+        &self,
+        _timestep: &Timestep,
+        _scenario_index: &ScenarioIndex,
+        model: &Network,
+        state: &State,
+        internal_state: &mut Option<Box<dyn ParameterState>>,
+    ) -> Result<u64, ParameterCalculationError> {
+        // Downcast the internal state to the correct type
+        let previous_max = downcast_internal_state_mut::<u64>(internal_state);
+
+        let value = self.metric.get_value(model, state)?;
+
+        // Determine the first threshold that is met
+        let mut position: u64 = 0;
+        for threshold in &self.thresholds {
+            let t = threshold.get_value(model, state)?;
+            let active = self.predicate.apply(value, t);
+
+            if active {
+                break;
+            }
+            position += 1;
+        }
+
+        if self.ratchet {
+            // If ratchet is enabled, we only update if the new position is greater than the previous max
+            if position > *previous_max {
+                *previous_max = position;
+            } else {
+                return Ok(*previous_max);
+            }
+        }
+
+        Ok(position)
+    }
+
+    fn as_parameter(&self) -> &dyn Parameter
+    where
+        Self: Sized,
+    {
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::MultiThresholdParameter;
+    use crate::metric::MetricF64;
+    use crate::parameters::{Array1Parameter, Predicate};
+    use crate::test_utils::{run_and_assert_parameter_u64, simple_model};
+    use ndarray::{Array1, Array2, Axis, concatenate};
+
+    /// Basic functional test of the `MultiThresholdParameter` parameter.
+    #[test]
+    fn test_multi_threshold() {
+        let mut model = simple_model(1, None);
+
+        // Create an artificial volume series to use for the delay test
+        let v1 = Array1::linspace(1.0, 0.0, 11);
+        let v2 = Array1::linspace(0.1, 1.0, 10);
+
+        let volumes = concatenate![Axis(0), v1, v2];
+
+        let volume = Array1Parameter::new("test-x".into(), volumes.clone(), None);
+
+        let volume_idx = model.network_mut().add_simple_parameter(Box::new(volume)).unwrap();
+
+        let t1: MetricF64 = 0.75.into();
+        let t2: MetricF64 = 0.5.into();
+
+        let thresholds = vec![t1, t2];
+
+        let parameter = MultiThresholdParameter::new(
+            "test-parameter".into(),
+            volume_idx.into(),
+            &thresholds,
+            Predicate::GreaterThan,
+            false,
+        );
+
+        // The multi-threshold parameter should return the index of the first threshold that is met.
+        // In this case, the thresholds are 0.75 and 0.5,
+        let expected_values: Array1<u64> = vec![0, 0, 0, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 1, 1, 0, 0, 0].into();
+
+        let expected_values: Array2<u64> = expected_values.insert_axis(Axis(1));
+
+        run_and_assert_parameter_u64(&mut model, Box::new(parameter), expected_values);
+    }
+
+    /// Basic functional test of the `MultiThresholdParameter` parameter with ratchet enabled.
+    #[test]
+    fn test_multi_threshold_with_ratchet() {
+        let mut model = simple_model(1, None);
+
+        // Create an artificial volume series to use for the delay test
+        let v1 = Array1::linspace(1.0, 0.0, 11);
+        let v2 = Array1::linspace(0.1, 1.0, 10);
+
+        let volumes = concatenate![Axis(0), v1, v2];
+
+        let volume = Array1Parameter::new("test-x".into(), volumes.clone(), None);
+
+        let volume_idx = model.network_mut().add_simple_parameter(Box::new(volume)).unwrap();
+
+        let t1: MetricF64 = 0.75.into();
+        let t2: MetricF64 = 0.5.into();
+
+        let thresholds = vec![t1, t2];
+
+        let parameter = MultiThresholdParameter::new(
+            "test-parameter".into(),
+            volume_idx.into(),
+            &thresholds,
+            Predicate::GreaterThan,
+            true,
+        );
+
+        // The multi-threshold parameter should return the index of the first threshold that is met,
+        // but with ratchet enabled, it should not decrease the value once it has been set.
+        // In this case, the thresholds are 0.75 and 0.5,
+        let expected_values: Array1<u64> = vec![0, 0, 0, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2].into();
+
+        let expected_values: Array2<u64> = expected_values.insert_axis(Axis(1));
+
+        run_and_assert_parameter_u64(&mut model, Box::new(parameter), expected_values);
+    }
+}

--- a/pywr-core/src/parameters/threshold.rs
+++ b/pywr-core/src/parameters/threshold.rs
@@ -16,6 +16,19 @@ pub enum Predicate {
     GreaterThanOrEqualTo,
 }
 
+impl Predicate {
+    /// Apply the predicate to a value and a threshold.
+    pub fn apply(&self, value: f64, threshold: f64) -> bool {
+        match self {
+            Predicate::LessThan => value < threshold,
+            Predicate::GreaterThan => value > threshold,
+            Predicate::EqualTo => (value - threshold).abs() < 1E-6, // TODO make this a global constant
+            Predicate::LessThanOrEqualTo => value <= threshold,
+            Predicate::GreaterThanOrEqualTo => value >= threshold,
+        }
+    }
+}
+
 pub struct ThresholdParameter {
     meta: ParameterMeta,
     metric: MetricF64,
@@ -77,14 +90,7 @@ impl GeneralParameter<u64> for ThresholdParameter {
 
         let threshold = self.threshold.get_value(model, state)?;
         let value = self.metric.get_value(model, state)?;
-
-        let active = match self.predicate {
-            Predicate::LessThan => value < threshold,
-            Predicate::GreaterThan => value > threshold,
-            Predicate::EqualTo => (value - threshold).abs() < 1E-6, // TODO make this a global constant
-            Predicate::LessThanOrEqualTo => value <= threshold,
-            Predicate::GreaterThanOrEqualTo => value >= threshold,
-        };
+        let active = self.predicate.apply(value, threshold);
 
         if active {
             // Update the internal state to remember we've been triggered!

--- a/pywr-schema/src/parameters/thresholds.rs
+++ b/pywr-schema/src/parameters/thresholds.rs
@@ -11,6 +11,8 @@ use crate::v1::{IntoV2, TryFromV1, try_convert_parameter_attr};
 use pywr_core::parameters::{ParameterName, ParameterType};
 use pywr_schema_macros::PywrVisitAll;
 use pywr_v1_schema::parameters::{
+    MultipleThresholdIndexParameter as MultiThresholdIndexParameterV1,
+    MultipleThresholdParameterIndexParameter as MultipleThresholdParameterIndexParameterV1,
     NodeThresholdParameter as NodeThresholdParameterV1, ParameterThresholdParameter as ParameterThresholdParameterV1,
     Predicate as PredicateV1, StorageThresholdParameter as StorageThresholdParameterV1,
 };
@@ -58,7 +60,7 @@ impl From<Predicate> for pywr_core::parameters::Predicate {
 
 /// A parameter that compares a metric against a threshold metric
 ///
-/// The metrics are compared using the given predicate and the result is returned as an index. If the comparison
+/// The metric is compared using the given predicate and the result is returned as an index. If the comparison
 /// evaluates to true the index is 1, otherwise it is 0. When values are provided for the `returned_metrics` attribute,
 /// these values are returned instead of the index. If the predicate comparison evaluates to false the first value is
 /// returned, if it is true the second value is returned.
@@ -111,10 +113,14 @@ impl ThresholdParameter {
         let metric = self.metric.load(network, args, None)?;
         let threshold = self.threshold.load(network, args, None)?;
 
+        // If the parameter has returned metrics, we need to create a sub-name for the threshold parameter
+        // so that it can be distinguished from the indexed array parameter.
+        // If it does not have returned metrics, we can just use the parameter name as the
+        // name for the threshold parameter.
         let name = if self.returned_metrics.is_some() {
-            ParameterName::new("threshold", Some(&self.meta.name))
+            ParameterName::new_with_subname(&self.meta.name, Some("threshold"), Some(&self.meta.name))
         } else {
-            self.meta.name.as_str().into()
+            ParameterName::new(&self.meta.name, parent)
         };
 
         let p = pywr_core::parameters::ThresholdParameter::new(
@@ -133,6 +139,7 @@ impl ThresholdParameter {
                     .iter()
                     .map(|v| v.load(network, args, None))
                     .collect::<Result<Vec<_>, _>>()?;
+
                 let values_param = pywr_core::parameters::IndexedArrayParameter::new(
                     ParameterName::new(&self.meta.name, parent),
                     p_idx.into(),
@@ -278,6 +285,148 @@ impl TryFromV1<StorageThresholdParameterV1> for ThresholdParameter {
             metric,
             returned_metrics,
             threshold,
+            predicate: v1.predicate.into(),
+            ratchet: false,
+        };
+        Ok(p)
+    }
+}
+
+/// A parameter that compares a metric against a multiple threshold metrics.
+///
+/// The metric is compared to the thresholds in order using the given predicate and the result is
+/// returned as an index of the first threshold that passed the comparison. I.e. if the first
+/// metric passes the comparison against the first threshold, the index is 0, if it passes the
+/// comparison against the second threshold, the index is 1, and so on.
+///
+/// When values are provided for the `returned_metrics` attribute, these values are returned instead
+/// of the index.
+///
+/// The parameter has different representations in core depending on the `returned_metrics` attribute. If values are
+/// set for `returned_metrics` then two parameters are added to the model. The first a
+/// [`pywr_core::parameters::MultiThresholdParameter`], which is set as the index parameter of a
+/// [`pywr_core::parameters::IndexedArrayParameter`] containing the `returned_metrics`
+/// values.
+#[derive(serde::Deserialize, serde::Serialize, Debug, Clone, JsonSchema, PywrVisitAll)]
+#[serde(deny_unknown_fields)]
+pub struct MultiThresholdParameter {
+    pub meta: ParameterMeta,
+    /// The metric to compare against the threshold.
+    pub metric: Metric,
+    /// The thresholds to compare against.
+    pub thresholds: Vec<Metric>,
+    /// The comparison predicate. Should be one of `LT`, `GT`, `EQ`, `LE`, or `GE` or their equivalents `<`, `>`, `==`,
+    /// `<=` or `>=`.
+    pub predicate: Predicate,
+    /// Optional metrics returned by the parameter.
+    pub returned_metrics: Option<Vec<Metric>>,
+    /// If true, the threshold comparison remains at the highest position ever reached.
+    #[serde(default)]
+    pub ratchet: bool,
+}
+
+#[cfg(feature = "core")]
+impl MultiThresholdParameter {
+    pub fn add_to_model(
+        &self,
+        network: &mut pywr_core::network::Network,
+        args: &LoadArgs,
+        parent: Option<&str>,
+    ) -> Result<ParameterType, SchemaError> {
+        let metric = self.metric.load(network, args, None)?;
+        let thresholds = self
+            .thresholds
+            .iter()
+            .map(|v| v.load(network, args, None))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let name = if self.returned_metrics.is_some() {
+            ParameterName::new_with_subname(&self.meta.name, Some("threshold"), Some(&self.meta.name))
+        } else {
+            self.meta.name.as_str().into()
+        };
+
+        let p = pywr_core::parameters::MultiThresholdParameter::new(
+            name,
+            metric,
+            &thresholds,
+            self.predicate.into(),
+            self.ratchet,
+        );
+
+        let p_idx = network.add_index_parameter(Box::new(p))?;
+
+        match self.returned_metrics {
+            Some(ref values) => {
+                let metrics = values
+                    .iter()
+                    .map(|v| v.load(network, args, None))
+                    .collect::<Result<Vec<_>, _>>()?;
+                let values_param = pywr_core::parameters::IndexedArrayParameter::new(
+                    ParameterName::new(&self.meta.name, parent),
+                    p_idx.into(),
+                    &metrics,
+                );
+                Ok(network.add_parameter(Box::new(values_param))?.into())
+            }
+            None => Ok(p_idx.into()),
+        }
+    }
+}
+
+impl TryFromV1<MultiThresholdIndexParameterV1> for MultiThresholdParameter {
+    type Error = ComponentConversionError;
+
+    fn try_from_v1(
+        v1: MultiThresholdIndexParameterV1,
+        parent_node: Option<&str>,
+        conversion_data: &mut ConversionData,
+    ) -> Result<Self, Self::Error> {
+        let meta: ParameterMeta = v1.meta.into_v2(parent_node, conversion_data);
+
+        let metric = Metric::Node(NodeAttrReference::new(v1.node, None));
+
+        let thresholds = v1
+            .thresholds
+            .into_iter()
+            .map(|v1_t| try_convert_parameter_attr(&meta.name, "thresholds", v1_t, parent_node, conversion_data))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let p = Self {
+            meta,
+            metric,
+            returned_metrics: None,
+            thresholds,
+            predicate: v1.predicate.into(),
+            ratchet: false,
+        };
+        Ok(p)
+    }
+}
+
+impl TryFromV1<MultipleThresholdParameterIndexParameterV1> for MultiThresholdParameter {
+    type Error = ComponentConversionError;
+
+    fn try_from_v1(
+        v1: MultipleThresholdParameterIndexParameterV1,
+        parent_node: Option<&str>,
+        conversion_data: &mut ConversionData,
+    ) -> Result<Self, Self::Error> {
+        let meta: ParameterMeta = v1.meta.into_v2(parent_node, conversion_data);
+
+        let metric = try_convert_parameter_attr(&meta.name, "parameter", v1.parameter, parent_node, conversion_data)?;
+
+        let thresholds = v1
+            .thresholds
+            .into_iter()
+            .map(|v1_t| try_convert_parameter_attr(&meta.name, "thresholds", v1_t, parent_node, conversion_data))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let p = Self {
+            meta,
+            metric,
+            returned_metrics: None,
+            thresholds,
             predicate: v1.predicate.into(),
             ratchet: false,
         };


### PR DESCRIPTION
Add MultiThresholdParameter and converions from v1 `MultipleThresholdIndexParameter` and
`MultipleThresholdParameterIndexParameter`.

This also adds a new `sub_name` field for `ParameterName` to allow schema level parameters to add multiple core level parameters to a network. This is required for the threshold parameters when they include `returned_metrics`.