### PR TITLE
feat: Implement microlp solver.

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Build
         run: cargo build --verbose  --all-features --workspace --exclude pywr-python
       - name: Run tests
-        run: cargo test  --features highs,cbc,ipm-simd --verbose -- --test-threads=1
+        run: cargo test  --features highs,cbc,microlp,ipm-simd --verbose -- --test-threads=1
       - name: Run mdbook test & build
         run: |
           output=$(mdbook test ./pywr-book 2>&1)

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -26,10 +26,10 @@ jobs:
         with:
           python-version-file: "pyproject.toml"
       - name: Run Clippy
-        run: cargo clippy --all-targets --features highs,cbc,ipm-simd
+        run: cargo clippy --all-targets --features highs,cbc,microlp,ipm-simd
       - name: Build
-        run: cargo build --verbose --features highs,cbc,ipm-simd --workspace --exclude pywr-python
+        run: cargo build --verbose --features highs,cbc,microlp,ipm-simd --workspace --exclude pywr-python
       - name: Run tests
         # Only test the library and binaries, not the docs
         # There were some issues with the docs tests timing out on Windows CI
-        run: cargo test --features highs,cbc,ipm-simd --verbose -- --test-threads=1
+        run: cargo test --features highs,cbc,microlp,ipm-simd --verbose -- --test-threads=1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1842,6 +1842,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "microlp"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d1790c73b93164ff65868f63164497cb32339458a9297e17e212d91df62258"
+dependencies = [
+ "log",
+ "sprs",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3129,6 +3139,7 @@ dependencies = [
  "ipm-ocl",
  "ipm-simd",
  "libc",
+ "microlp",
  "nalgebra 0.34.0",
  "ndarray",
  "num",
@@ -4048,6 +4059,18 @@ dependencies = [
  "hashbrown 0.15.3",
  "num-traits 0.2.19",
  "robust",
+ "smallvec",
+]
+
+[[package]]
+name = "sprs"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bff8419009a08f6cb7519a602c5590241fbff1446bcc823c07af15386eb801b"
+dependencies = [
+ "ndarray",
+ "num-complex",
+ "num-traits 0.2.19",
  "smallvec",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,7 @@ schemars = { version = "1.0", features = ["chrono04"] }
 rand = "0.8"
 rand_chacha = "0.3"
 wide = "0.7.33"
+microlp = "0.2.11"
 
 [workspace.metadata.docs.rs]
 rustdoc-args = ["--html-in-header", "katex-header.html"]

--- a/pywr-core/Cargo.toml
+++ b/pywr-core/Cargo.toml
@@ -38,6 +38,7 @@ rand_distr = "0.4"
 rand_chacha = { workspace = true }
 serde = { version = "1.0", features = ["derive"] }
 wide = { workspace = true, optional = true }
+microlp = { workspace = true, optional = true }
 
 [dev-dependencies]
 criterion = "0.7"
@@ -47,6 +48,7 @@ cbc = []
 highs = ["dep:highs-sys"]
 ipm-ocl = ["dep:ipm-ocl", "dep:ocl"]
 ipm-simd = ["dep:ipm-simd", "dep:wide"]
+microlp = ["dep:microlp"]
 default = ["pyo3"]
 pyo3 = ["dep:pyo3"]
 

--- a/pywr-core/src/solvers/builder.rs
+++ b/pywr-core/src/solvers/builder.rs
@@ -11,9 +11,6 @@ use std::fmt::Debug;
 use std::ops::Deref;
 use std::time::Instant;
 
-const FMAX: f64 = f64::MAX;
-const FMIN: f64 = f64::MIN;
-
 enum Bounds {
     // Free,
     Lower(f64),
@@ -34,6 +31,10 @@ pub enum ColType {
 /// This struct is intended to facilitate passing the LP data to a external library. Most
 /// libraries accept LP construct in sparse form.
 struct Lp<I> {
+    /// The maximum value for a floating point number to be used as a bound.
+    f64_max: f64,
+    /// The minimum value for a floating point number to be used as a bound.
+    f64_min: f64,
     col_lower: Vec<f64>,
     col_upper: Vec<f64>,
     col_obj_coef: Vec<f64>,
@@ -71,8 +72,8 @@ where
             .zip(self.row_upper.iter_mut())
         {
             if mask == &I::one() {
-                *lb = FMIN;
-                *ub = FMAX;
+                *lb = self.f64_min;
+                *ub = self.f64_max;
             }
         }
     }
@@ -129,6 +130,8 @@ where
 /// between variable and fixed types. In the generated `LP<I>` the user is able to modify the
 /// variable rows, but not the fixed rows.
 struct LpBuilder<I> {
+    f64_max: f64,
+    f64_min: f64,
     col_lower: Vec<f64>,
     col_upper: Vec<f64>,
     col_obj_coef: Vec<f64>,
@@ -137,12 +140,14 @@ struct LpBuilder<I> {
     fixed_rows: Vec<RowBuilder<I>>,
 }
 
-impl<I> Default for LpBuilder<I>
+impl<I> LpBuilder<I>
 where
     I: num::PrimInt,
 {
-    fn default() -> Self {
+    fn new(f64_max: f64, f64_min: f64) -> Self {
         Self {
+            f64_max,
+            f64_min,
             col_lower: Vec::new(),
             col_upper: Vec::new(),
             col_obj_coef: Vec::new(),
@@ -151,16 +156,11 @@ where
             fixed_rows: Vec::new(),
         }
     }
-}
 
-impl<I> LpBuilder<I>
-where
-    I: num::PrimInt,
-{
     fn add_column(&mut self, obj_coef: f64, bounds: Bounds, col_type: ColType) -> I {
         let (lb, ub): (f64, f64) = match bounds {
             Bounds::Double(lb, ub) => (lb, ub),
-            Bounds::Lower(lb) => (lb, FMAX),
+            Bounds::Lower(lb) => (lb, self.f64_max),
             // Bounds::Fixed(b) => (b, b),
             // Bounds::Free => (f64::MIN, FMAX),
             // Bounds::Upper(ub) => (f64::MIN, ub),
@@ -217,7 +217,7 @@ where
         for (rows, mask) in [(self.rows, I::one()), (self.fixed_rows, I::zero())] {
             for row in rows {
                 row_lower.push(row.lower);
-                row_upper.push(row.upper);
+                row_upper.push(row.upper.unwrap_or(self.f64_max));
                 row_mask.push(mask);
                 let prev_row_start = *row_starts.get(&row_starts.len() - 1).unwrap();
                 row_starts.push(prev_row_start + I::from(row.columns.len()).unwrap());
@@ -229,6 +229,8 @@ where
         }
 
         Lp {
+            f64_max: self.f64_max,
+            f64_min: self.f64_min,
             col_lower: self.col_lower,
             col_upper: self.col_upper,
             col_obj_coef: self.col_obj_coef,
@@ -247,7 +249,7 @@ where
 #[derive(Debug, PartialEq)]
 struct RowBuilder<I> {
     lower: f64,
-    upper: f64,
+    upper: Option<f64>,
     columns: BTreeMap<I, f64>,
 }
 
@@ -255,7 +257,7 @@ impl<I> Default for RowBuilder<I> {
     fn default() -> Self {
         Self {
             lower: 0.0,
-            upper: FMAX,
+            upper: None,
             columns: BTreeMap::new(),
         }
     }
@@ -266,7 +268,7 @@ where
     I: num::PrimInt,
 {
     pub fn set_upper(&mut self, upper: f64) {
-        self.upper = upper;
+        self.upper = Some(upper);
     }
 
     pub fn set_lower(&mut self, lower: f64) {
@@ -389,6 +391,26 @@ where
 
     pub fn coefficients_to_update(&self) -> &[(I, I, f64)] {
         &self.builder.coefficients_to_update
+    }
+
+    /// Apply the updated coefficients to the sparse matrix.
+    pub fn apply_updated_coefficients(&mut self) {
+        for (row, col, value) in self.builder.coefficients_to_update.drain(..) {
+            let row = row.to_usize().unwrap();
+            let col = col.to_usize().unwrap();
+
+            // Find the position of the column in the sparse matrix
+            let start = self.builder.row_starts[row].to_usize().unwrap();
+            let end = self.builder.row_starts[row + 1].to_usize().unwrap();
+            if let Some(pos) = self.builder.columns[start..end]
+                .iter()
+                .position(|&c| c.to_usize().unwrap() == col)
+            {
+                self.builder.elements[start + pos] = value;
+            } else {
+                panic!("Column not found in row when applying updated coefficients.");
+            }
+        }
     }
 
     pub fn update(
@@ -599,24 +621,19 @@ pub struct SolverBuilder<I> {
     node_set_bin_col_map: HashMap<Vec<NodeIndex>, I>,
 }
 
-impl<I> Default for SolverBuilder<I>
+impl<I> SolverBuilder<I>
 where
-    I: num::PrimInt,
+    I: num::PrimInt + Default + Debug,
 {
-    fn default() -> Self {
+    pub fn new(f64_max: f64, f64_min: f64) -> Self {
         Self {
-            builder: LpBuilder::default(),
+            builder: LpBuilder::new(f64_max, f64_min),
             col_edge_map: ColumnEdgeMapBuilder::default(),
             node_bin_col_map: HashMap::new(),
             node_set_bin_col_map: HashMap::new(),
         }
     }
-}
 
-impl<I> SolverBuilder<I>
-where
-    I: num::PrimInt + Default + Debug,
-{
     pub fn col_for_edge(&self, edge_index: &EdgeIndex) -> I {
         self.col_edge_map.col_for_edge(edge_index)
     }
@@ -839,15 +856,15 @@ where
                     match bounds {
                         Some(bounds) => {
                             // If the bounds are constant then the binary variable is used to control the upper bound
-                            row_ub.add_element(*col, bounds.max_flow.min(1e8));
+                            row_ub.add_element(*col, bounds.max_flow.min(1e6));
                             row_ub.set_lower(0.0);
-                            row_ub.set_upper(FMAX);
+                            row_ub.set_upper(self.builder.f64_max);
                             self.builder.add_fixed_row(row_ub);
 
                             if bounds.min_flow != 0.0 {
-                                row_lb.add_element(*col, -bounds.min_flow.max(1e-8));
+                                row_lb.add_element(*col, -bounds.min_flow.max(1e-6));
                                 row_lb.set_lower(0.0);
-                                row_lb.set_upper(FMAX);
+                                row_lb.set_upper(self.builder.f64_max);
 
                                 self.builder.add_fixed_row(row_lb);
                             }
@@ -1045,12 +1062,12 @@ mod tests {
 
     #[test]
     fn model_builder_new() {
-        let _builder: LpBuilder<i32> = LpBuilder::default();
+        let _builder: LpBuilder<i32> = LpBuilder::new(f64::INFINITY, f64::NEG_INFINITY);
     }
 
     #[test]
     fn builder_add_rows() {
-        let mut builder: LpBuilder<i32> = LpBuilder::default();
+        let mut builder: LpBuilder<i32> = LpBuilder::new(f64::INFINITY, f64::NEG_INFINITY);
         let mut row = RowBuilder::default();
         row.add_element(0, 1.0);
         row.add_element(1, 1.0);
@@ -1061,7 +1078,7 @@ mod tests {
 
     #[test]
     fn builder_solve2() {
-        let mut builder = LpBuilder::default();
+        let mut builder = LpBuilder::new(f64::MAX, f64::MIN);
 
         builder.add_column(-2.0, Bounds::Lower(0.0), ColType::Continuous);
         builder.add_column(-3.0, Bounds::Lower(0.0), ColType::Continuous);

--- a/pywr-core/src/solvers/cbc/mod.rs
+++ b/pywr-core/src/solvers/cbc/mod.rs
@@ -247,7 +247,7 @@ impl Solver for CbcSolver {
         values: &ConstParameterValues,
         _settings: &Self::Settings,
     ) -> Result<Box<Self>, SolverSetupError> {
-        let builder = SolverBuilder::default();
+        let builder = SolverBuilder::new(f64::MAX, f64::MIN);
         let built = builder.create(model, values)?;
 
         let solver = CbcSolver::from_builder(built);

--- a/pywr-core/src/solvers/clp/mod.rs
+++ b/pywr-core/src/solvers/clp/mod.rs
@@ -249,7 +249,7 @@ impl Solver for ClpSolver {
         values: &ConstParameterValues,
         _settings: &Self::Settings,
     ) -> Result<Box<Self>, SolverSetupError> {
-        let builder = SolverBuilder::default();
+        let builder = SolverBuilder::new(f64::MAX, f64::MIN);
         let built = builder.create(model, values)?;
 
         let solver = ClpSolver::from_builder(built);

--- a/pywr-core/src/solvers/highs/mod.rs
+++ b/pywr-core/src/solvers/highs/mod.rs
@@ -321,7 +321,7 @@ impl Solver for HighsSolver {
         values: &ConstParameterValues,
         _settings: &Self::Settings,
     ) -> Result<Box<Self>, SolverSetupError> {
-        let builder: SolverBuilder<HighsInt> = SolverBuilder::default();
+        let builder: SolverBuilder<HighsInt> = SolverBuilder::new(f64::MAX, f64::MIN);
         let built = builder.create(network, values)?;
 
         let num_cols = built.num_cols();

--- a/pywr-core/src/solvers/microlp/mod.rs
+++ b/pywr-core/src/solvers/microlp/mod.rs
@@ -1,0 +1,148 @@
+mod settings;
+use super::builder::{ColType, SolverBuilder};
+use crate::network::Network;
+use crate::solvers::builder::BuiltSolver;
+use crate::solvers::{Solver, SolverFeatures, SolverSetupError, SolverSolveError, SolverTimings};
+use crate::state::{ConstParameterValues, State};
+use crate::timestep::Timestep;
+use microlp::{ComparisonOp, OptimizationDirection, Problem};
+pub use settings::{MicroLpSolverSettings, MicroLpSolverSettingsBuilder};
+use std::time::Instant;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum MicroLpError {
+    #[error("MicroLp solver error: {0}")]
+    SolveError(#[from] microlp::Error),
+}
+
+pub struct MicroLpSolver {
+    builder: BuiltSolver<usize>,
+}
+
+impl MicroLpSolver {
+    pub fn make_problem(&self) -> Problem {
+        let mut problem = Problem::new(OptimizationDirection::Minimize);
+
+        let variables: Vec<_> = self
+            .builder
+            .col_lower()
+            .iter()
+            .zip(self.builder.col_upper())
+            .zip(self.builder.col_obj_coef())
+            .zip(self.builder.col_type())
+            .map(|(((lb, ub), obj_coeff), c_ty)| match c_ty {
+                ColType::Continuous => problem.add_var(*obj_coeff, (*lb, *ub)),
+                ColType::Integer => {
+                    let ub = *ub as i32;
+                    let lb = *lb as i32;
+
+                    if lb == 0 && ub == 1 {
+                        // Binary variable
+                        problem.add_binary_var(*obj_coeff)
+                    } else {
+                        problem.add_integer_var(*obj_coeff, (lb, ub))
+                    }
+                }
+            })
+            .collect();
+
+        for row in 0..self.builder.num_rows() {
+            let row_lower = self.builder.row_lower()[row];
+            let row_upper = self.builder.row_upper()[row];
+            let row_start = self.builder.row_starts()[row];
+            let row_end = self.builder.row_starts()[row + 1];
+            let row_cols = &self.builder.columns()[row_start..row_end];
+            let row_values = &self.builder.elements()[row_start..row_end];
+
+            let expr = row_cols
+                .iter()
+                .zip(row_values.iter())
+                .map(|(&col, &val)| (variables[col], val));
+
+            if row_lower == row_upper {
+                // If the bounds are equal we can just add a single equality constraint
+                problem.add_constraint(expr.clone(), ComparisonOp::Eq, row_lower);
+            } else {
+                assert!(row_lower < row_upper, "Row lower bound must be less than upper bound");
+                // Otherwise add two rows for each constraint (>= and <=)
+                problem.add_constraint(expr.clone(), ComparisonOp::Ge, row_lower);
+
+                if row_upper.is_finite() {
+                    problem.add_constraint(expr, ComparisonOp::Le, row_upper);
+                }
+            }
+        }
+
+        problem
+    }
+}
+
+impl Solver for MicroLpSolver {
+    type Settings = MicroLpSolverSettings;
+
+    fn name() -> &'static str {
+        "microlp"
+    }
+
+    fn features() -> &'static [SolverFeatures] {
+        &[
+            SolverFeatures::VirtualStorage,
+            SolverFeatures::MutualExclusivity,
+            SolverFeatures::AggregatedNode,
+            SolverFeatures::AggregatedNodeFactors,
+            SolverFeatures::AggregatedNodeDynamicFactors,
+            SolverFeatures::VirtualStorage,
+        ]
+    }
+
+    fn setup(
+        model: &Network,
+        values: &ConstParameterValues,
+        _settings: &Self::Settings,
+    ) -> Result<Box<Self>, SolverSetupError> {
+        let builder = SolverBuilder::new(f64::INFINITY, f64::NEG_INFINITY);
+        let built = builder.create(model, values)?;
+
+        let solver = MicroLpSolver { builder: built };
+        Ok(Box::new(solver))
+    }
+
+    fn solve(
+        &mut self,
+        model: &Network,
+        timestep: &Timestep,
+        state: &mut State,
+    ) -> Result<SolverTimings, SolverSolveError> {
+        let mut timings = SolverTimings::default();
+        self.builder.update(model, timestep, state, &mut timings)?;
+
+        self.builder.apply_updated_coefficients();
+
+        let now = Instant::now();
+        let problem = self.make_problem();
+        timings.update_constraints += now.elapsed();
+
+        let now = Instant::now();
+        let solution = problem.solve().map_err(MicroLpError::SolveError)?;
+
+        let solution = solution.iter().map(|(_, x)| *x).collect::<Vec<f64>>();
+
+        timings.solve = now.elapsed();
+
+        // Create the updated network state from the results
+        let network_state = state.get_mut_network_state();
+        network_state.reset();
+
+        let start_save_solution = Instant::now();
+        for edge in model.edges().iter() {
+            let col = self.builder.col_for_edge(&edge.index());
+            let flow = solution[col];
+            network_state.add_flow(edge, timestep, flow)?;
+        }
+        state.complete(model, timestep)?;
+        timings.save_solution += start_save_solution.elapsed();
+
+        Ok(timings)
+    }
+}

--- a/pywr-core/src/solvers/microlp/settings.rs
+++ b/pywr-core/src/solvers/microlp/settings.rs
@@ -1,0 +1,95 @@
+use crate::solvers::SolverSettings;
+
+#[derive(PartialEq, Debug, Copy, Clone)]
+pub struct MicroLpSolverSettings {
+    parallel: bool,
+    threads: usize,
+    ignore_feature_requirements: bool,
+}
+
+// Default implementation is a convenience that defers to the builder.
+impl Default for MicroLpSolverSettings {
+    fn default() -> Self {
+        MicroLpSolverSettingsBuilder::default().build()
+    }
+}
+
+impl SolverSettings for MicroLpSolverSettings {
+    fn parallel(&self) -> bool {
+        false
+    }
+
+    fn threads(&self) -> usize {
+        1
+    }
+
+    fn ignore_feature_requirements(&self) -> bool {
+        false
+    }
+}
+
+/// Builder for [`MicroLpSolverSettings`].
+///
+/// # Examples
+///
+/// ```
+/// use std::num::NonZeroUsize;
+/// use pywr_core::solvers::MicroLpSolverSettingsBuilder;
+/// // Settings with parallel enabled and 4 threads.
+/// let settings = MicroLpSolverSettingsBuilder::default().parallel().threads(4).build();
+///
+/// let mut builder = MicroLpSolverSettingsBuilder::default();
+///
+/// builder = builder.parallel();
+/// let settings = builder.build();
+///
+/// ```
+#[derive(Default)]
+pub struct MicroLpSolverSettingsBuilder {
+    parallel: bool,
+    threads: usize,
+    ignore_feature_requirements: bool,
+}
+
+impl crate::solvers::MicroLpSolverSettingsBuilder {
+    pub fn parallel(mut self) -> Self {
+        self.parallel = true;
+        self
+    }
+
+    pub fn threads(mut self, threads: usize) -> Self {
+        self.threads = threads;
+        self
+    }
+
+    pub fn ignore_feature_requirements(mut self) -> Self {
+        self.ignore_feature_requirements = true;
+        self
+    }
+
+    /// Construct a [`ClpSolverSettings`] from the builder.
+    pub fn build(self) -> MicroLpSolverSettings {
+        MicroLpSolverSettings {
+            parallel: self.parallel,
+            threads: self.threads,
+            ignore_feature_requirements: self.ignore_feature_requirements,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{MicroLpSolverSettings, MicroLpSolverSettingsBuilder};
+
+    #[test]
+    fn builder_test() {
+        let _settings = MicroLpSolverSettings {
+            parallel: true,
+            threads: 0,
+            ignore_feature_requirements: false,
+        };
+        let settings_from_builder = MicroLpSolverSettingsBuilder::default().parallel().build();
+
+        assert_eq!(settings_from_builder, settings_from_builder);
+    }
+}

--- a/pywr-core/src/solvers/mod.rs
+++ b/pywr-core/src/solvers/mod.rs
@@ -17,6 +17,7 @@ mod highs;
 mod ipm_ocl;
 #[cfg(feature = "ipm-simd")]
 mod ipm_simd;
+mod microlp;
 
 #[cfg(feature = "ipm-ocl")]
 pub use self::ipm_ocl::{ClIpmF32Solver, ClIpmF64Solver, ClIpmSolverSettings, ClIpmSolverSettingsBuilder};
@@ -29,7 +30,8 @@ pub use cbc::{CbcError, CbcSolver, CbcSolverSettings, CbcSolverSettingsBuilder};
 pub use clp::{ClpError, ClpSolver, ClpSolverSettings, ClpSolverSettingsBuilder};
 #[cfg(feature = "highs")]
 pub use highs::{HighsSolver, HighsSolverSettings, HighsSolverSettingsBuilder};
-
+#[cfg(feature = "microlp")]
+pub use microlp::{MicroLpError, MicroLpSolver, MicroLpSolverSettings, MicroLpSolverSettingsBuilder};
 #[derive(Default, Debug)]
 pub struct SolverTimings {
     pub update_objective: Duration,
@@ -144,6 +146,9 @@ pub enum SolverSolveError {
     #[cfg(feature = "highs")]
     #[error("Highs error: {0}")]
     HighsModelError(#[from] highs::HighsModelError),
+    #[cfg(feature = "microlp")]
+    #[error("MicroLP error: {0}")]
+    MicroLpError(#[from] MicroLpError),
 }
 
 pub trait Solver: Send {

--- a/pywr-core/src/test_utils.rs
+++ b/pywr-core/src/test_utils.rs
@@ -396,6 +396,17 @@ pub fn run_all_solvers(
         }
     }
 
+    #[cfg(feature = "microlp")]
+    {
+        if !solvers_to_skip.contains(&"microlp") {
+            check_features_and_run::<crate::solvers::MicroLpSolver>(
+                model,
+                !solvers_without_features.contains(&"microlp"),
+                expected_outputs,
+            );
+        }
+    }
+
     #[cfg(feature = "ipm-simd")]
     {
         if !solvers_to_skip.contains(&"ipm-simd") {


### PR DESCRIPTION
This is a Rust based solver that uses the simplex method and can handle integer variables. A new feature is added to enable this solver. The API requires rebuilding the LP every solve, which is probably not very efficient.

This solver also uses f64::INFINITY for identifing unbounded rows and columns. The current solvers uses f64::MAX. The solver builders are updated so that this value can be set on a per solver basis.

Added it to the CI tests.