### PR TITLE
chore: Rename Metric::Constant to Metric::Literal.

### DIFF
--- a/pywr-python/tests/models/aggregated-node1/model.json
+++ b/pywr-python/tests/models/aggregated-node1/model.json
@@ -29,7 +29,7 @@
         },
         "type": "Link",
         "max_flow": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 2.0
         }
       },
@@ -39,7 +39,7 @@
         },
         "type": "Link",
         "cost": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 1.0
         }
       },
@@ -57,7 +57,7 @@
           }
         ],
         "max_flow": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 5.0
         }
       },
@@ -67,7 +67,7 @@
         },
         "type": "Output",
         "cost": {
-          "type": "Constant",
+          "type": "Literal",
           "value": -10.0
         },
         "max_flow": {

--- a/pywr-python/tests/models/piecewise-link1/model.json
+++ b/pywr-python/tests/models/piecewise-link1/model.json
@@ -45,11 +45,11 @@
         "steps": [
           {
             "cost": {
-              "type": "Constant",
+              "type": "Literal",
               "value": -10.0
             },
             "max_flow": {
-              "type": "Constant",
+              "type": "Literal",
               "value": 1.0
             }
           },
@@ -69,7 +69,7 @@
         },
         "type": "Output",
         "cost": {
-          "type": "Constant",
+          "type": "Literal",
           "value": -5.0
         },
         "max_flow": {

--- a/pywr-python/tests/models/simple-custom-parameter/model.json
+++ b/pywr-python/tests/models/simple-custom-parameter/model.json
@@ -35,7 +35,7 @@
         },
         "type": "Output",
         "cost": {
-          "type": "Constant",
+          "type": "Literal",
           "value": -10.0
         },
         "max_flow": {

--- a/pywr-python/tests/models/simple-storage-timeseries/model.json
+++ b/pywr-python/tests/models/simple-storage-timeseries/model.json
@@ -15,7 +15,7 @@
         },
         "type": "Input",
         "max_flow": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 9.0
         }
       },
@@ -25,7 +25,7 @@
         },
         "type": "Storage",
         "cost": {
-          "type": "Constant",
+          "type": "Literal",
           "value": -1.0
         },
         "initial_volume": {
@@ -33,7 +33,7 @@
           "volume": 500.0
         },
         "max_volume": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 1000.0
         }
       },
@@ -43,7 +43,7 @@
         },
         "type": "Output",
         "cost": {
-          "type": "Constant",
+          "type": "Literal",
           "value": -10.0
         },
         "max_flow": {

--- a/pywr-python/tests/models/simple-timeseries/model.json
+++ b/pywr-python/tests/models/simple-timeseries/model.json
@@ -35,7 +35,7 @@
         },
         "type": "Output",
         "cost": {
-          "type": "Constant",
+          "type": "Literal",
           "value": -10.0
         },
         "max_flow": {

--- a/pywr-schema/src/metric.rs
+++ b/pywr-schema/src/metric.rs
@@ -43,8 +43,8 @@ use strum_macros::{Display, EnumDiscriminants, EnumIter, EnumString, IntoStaticS
 // This creates a separate enum called `MetricType` that is available in this module.
 #[strum_discriminants(name(MetricType))]
 pub enum Metric {
-    /// A constant floating point value.
-    Constant { value: f64 },
+    /// A literal floating point value.
+    Literal { value: f64 },
     /// A reference to a constant value in a table.
     Table(TableDataRef),
     /// An attribute of a node.
@@ -63,13 +63,13 @@ pub enum Metric {
 
 impl Default for Metric {
     fn default() -> Self {
-        Self::Constant { value: 0.0 }
+        Self::Literal { value: 0.0 }
     }
 }
 
 impl From<f64> for Metric {
     fn from(value: f64) -> Self {
-        Self::Constant { value }
+        Self::Literal { value }
     }
 }
 
@@ -95,7 +95,7 @@ impl Metric {
 
                 parameter_ref.load_f64(network, parent)
             }
-            Self::Constant { value } => Ok((*value).into()),
+            Self::Literal { value } => Ok((*value).into()),
             Self::Table(table_ref) => {
                 let value = args
                     .tables
@@ -136,7 +136,7 @@ impl Metric {
             Self::Node(node_ref) => Ok(node_ref.name.to_string()),
             Self::Parameter(parameter_ref) => Ok(parameter_ref.name.clone()),
             Self::LocalParameter(parameter_ref) => Ok(parameter_ref.name.clone()),
-            Self::Constant { .. } => Err(SchemaError::LiteralConstantOutputNotSupported),
+            Self::Literal { .. } => Err(SchemaError::LiteralConstantOutputNotSupported),
             Self::Table(table_ref) => Ok(table_ref.table.clone()),
             Self::Timeseries(ts_ref) => Ok(ts_ref.name.clone()),
             Self::InterNetworkTransfer { name } => Ok(name.clone()),
@@ -149,7 +149,7 @@ impl Metric {
             Self::Node(node_ref) => node_ref.attribute(args)?.to_string(),
             Self::Parameter(p_ref) => p_ref.key.clone().unwrap_or_else(|| "value".to_string()),
             Self::LocalParameter(p_ref) => p_ref.key.clone().unwrap_or_else(|| "value".to_string()),
-            Self::Constant { .. } => "value".to_string(),
+            Self::Literal { .. } => "value".to_string(),
             Self::Table(tbl_ref) => tbl_ref.key().join(";").to_string(),
             Self::Timeseries(ts_ref) => ts_ref
                 .column()
@@ -170,7 +170,7 @@ impl Metric {
             Self::Node(node_ref) => Some(node_ref.node_type(args)?.to_string()),
             Self::Parameter(parameter_ref) => Some(parameter_ref.parameter_type(args)?.to_string()),
             Self::LocalParameter(parameter_ref) => Some(parameter_ref.parameter_type(args)?.to_string()),
-            Self::Constant { .. } => None,
+            Self::Literal { .. } => None,
             Self::Table(_) => None,
             Self::Timeseries(_) => None,
             Self::InterNetworkTransfer { .. } => None,
@@ -210,7 +210,7 @@ impl TryFromV1<ParameterValueV1> for Metric {
         conversion_data: &mut ConversionData,
     ) -> Result<Self, Self::Error> {
         let p = match v1 {
-            ParameterValueV1::Constant(value) => Self::Constant { value },
+            ParameterValueV1::Constant(value) => Self::Literal { value },
             ParameterValueV1::Reference(p_name) => Self::Parameter(ParameterReference {
                 name: p_name,
                 key: None,

--- a/pywr-schema/src/nodes/core.rs
+++ b/pywr-schema/src/nodes/core.rs
@@ -1714,7 +1714,7 @@ mod tests {
                     "name": "supply1"
                 },
                 "max_flow": {
-                    "type": "Constant",
+                    "type": "Literal",
                     "value": 15.0
                 }
             }
@@ -1733,7 +1733,7 @@ mod tests {
                     "name": "storage1"
                 },
                 "max_volume": {
-                  "type": "Constant",
+                  "type": "Literal",
                   "value": 10.0
                 },
                 "initial_volume": {
@@ -1756,7 +1756,7 @@ mod tests {
                     "name": "storage1"
                 },
                 "max_volume": {
-                  "type": "Constant",
+                  "type": "Literal",
                   "value": 15.0
                 },
                 "initial_volume": {

--- a/pywr-schema/src/nodes/river_split_with_gauge.rs
+++ b/pywr-schema/src/nodes/river_split_with_gauge.rs
@@ -354,12 +354,12 @@ fn convert_factors(
 ) -> Result<Vec<Metric>, ConversionError> {
     let mut iter = factors.into_iter();
     if let Some(first_factor) = iter.next() {
-        if let Metric::Constant { value } = first_factor.try_into_v2(parent_node, conversion_data)? {
+        if let Metric::Literal { value } = first_factor.try_into_v2(parent_node, conversion_data)? {
             // First Metric is a constant; we can proceed with the conversion
 
             let split_factors = iter
                 .map(|f| {
-                    if let Metric::Constant { value } = f.try_into_v2(parent_node, conversion_data)? {
+                    if let Metric::Literal { value } = f.try_into_v2(parent_node, conversion_data)? {
                         Ok(value)
                     } else {
                         Err(ConversionError::NonConstantValue {})
@@ -371,7 +371,7 @@ fn convert_factors(
             let sum: f64 = split_factors.iter().sum::<f64>() + value;
             Ok(split_factors
                 .into_iter()
-                .map(|f| Metric::Constant { value: f / sum })
+                .map(|f| Metric::Literal { value: f / sum })
                 .collect())
         } else {
             // Non-constant metric can not be easily converted to proportional factors

--- a/pywr-schema/src/parameters/control_curves.rs
+++ b/pywr-schema/src/parameters/control_curves.rs
@@ -421,7 +421,7 @@ mod tests {
                 },
                 "control_curves": [
                     {"type": "Parameter", "name": "reservoir_cc"},
-                    {"type": "Constant", "value": 0.2}
+                    {"type": "Literal", "value": 0.2}
                 ],
                 "values": [
                     [-0.1, -1.0],

--- a/pywr-schema/src/parameters/doc_examples/aggregated_1.json
+++ b/pywr-schema/src/parameters/doc_examples/aggregated_1.json
@@ -8,7 +8,7 @@
   },
   "metrics": [
     {
-      "type": "Constant",
+      "type": "Literal",
       "value": 3.1415
     },
     {

--- a/pywr-schema/src/parameters/doc_examples/division.json
+++ b/pywr-schema/src/parameters/doc_examples/division.json
@@ -8,7 +8,7 @@
     "name": "my-monthly-profile"
   },
   "denominator": {
-    "type": "Constant",
+    "type": "Literal",
     "value": 0.3
   }
 }

--- a/pywr-schema/src/parameters/doc_examples/hydropower.json
+++ b/pywr-schema/src/parameters/doc_examples/hydropower.json
@@ -4,11 +4,11 @@
   },
   "type": "HydropowerTarget",
   "target": {
-    "type": "Constant",
+    "type": "Literal",
     "value": 320.11
   },
   "water_elevation": {
-    "type": "Constant",
+    "type": "Literal",
     "value": 1.0
   },
   "turbine_elevation": 35.0,

--- a/pywr-schema/src/parameters/doc_examples/threshold_returned_values1.json
+++ b/pywr-schema/src/parameters/doc_examples/threshold_returned_values1.json
@@ -1,24 +1,24 @@
 {
   "type": "Threshold",
   "meta": {
-      "name": "my-threshold-param"
+    "name": "my-threshold-param"
   },
   "metric": {
-      "type": "Node",
-      "name": "river-1"
+    "type": "Node",
+    "name": "river-1"
   },
   "threshold": {
-      "type": "Constant",
-      "value": 5.0
+    "type": "Literal",
+    "value": 5.0
   },
   "predicate": "LT",
   "returned_metrics": [
     {
-      "type": "Constant",
+      "type": "Literal",
       "value": 1.5
     },
     {
-      "type": "Constant",
+      "type": "Literal",
       "value": 0.5
     }
   ]

--- a/pywr-schema/src/parameters/doc_examples/threshold_returned_values2.json
+++ b/pywr-schema/src/parameters/doc_examples/threshold_returned_values2.json
@@ -2,22 +2,22 @@
   {
     "type": "Threshold",
     "meta": {
-        "name": "my-threshold-param"
+      "name": "my-threshold-param"
     },
     "metric": {
-        "type": "Node",
-        "name": "river-1"
+      "type": "Node",
+      "name": "river-1"
     },
     "threshold": {
-        "type": "Constant",
-        "value": 5.0
+      "type": "Literal",
+      "value": 5.0
     },
     "predicate": "LT"
   },
   {
     "type": "IndexedArray",
     "meta": {
-        "name": "my-indexed-array-param"
+      "name": "my-indexed-array-param"
     },
     "index_parameter": {
       "type": "Parameter",
@@ -25,11 +25,11 @@
     },
     "metrics": [
       {
-        "type": "Constant",
+        "type": "Literal",
         "value": 1.5
       },
       {
-        "type": "Constant",
+        "type": "Literal",
         "value": 0.5
       }
     ]

--- a/pywr-schema/tests/30-day-licence.json
+++ b/pywr-schema/tests/30-day-licence.json
@@ -17,7 +17,7 @@
         },
         "type": "Input",
         "max_flow": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 15
         }
       },
@@ -37,7 +37,7 @@
           "name": "demand"
         },
         "cost": {
-          "type": "Constant",
+          "type": "Literal",
           "value": -10
         }
       },
@@ -52,7 +52,7 @@
           }
         ],
         "max_volume": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 300
         },
         "initial_volume": {

--- a/pywr-schema/tests/abstraction1.json
+++ b/pywr-schema/tests/abstraction1.json
@@ -26,19 +26,19 @@
         },
         "type": "Abstraction",
         "mrf": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 2.0
         },
         "mrf_cost": {
-          "type": "Constant",
+          "type": "Literal",
           "value": -1000.0
         },
         "abs_max_flow": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 4.0
         },
         "abs_cost": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 1.0
         }
       },
@@ -54,11 +54,11 @@
         },
         "type": "Output",
         "cost": {
-          "type": "Constant",
+          "type": "Literal",
           "value": -500
         },
         "max_flow": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 4.0
         }
       },
@@ -68,7 +68,7 @@
         },
         "type": "VirtualStorage",
         "max_volume": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 13
         },
         "initial_volume": {

--- a/pywr-schema/tests/abstraction2.json
+++ b/pywr-schema/tests/abstraction2.json
@@ -26,11 +26,11 @@
         },
         "type": "Abstraction",
         "abs_max_flow": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 4.0
         },
         "abs_cost": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 1.0
         }
       },
@@ -46,11 +46,11 @@
         },
         "type": "Output",
         "cost": {
-          "type": "Constant",
+          "type": "Literal",
           "value": -500
         },
         "max_flow": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 4.0
         }
       },
@@ -60,7 +60,7 @@
         },
         "type": "VirtualStorage",
         "max_volume": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 13
         },
         "initial_volume": {

--- a/pywr-schema/tests/agg-storage1.json
+++ b/pywr-schema/tests/agg-storage1.json
@@ -17,7 +17,7 @@
         },
         "type": "Input",
         "max_flow": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 5
         }
       },
@@ -27,11 +27,11 @@
         },
         "type": "Storage",
         "cost": {
-          "type": "Constant",
+          "type": "Literal",
           "value": -0.1
         },
         "max_volume": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 100
         },
         "initial_volume": {
@@ -49,7 +49,7 @@
           "name": "demand"
         },
         "cost": {
-          "type": "Constant",
+          "type": "Literal",
           "value": -10
         }
       },
@@ -59,7 +59,7 @@
         },
         "type": "Input",
         "max_flow": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 5
         }
       },
@@ -69,11 +69,11 @@
         },
         "type": "Storage",
         "cost": {
-          "type": "Constant",
+          "type": "Literal",
           "value": -0.1
         },
         "max_volume": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 100
         },
         "initial_volume": {
@@ -91,7 +91,7 @@
           "name": "demand"
         },
         "cost": {
-          "type": "Constant",
+          "type": "Literal",
           "value": -10
         }
       },
@@ -140,17 +140,17 @@
         },
         "control_curves": [
           {
-            "type": "Constant",
+            "type": "Literal",
             "value": 0.475
           }
         ],
         "values": [
           {
-            "type": "Constant",
+            "type": "Literal",
             "value": 10.0
           },
           {
-            "type": "Constant",
+            "type": "Literal",
             "value": 5.0
           }
         ]

--- a/pywr-schema/tests/agg-storage2.json
+++ b/pywr-schema/tests/agg-storage2.json
@@ -17,7 +17,7 @@
         },
         "type": "Input",
         "max_flow": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 5
         }
       },
@@ -27,11 +27,11 @@
         },
         "type": "Reservoir",
         "cost": {
-          "type": "Constant",
+          "type": "Literal",
           "value": -0.1
         },
         "max_volume": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 100
         },
         "initial_volume": {
@@ -49,7 +49,7 @@
           "name": "demand"
         },
         "cost": {
-          "type": "Constant",
+          "type": "Literal",
           "value": -10
         }
       },
@@ -59,7 +59,7 @@
         },
         "type": "Input",
         "max_flow": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 5
         }
       },
@@ -69,11 +69,11 @@
         },
         "type": "Reservoir",
         "cost": {
-          "type": "Constant",
+          "type": "Literal",
           "value": -0.1
         },
         "max_volume": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 100
         },
         "initial_volume": {
@@ -91,7 +91,7 @@
           "name": "demand"
         },
         "cost": {
-          "type": "Constant",
+          "type": "Literal",
           "value": -10
         }
       },
@@ -140,17 +140,17 @@
         },
         "control_curves": [
           {
-            "type": "Constant",
+            "type": "Literal",
             "value": 0.475
           }
         ],
         "values": [
           {
-            "type": "Constant",
+            "type": "Literal",
             "value": 10.0
           },
           {
-            "type": "Constant",
+            "type": "Literal",
             "value": 5.0
           }
         ]

--- a/pywr-schema/tests/agg-storage3.json
+++ b/pywr-schema/tests/agg-storage3.json
@@ -17,7 +17,7 @@
         },
         "type": "Input",
         "max_flow": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 5
         }
       },
@@ -27,11 +27,11 @@
         },
         "type": "PiecewiseStorage",
         "cost": {
-          "type": "Constant",
+          "type": "Literal",
           "value": -0.1
         },
         "max_volume": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 100
         },
         "initial_volume": {
@@ -41,21 +41,21 @@
         "steps": [
           {
             "cost": {
-              "type": "Constant",
+              "type": "Literal",
               "value": -0.2
             },
             "control_curve": {
-              "type": "Constant",
+              "type": "Literal",
               "value": 0.25
             }
           },
           {
             "cost": {
-              "type": "Constant",
+              "type": "Literal",
               "value": -0.15
             },
             "control_curve": {
-              "type": "Constant",
+              "type": "Literal",
               "value": 0.5
             }
           }
@@ -71,7 +71,7 @@
           "name": "demand"
         },
         "cost": {
-          "type": "Constant",
+          "type": "Literal",
           "value": -10
         }
       },
@@ -81,7 +81,7 @@
         },
         "type": "Input",
         "max_flow": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 5
         }
       },
@@ -91,11 +91,11 @@
         },
         "type": "PiecewiseStorage",
         "cost": {
-          "type": "Constant",
+          "type": "Literal",
           "value": -0.1
         },
         "max_volume": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 100
         },
         "initial_volume": {
@@ -105,21 +105,21 @@
         "steps": [
           {
             "cost": {
-              "type": "Constant",
+              "type": "Literal",
               "value": -0.2
             },
             "control_curve": {
-              "type": "Constant",
+              "type": "Literal",
               "value": 0.25
             }
           },
           {
             "cost": {
-              "type": "Constant",
+              "type": "Literal",
               "value": -0.15
             },
             "control_curve": {
-              "type": "Constant",
+              "type": "Literal",
               "value": 0.5
             }
           }
@@ -135,7 +135,7 @@
           "name": "demand"
         },
         "cost": {
-          "type": "Constant",
+          "type": "Literal",
           "value": -10
         }
       },
@@ -184,17 +184,17 @@
         },
         "control_curves": [
           {
-            "type": "Constant",
+            "type": "Literal",
             "value": 0.475
           }
         ],
         "values": [
           {
-            "type": "Constant",
+            "type": "Literal",
             "value": 10.0
           },
           {
-            "type": "Constant",
+            "type": "Literal",
             "value": 5.0
           }
         ]

--- a/pywr-schema/tests/csv1.json
+++ b/pywr-schema/tests/csv1.json
@@ -17,7 +17,7 @@
         },
         "type": "Input",
         "max_flow": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 15
         }
       },
@@ -37,7 +37,7 @@
           "name": "demand"
         },
         "cost": {
-          "type": "Constant",
+          "type": "Literal",
           "value": -10
         }
       }

--- a/pywr-schema/tests/csv2.json
+++ b/pywr-schema/tests/csv2.json
@@ -17,7 +17,7 @@
         },
         "type": "Input",
         "max_flow": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 15
         }
       },
@@ -37,7 +37,7 @@
           "name": "demand"
         },
         "cost": {
-          "type": "Constant",
+          "type": "Literal",
           "value": -10
         }
       }

--- a/pywr-schema/tests/csv3.json
+++ b/pywr-schema/tests/csv3.json
@@ -17,7 +17,7 @@
         },
         "type": "Input",
         "max_flow": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 15
         }
       },
@@ -37,7 +37,7 @@
           "name": "demand"
         },
         "cost": {
-          "type": "Constant",
+          "type": "Literal",
           "value": -10
         }
       }

--- a/pywr-schema/tests/delay1.json
+++ b/pywr-schema/tests/delay1.json
@@ -17,7 +17,7 @@
         },
         "type": "Catchment",
         "flow": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 15
         }
       },
@@ -41,11 +41,11 @@
         },
         "type": "Output",
         "max_flow": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 20.0
         },
         "cost": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 1.0
         }
       }

--- a/pywr-schema/tests/hdf1.json
+++ b/pywr-schema/tests/hdf1.json
@@ -17,7 +17,7 @@
         },
         "type": "Input",
         "max_flow": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 15
         }
       },
@@ -37,7 +37,7 @@
           "name": "demand"
         },
         "cost": {
-          "type": "Constant",
+          "type": "Literal",
           "value": -10
         }
       }

--- a/pywr-schema/tests/invalid/agg-storage-with-flow-node.json
+++ b/pywr-schema/tests/invalid/agg-storage-with-flow-node.json
@@ -17,7 +17,7 @@
         },
         "type": "Input",
         "max_flow": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 5
         }
       },
@@ -37,7 +37,7 @@
           "name": "demand"
         },
         "cost": {
-          "type": "Constant",
+          "type": "Literal",
           "value": -10
         }
       },
@@ -47,7 +47,7 @@
         },
         "type": "Input",
         "max_flow": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 5
         }
       },
@@ -57,11 +57,11 @@
         },
         "type": "Storage",
         "cost": {
-          "type": "Constant",
+          "type": "Literal",
           "value": -0.1
         },
         "max_volume": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 100
         },
         "initial_volume": {
@@ -79,7 +79,7 @@
           "name": "demand"
         },
         "cost": {
-          "type": "Constant",
+          "type": "Literal",
           "value": -10
         }
       },
@@ -128,17 +128,17 @@
         },
         "control_curves": [
           {
-            "type": "Constant",
+            "type": "Literal",
             "value": 0.475
           }
         ],
         "values": [
           {
-            "type": "Constant",
+            "type": "Literal",
             "value": 10.0
           },
           {
-            "type": "Constant",
+            "type": "Literal",
             "value": 5.0
           }
         ]

--- a/pywr-schema/tests/link_with_soft_max.json
+++ b/pywr-schema/tests/link_with_soft_max.json
@@ -24,11 +24,11 @@
         "type": "Link",
         "soft_max": {
           "cost": {
-            "type": "Constant",
+            "type": "Literal",
             "value": 500
           },
           "flow": {
-            "type": "Constant",
+            "type": "Literal",
             "value": 30
           }
         }
@@ -39,11 +39,11 @@
         },
         "type": "Output",
         "max_flow": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 10.0
         },
         "cost": {
-          "type": "Constant",
+          "type": "Literal",
           "value": -10
         }
       }

--- a/pywr-schema/tests/link_with_soft_min.json
+++ b/pywr-schema/tests/link_with_soft_min.json
@@ -23,20 +23,20 @@
         },
         "type": "Link",
         "max_flow": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 20.0
         },
         "cost": {
-          "type": "Constant",
+          "type": "Literal",
           "value": -50
         },
         "soft_min": {
           "cost": {
-            "type": "Constant",
+            "type": "Literal",
             "value": 50
           },
           "flow": {
-            "type": "Constant",
+            "type": "Literal",
             "value": 5
           }
         }
@@ -47,11 +47,11 @@
         },
         "type": "Output",
         "max_flow": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 10.0
         },
         "cost": {
-          "type": "Constant",
+          "type": "Literal",
           "value": -10
         }
       }

--- a/pywr-schema/tests/local-parameter1.json
+++ b/pywr-schema/tests/local-parameter1.json
@@ -17,7 +17,7 @@
         },
         "type": "Input",
         "max_flow": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 15.0
         }
       },
@@ -37,7 +37,7 @@
           "name": "demand"
         },
         "cost": {
-          "type": "Constant",
+          "type": "Literal",
           "value": -10
         },
         "parameters": [

--- a/pywr-schema/tests/local-parameter2.json
+++ b/pywr-schema/tests/local-parameter2.json
@@ -17,7 +17,7 @@
         },
         "type": "Catchment",
         "flow": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 5
         }
       },
@@ -43,7 +43,7 @@
           "proportion": 1.0
         },
         "max_volume": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 100.0
         },
         "cost": {
@@ -62,17 +62,17 @@
             },
             "control_curves": [
               {
-                "type": "Constant",
+                "type": "Literal",
                 "value": 0.5
               }
             ],
             "values": [
               {
-                "type": "Constant",
+                "type": "Literal",
                 "value": 0.1
               },
               {
-                "type": "Constant",
+                "type": "Literal",
                 "value": -5
               }
             ]
@@ -85,11 +85,11 @@
         },
         "type": "Output",
         "max_flow": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 3.0
         },
         "cost": {
-          "type": "Constant",
+          "type": "Literal",
           "value": -10.0
         }
       }

--- a/pywr-schema/tests/loss_link1.json
+++ b/pywr-schema/tests/loss_link1.json
@@ -25,7 +25,7 @@
         "loss_factor": {
           "type": "Net",
           "factor": {
-            "type": "Constant",
+            "type": "Literal",
             "value": 0.1
           }
         }
@@ -36,11 +36,11 @@
         },
         "type": "Output",
         "max_flow": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 10.0
         },
         "cost": {
-          "type": "Constant",
+          "type": "Literal",
           "value": -10
         }
       },
@@ -52,7 +52,7 @@
         "loss_factor": {
           "type": "Gross",
           "factor": {
-            "type": "Constant",
+            "type": "Literal",
             "value": 0.1
           }
         }
@@ -63,11 +63,11 @@
         },
         "type": "Output",
         "max_flow": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 10.0
         },
         "cost": {
-          "type": "Constant",
+          "type": "Literal",
           "value": -10
         }
       },
@@ -83,11 +83,11 @@
         },
         "type": "Output",
         "max_flow": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 10.0
         },
         "cost": {
-          "type": "Constant",
+          "type": "Literal",
           "value": -10
         }
       }

--- a/pywr-schema/tests/loss_link2.json
+++ b/pywr-schema/tests/loss_link2.json
@@ -17,7 +17,7 @@
         },
         "type": "Catchment",
         "flow": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 15.0
         }
       },
@@ -29,7 +29,7 @@
         "loss_factor": {
           "type": "Net",
           "factor": {
-            "type": "Constant",
+            "type": "Literal",
             "value": 0.0
           }
         }
@@ -40,11 +40,11 @@
         },
         "type": "Output",
         "max_flow": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 10.0
         },
         "cost": {
-          "type": "Constant",
+          "type": "Literal",
           "value": -10
         }
       },
@@ -54,7 +54,7 @@
         },
         "type": "Output",
         "cost": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 10
         }
       }

--- a/pywr-schema/tests/memory1.json
+++ b/pywr-schema/tests/memory1.json
@@ -17,7 +17,7 @@
         },
         "type": "Input",
         "max_flow": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 15
         }
       },
@@ -37,7 +37,7 @@
           "name": "demand"
         },
         "cost": {
-          "type": "Constant",
+          "type": "Literal",
           "value": -10
         }
       }

--- a/pywr-schema/tests/multi1/network1.json
+++ b/pywr-schema/tests/multi1/network1.json
@@ -6,7 +6,7 @@
       },
       "type": "Input",
       "max_flow": {
-        "type": "Constant",
+        "type": "Literal",
         "value": 15.0
       }
     },
@@ -26,7 +26,7 @@
         "name": "demand"
       },
       "cost": {
-        "type": "Constant",
+        "type": "Literal",
         "value": -10
       }
     }

--- a/pywr-schema/tests/multi1/network2.json
+++ b/pywr-schema/tests/multi1/network2.json
@@ -26,7 +26,7 @@
         "name": "demand"
       },
       "cost": {
-        "type": "Constant",
+        "type": "Literal",
         "value": -10
       }
     }

--- a/pywr-schema/tests/multi2/network1.json
+++ b/pywr-schema/tests/multi2/network1.json
@@ -26,7 +26,7 @@
         "name": "demand"
       },
       "cost": {
-        "type": "Constant",
+        "type": "Literal",
         "value": -10
       }
     }

--- a/pywr-schema/tests/multi2/network2.json
+++ b/pywr-schema/tests/multi2/network2.json
@@ -26,7 +26,7 @@
         "name": "demand"
       },
       "cost": {
-        "type": "Constant",
+        "type": "Literal",
         "value": -10
       }
     }

--- a/pywr-schema/tests/muskingum1.json
+++ b/pywr-schema/tests/muskingum1.json
@@ -29,11 +29,11 @@
         "routing_method": {
           "type": "Muskingum",
           "travel_time": {
-            "type": "Constant",
+            "type": "Literal",
             "value": 1.1
           },
           "weight": {
-            "type": "Constant",
+            "type": "Literal",
             "value": 0.25
           },
           "initial_condition": {

--- a/pywr-schema/tests/mutual-exclusivity1.json
+++ b/pywr-schema/tests/mutual-exclusivity1.json
@@ -23,7 +23,7 @@
         },
         "type": "Link",
         "max_flow": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 10.0
         }
       },
@@ -33,11 +33,11 @@
         },
         "type": "Output",
         "max_flow": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 15.0
         },
         "cost": {
-          "type": "Constant",
+          "type": "Literal",
           "value": -15
         }
       },
@@ -47,7 +47,7 @@
         },
         "type": "Link",
         "max_flow": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 10.0
         }
       },
@@ -57,11 +57,11 @@
         },
         "type": "Output",
         "max_flow": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 15.0
         },
         "cost": {
-          "type": "Constant",
+          "type": "Literal",
           "value": -10
         }
       },

--- a/pywr-schema/tests/mutual-exclusivity2.json
+++ b/pywr-schema/tests/mutual-exclusivity2.json
@@ -23,13 +23,13 @@
         },
         "type": "WaterTreatmentWorks",
         "max_flow": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 10.0
         },
         "loss_factor": {
           "type": "Net",
           "factor": {
-            "type": "Constant",
+            "type": "Literal",
             "value": 0.1
           }
         }
@@ -40,11 +40,11 @@
         },
         "type": "Output",
         "max_flow": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 15.0
         },
         "cost": {
-          "type": "Constant",
+          "type": "Literal",
           "value": -15
         }
       },
@@ -54,7 +54,7 @@
         },
         "type": "WaterTreatmentWorks",
         "max_flow": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 10.0
         }
       },
@@ -64,11 +64,11 @@
         },
         "type": "Output",
         "max_flow": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 15.0
         },
         "cost": {
-          "type": "Constant",
+          "type": "Literal",
           "value": -10
         }
       },

--- a/pywr-schema/tests/mutual-exclusivity3.json
+++ b/pywr-schema/tests/mutual-exclusivity3.json
@@ -25,13 +25,13 @@
         "steps": [
           {
             "max_flow": {
-              "type": "Constant",
+              "type": "Literal",
               "value": 5.0
             }
           },
           {
             "max_flow": {
-              "type": "Constant",
+              "type": "Literal",
               "value": 5.0
             }
           }
@@ -43,11 +43,11 @@
         },
         "type": "Output",
         "max_flow": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 15.0
         },
         "cost": {
-          "type": "Constant",
+          "type": "Literal",
           "value": -15
         }
       },
@@ -59,13 +59,13 @@
         "steps": [
           {
             "max_flow": {
-              "type": "Constant",
+              "type": "Literal",
               "value": 5.0
             }
           },
           {
             "max_flow": {
-              "type": "Constant",
+              "type": "Literal",
               "value": 5.0
             }
           }
@@ -77,11 +77,11 @@
         },
         "type": "Output",
         "max_flow": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 15.0
         },
         "cost": {
-          "type": "Constant",
+          "type": "Literal",
           "value": -10
         }
       },

--- a/pywr-schema/tests/mutual-exclusivity4.json
+++ b/pywr-schema/tests/mutual-exclusivity4.json
@@ -23,7 +23,7 @@
         },
         "type": "Link",
         "min_flow": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 10.0
         }
       },
@@ -33,7 +33,7 @@
         },
         "type": "Output",
         "cost": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 5
         }
       },
@@ -43,7 +43,7 @@
         },
         "type": "Link",
         "min_flow": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 10.0
         }
       },
@@ -53,7 +53,7 @@
         },
         "type": "Output",
         "cost": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 10
         }
       },

--- a/pywr-schema/tests/piecewise_link1.json
+++ b/pywr-schema/tests/piecewise_link1.json
@@ -17,7 +17,7 @@
         },
         "type": "Input",
         "max_flow": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 15
         }
       },
@@ -29,27 +29,27 @@
         "steps": [
           {
             "cost": {
-              "type": "Constant",
+              "type": "Literal",
               "value": 1.0
             },
             "max_flow": {
-              "type": "Constant",
+              "type": "Literal",
               "value": 1.0
             }
           },
           {
             "cost": {
-              "type": "Constant",
+              "type": "Literal",
               "value": 5.0
             },
             "max_flow": {
-              "type": "Constant",
+              "type": "Literal",
               "value": 3.0
             }
           },
           {
             "cost": {
-              "type": "Constant",
+              "type": "Literal",
               "value": 15.0
             }
           }
@@ -61,11 +61,11 @@
         },
         "type": "Output",
         "max_flow": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 15.0
         },
         "cost": {
-          "type": "Constant",
+          "type": "Literal",
           "value": -10
         }
       }

--- a/pywr-schema/tests/piecewise_storage1.json
+++ b/pywr-schema/tests/piecewise_storage1.json
@@ -17,11 +17,11 @@
         },
         "type": "Input",
         "max_flow": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 5
         },
         "cost": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 2.0
         }
       },
@@ -35,27 +35,27 @@
           "proportion": 1.0
         },
         "max_volume": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 1000.0
         },
         "steps": [
           {
             "cost": {
-              "type": "Constant",
+              "type": "Literal",
               "value": -15
             },
             "control_curve": {
-              "type": "Constant",
+              "type": "Literal",
               "value": 0.25
             }
           },
           {
             "cost": {
-              "type": "Constant",
+              "type": "Literal",
               "value": -5
             },
             "control_curve": {
-              "type": "Constant",
+              "type": "Literal",
               "value": 0.5
             }
           }
@@ -67,11 +67,11 @@
         },
         "type": "Output",
         "max_flow": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 15
         },
         "cost": {
-          "type": "Constant",
+          "type": "Literal",
           "value": -10
         }
       }

--- a/pywr-schema/tests/piecewise_storage2.json
+++ b/pywr-schema/tests/piecewise_storage2.json
@@ -17,11 +17,11 @@
         },
         "type": "Input",
         "max_flow": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 3.0
         },
         "cost": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 2.0
         }
       },
@@ -35,23 +35,23 @@
           "volume": 1000.0
         },
         "max_volume": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 1000.0
         },
         "steps": [
           {
             "cost": {
-              "type": "Constant",
+              "type": "Literal",
               "value": -15.0
             },
             "control_curve": {
-              "type": "Constant",
+              "type": "Literal",
               "value": 0.25
             }
           },
           {
             "cost": {
-              "type": "Constant",
+              "type": "Literal",
               "value": -5.0
             },
             "control_curve": {
@@ -67,11 +67,11 @@
         },
         "type": "Output",
         "max_flow": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 5.0
         },
         "cost": {
-          "type": "Constant",
+          "type": "Literal",
           "value": -10
         }
       }

--- a/pywr-schema/tests/piecewise_storage3.json
+++ b/pywr-schema/tests/piecewise_storage3.json
@@ -17,11 +17,11 @@
         },
         "type": "Input",
         "max_flow": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 3.0
         },
         "cost": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 2.0
         }
       },
@@ -35,23 +35,23 @@
           "proportion": 0.5
         },
         "max_volume": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 1000.0
         },
         "steps": [
           {
             "cost": {
-              "type": "Constant",
+              "type": "Literal",
               "value": -15.0
             },
             "control_curve": {
-              "type": "Constant",
+              "type": "Literal",
               "value": 0.25
             }
           },
           {
             "cost": {
-              "type": "Constant",
+              "type": "Literal",
               "value": -5.0
             },
             "control_curve": {
@@ -67,11 +67,11 @@
         },
         "type": "Output",
         "max_flow": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 5.0
         },
         "cost": {
-          "type": "Constant",
+          "type": "Literal",
           "value": -10
         }
       }

--- a/pywr-schema/tests/piecewise_storage4.json
+++ b/pywr-schema/tests/piecewise_storage4.json
@@ -17,11 +17,11 @@
         },
         "type": "Input",
         "max_flow": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 3.0
         },
         "cost": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 2.0
         }
       },
@@ -35,27 +35,27 @@
           "proportion": 0.5
         },
         "max_volume": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 1000.0
         },
         "min_volume": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 300.0
         },
         "steps": [
           {
             "cost": {
-              "type": "Constant",
+              "type": "Literal",
               "value": -15.0
             },
             "control_curve": {
-              "type": "Constant",
+              "type": "Literal",
               "value": 0.25
             }
           },
           {
             "cost": {
-              "type": "Constant",
+              "type": "Literal",
               "value": -5.0
             },
             "control_curve": {
@@ -71,11 +71,11 @@
         },
         "type": "Output",
         "max_flow": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 5.0
         },
         "cost": {
-          "type": "Constant",
+          "type": "Literal",
           "value": -10
         }
       }

--- a/pywr-schema/tests/python-parameter1.json
+++ b/pywr-schema/tests/python-parameter1.json
@@ -17,7 +17,7 @@
         },
         "type": "Input",
         "max_flow": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 15.0
         }
       },
@@ -33,11 +33,11 @@
         },
         "type": "Output",
         "max_flow": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 10
         },
         "cost": {
-          "type": "Constant",
+          "type": "Literal",
           "value": -10
         }
       }

--- a/pywr-schema/tests/python-parameter2.json
+++ b/pywr-schema/tests/python-parameter2.json
@@ -17,7 +17,7 @@
         },
         "type": "Input",
         "max_flow": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 8.0
         }
       },
@@ -33,11 +33,11 @@
         },
         "type": "Output",
         "max_flow": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 10
         },
         "cost": {
-          "type": "Constant",
+          "type": "Literal",
           "value": -10
         }
       }

--- a/pywr-schema/tests/reservoir_with_river.json
+++ b/pywr-schema/tests/reservoir_with_river.json
@@ -17,7 +17,7 @@
         },
         "type": "Catchment",
         "flow": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 15
         }
       },
@@ -27,11 +27,11 @@
         },
         "type": "Reservoir",
         "max_volume": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 21000
         },
         "cost": {
-          "type": "Constant",
+          "type": "Literal",
           "value": -10.0
         },
         "initial_volume": {
@@ -39,7 +39,7 @@
           "proportion": 1.0
         },
         "compensation": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 0.2
         },
         "spill": "LinkNode"
@@ -56,11 +56,11 @@
         },
         "type": "Output",
         "max_flow": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 20.0
         },
         "cost": {
-          "type": "Constant",
+          "type": "Literal",
           "value": -10.0
         }
       }

--- a/pywr-schema/tests/reservoir_with_spill.json
+++ b/pywr-schema/tests/reservoir_with_spill.json
@@ -17,7 +17,7 @@
         },
         "type": "Catchment",
         "flow": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 15
         }
       },
@@ -27,11 +27,11 @@
         },
         "type": "Reservoir",
         "max_volume": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 21000
         },
         "cost": {
-          "type": "Constant",
+          "type": "Literal",
           "value": -10.0
         },
         "initial_volume": {
@@ -39,7 +39,7 @@
           "proportion": 1.0
         },
         "compensation": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 0.2
         },
         "spill": "OutputNode"
@@ -50,11 +50,11 @@
         },
         "type": "Output",
         "max_flow": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 20.0
         },
         "cost": {
-          "type": "Constant",
+          "type": "Literal",
           "value": -10.0
         }
       }

--- a/pywr-schema/tests/river_gauge1.json
+++ b/pywr-schema/tests/river_gauge1.json
@@ -17,7 +17,7 @@
         },
         "type": "Catchment",
         "flow": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 15
         }
       },
@@ -27,11 +27,11 @@
         },
         "type": "RiverGauge",
         "mrf": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 5.0
         },
         "mrf_cost": {
-          "type": "Constant",
+          "type": "Literal",
           "value": -20.0
         }
       },
@@ -47,11 +47,11 @@
         },
         "type": "Output",
         "max_flow": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 15
         },
         "cost": {
-          "type": "Constant",
+          "type": "Literal",
           "value": -10
         }
       }

--- a/pywr-schema/tests/river_loss1.json
+++ b/pywr-schema/tests/river_loss1.json
@@ -17,7 +17,7 @@
         },
         "type": "Catchment",
         "flow": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 10.0
         }
       },
@@ -35,7 +35,7 @@
         "loss_factor": {
           "type": "Gross",
           "factor": {
-            "type": "Constant",
+            "type": "Literal",
             "value": 0.1
           }
         }

--- a/pywr-schema/tests/river_split_with_gauge1.json
+++ b/pywr-schema/tests/river_split_with_gauge1.json
@@ -17,7 +17,7 @@
         },
         "type": "Catchment",
         "flow": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 15.0
         }
       },
@@ -27,11 +27,11 @@
         },
         "type": "RiverGauge",
         "mrf": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 5.0
         },
         "mrf_cost": {
-          "type": "Constant",
+          "type": "Literal",
           "value": -20
         }
       },
@@ -47,11 +47,11 @@
         },
         "type": "Output",
         "max_flow": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 15.0
         },
         "cost": {
-          "type": "Constant",
+          "type": "Literal",
           "value": -10
         }
       }

--- a/pywr-schema/tests/seasonal-vs1.json
+++ b/pywr-schema/tests/seasonal-vs1.json
@@ -17,7 +17,7 @@
         },
         "type": "Input",
         "max_flow": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 15
         }
       },
@@ -37,7 +37,7 @@
           "name": "demand"
         },
         "cost": {
-          "type": "Constant",
+          "type": "Literal",
           "value": -10
         }
       },
@@ -52,7 +52,7 @@
           }
         ],
         "max_volume": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 300
         },
         "initial_volume": {

--- a/pywr-schema/tests/seasonal-vs2.json
+++ b/pywr-schema/tests/seasonal-vs2.json
@@ -17,7 +17,7 @@
         },
         "type": "Input",
         "max_flow": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 15
         }
       },
@@ -37,7 +37,7 @@
           "name": "demand"
         },
         "cost": {
-          "type": "Constant",
+          "type": "Literal",
           "value": -10
         }
       },
@@ -52,7 +52,7 @@
           }
         ],
         "max_volume": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 300
         },
         "initial_volume": {

--- a/pywr-schema/tests/simple1.json
+++ b/pywr-schema/tests/simple1.json
@@ -17,7 +17,7 @@
         },
         "type": "Input",
         "max_flow": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 15.0
         }
       },
@@ -37,7 +37,7 @@
           "name": "demand"
         },
         "cost": {
-          "type": "Constant",
+          "type": "Literal",
           "value": -10
         }
       }

--- a/pywr-schema/tests/storage_max_volumes.json
+++ b/pywr-schema/tests/storage_max_volumes.json
@@ -17,7 +17,7 @@
         },
         "type": "Input",
         "max_flow": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 15.0
         }
       },
@@ -31,7 +31,7 @@
           "proportion": 0.5
         },
         "max_volume": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 10.0
         }
       },

--- a/pywr-schema/tests/tbl-formats1.json
+++ b/pywr-schema/tests/tbl-formats1.json
@@ -17,7 +17,7 @@
         },
         "type": "Input",
         "max_flow": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 15.0
         }
       },
@@ -39,7 +39,7 @@
           "column": "\uD83D\uDC0D"
         },
         "cost": {
-          "type": "Constant",
+          "type": "Literal",
           "value": -10
         }
       }

--- a/pywr-schema/tests/timeseries.json
+++ b/pywr-schema/tests/timeseries.json
@@ -45,7 +45,7 @@
         },
         "type": "Output",
         "cost": {
-          "type": "Constant",
+          "type": "Literal",
           "value": -10
         },
         "max_flow": {
@@ -93,7 +93,7 @@
             "name": "inflow"
           },
           {
-            "type": "Constant",
+            "type": "Literal",
             "value": 0.5
           }
         ]

--- a/pywr-schema/tests/timeseries2.json
+++ b/pywr-schema/tests/timeseries2.json
@@ -53,7 +53,7 @@
         },
         "type": "Output",
         "cost": {
-          "type": "Constant",
+          "type": "Literal",
           "value": -10
         },
         "max_flow": {
@@ -105,7 +105,7 @@
             }
           },
           {
-            "type": "Constant",
+            "type": "Literal",
             "value": 0.5
           }
         ]

--- a/pywr-schema/tests/timeseries3.json
+++ b/pywr-schema/tests/timeseries3.json
@@ -58,7 +58,7 @@
         },
         "type": "Output",
         "cost": {
-          "type": "Constant",
+          "type": "Literal",
           "value": -10
         },
         "max_flow": {
@@ -110,7 +110,7 @@
             }
           },
           {
-            "type": "Constant",
+            "type": "Literal",
             "value": 0.5
           }
         ]

--- a/pywr-schema/tests/timeseries4.json
+++ b/pywr-schema/tests/timeseries4.json
@@ -82,7 +82,7 @@
         },
         "type": "Output",
         "cost": {
-          "type": "Constant",
+          "type": "Literal",
           "value": -10
         },
         "max_flow": {
@@ -134,7 +134,7 @@
             }
           },
           {
-            "type": "Constant",
+            "type": "Literal",
             "value": 0.5
           }
         ]

--- a/pywr-schema/tests/timeseries5.json
+++ b/pywr-schema/tests/timeseries5.json
@@ -82,7 +82,7 @@
         },
         "type": "Output",
         "cost": {
-          "type": "Constant",
+          "type": "Literal",
           "value": -10
         },
         "max_flow": {
@@ -134,7 +134,7 @@
             }
           },
           {
-            "type": "Constant",
+            "type": "Literal",
             "value": 0.5
           }
         ]

--- a/pywr-schema/tests/timeseries_pandas.json
+++ b/pywr-schema/tests/timeseries_pandas.json
@@ -45,7 +45,7 @@
         },
         "type": "Output",
         "cost": {
-          "type": "Constant",
+          "type": "Literal",
           "value": -10
         },
         "max_flow": {
@@ -88,7 +88,7 @@
             "name": "inflow"
           },
           {
-            "type": "Constant",
+            "type": "Literal",
             "value": 0.5
           }
         ]

--- a/pywr-schema/tests/v1/breaklink-converted.json
+++ b/pywr-schema/tests/v1/breaklink-converted.json
@@ -17,7 +17,7 @@
         },
         "type": "Input",
         "max_flow": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 15.0
         }
       },
@@ -27,15 +27,15 @@
         },
         "type": "Link",
         "max_flow": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 5.0
         },
         "min_flow": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 1.0
         },
         "cost": {
-          "type": "Constant",
+          "type": "Literal",
           "value": -1.0
         }
       },
@@ -45,11 +45,11 @@
         },
         "type": "Output",
         "max_flow": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 10.0
         },
         "cost": {
-          "type": "Constant",
+          "type": "Literal",
           "value": -10.0
         }
       }

--- a/pywr-schema/tests/v1/inline-parameter-converted.json
+++ b/pywr-schema/tests/v1/inline-parameter-converted.json
@@ -34,7 +34,7 @@
       },
       {
         "cost": {
-          "type": "Constant",
+          "type": "Literal",
           "value": -10.0
         },
         "max_flow": {

--- a/pywr-schema/tests/v1/river_split_with_gauge1-converted.json
+++ b/pywr-schema/tests/v1/river_split_with_gauge1-converted.json
@@ -17,7 +17,7 @@
         },
         "type": "Catchment",
         "flow": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 100.0
         }
       },
@@ -31,13 +31,13 @@
           "name": "Gauge-p0"
         },
         "mrf_cost": {
-          "type": "Constant",
+          "type": "Literal",
           "value": -1000.0
         },
         "splits": [
           {
             "factor": {
-              "type": "Constant",
+              "type": "Literal",
               "value": 0.25
             },
             "slot_name": "abstraction"
@@ -56,11 +56,11 @@
         },
         "type": "Output",
         "max_flow": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 50.0
         },
         "cost": {
-          "type": "Constant",
+          "type": "Literal",
           "value": -10.0
         }
       }

--- a/pywr-schema/tests/v1/timeseries-converted.json
+++ b/pywr-schema/tests/v1/timeseries-converted.json
@@ -63,7 +63,7 @@
           "name": "output1"
         },
         "cost": {
-          "type": "Constant",
+          "type": "Literal",
           "value": -10.0
         }
       }
@@ -115,7 +115,7 @@
             }
           },
           {
-            "type": "Constant",
+            "type": "Literal",
             "value": 0.5
           }
         ]

--- a/pywr-schema/tests/vs-with-piecewise-link.json
+++ b/pywr-schema/tests/vs-with-piecewise-link.json
@@ -17,7 +17,7 @@
         },
         "type": "Input",
         "max_flow": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 15
         }
       },
@@ -29,27 +29,27 @@
         "steps": [
           {
             "cost": {
-              "type": "Constant",
+              "type": "Literal",
               "value": 1.0
             },
             "max_flow": {
-              "type": "Constant",
+              "type": "Literal",
               "value": 1.0
             }
           },
           {
             "cost": {
-              "type": "Constant",
+              "type": "Literal",
               "value": 5.0
             },
             "max_flow": {
-              "type": "Constant",
+              "type": "Literal",
               "value": 3.0
             }
           },
           {
             "cost": {
-              "type": "Constant",
+              "type": "Literal",
               "value": 15.0
             }
           }
@@ -61,11 +61,11 @@
         },
         "type": "Output",
         "max_flow": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 15.0
         },
         "cost": {
-          "type": "Constant",
+          "type": "Literal",
           "value": -10
         }
       },
@@ -75,7 +75,7 @@
         },
         "type": "VirtualStorage",
         "max_volume": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 100
         },
         "initial_volume": {

--- a/pywr-schema/tests/vs-with-wtw1.json
+++ b/pywr-schema/tests/vs-with-wtw1.json
@@ -17,7 +17,7 @@
         },
         "type": "Input",
         "max_flow": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 15
         }
       },
@@ -27,13 +27,13 @@
         },
         "type": "WaterTreatmentWorks",
         "max_flow": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 10.0
         },
         "loss_factor": {
           "type": "Net",
           "factor": {
-            "type": "Constant",
+            "type": "Literal",
             "value": 0.1
           }
         }
@@ -44,11 +44,11 @@
         },
         "type": "Output",
         "max_flow": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 15.0
         },
         "cost": {
-          "type": "Constant",
+          "type": "Literal",
           "value": -10
         }
       },
@@ -58,7 +58,7 @@
         },
         "type": "VirtualStorage",
         "max_volume": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 100
         },
         "initial_volume": {

--- a/pywr-schema/tests/vs-with-wtw2.json
+++ b/pywr-schema/tests/vs-with-wtw2.json
@@ -17,7 +17,7 @@
         },
         "type": "Input",
         "max_flow": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 15
         }
       },
@@ -27,13 +27,13 @@
         },
         "type": "WaterTreatmentWorks",
         "max_flow": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 10.0
         },
         "loss_factor": {
           "type": "Net",
           "factor": {
-            "type": "Constant",
+            "type": "Literal",
             "value": 0.1
           }
         }
@@ -44,11 +44,11 @@
         },
         "type": "Output",
         "max_flow": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 15.0
         },
         "cost": {
-          "type": "Constant",
+          "type": "Literal",
           "value": -10
         }
       },
@@ -58,7 +58,7 @@
         },
         "type": "VirtualStorage",
         "max_volume": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 100
         },
         "initial_volume": {

--- a/pywr-schema/tests/wtw1.json
+++ b/pywr-schema/tests/wtw1.json
@@ -23,13 +23,13 @@
         },
         "type": "WaterTreatmentWorks",
         "max_flow": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 10.0
         },
         "loss_factor": {
           "type": "Net",
           "factor": {
-            "type": "Constant",
+            "type": "Literal",
             "value": 0.1
           }
         }
@@ -40,11 +40,11 @@
         },
         "type": "Output",
         "max_flow": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 15.0
         },
         "cost": {
-          "type": "Constant",
+          "type": "Literal",
           "value": -10
         }
       },
@@ -54,7 +54,7 @@
         },
         "type": "WaterTreatmentWorks",
         "max_flow": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 10.0
         }
       },
@@ -64,11 +64,11 @@
         },
         "type": "Output",
         "max_flow": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 15.0
         },
         "cost": {
-          "type": "Constant",
+          "type": "Literal",
           "value": -10
         }
       }

--- a/pywr-schema/tests/wtw2.json
+++ b/pywr-schema/tests/wtw2.json
@@ -17,7 +17,7 @@
         },
         "type": "Catchment",
         "flow": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 20.0
         }
       },
@@ -27,13 +27,13 @@
         },
         "type": "WaterTreatmentWorks",
         "max_flow": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 10.0
         },
         "loss_factor": {
           "type": "Net",
           "factor": {
-            "type": "Constant",
+            "type": "Literal",
             "value": 0.0
           }
         }
@@ -44,7 +44,7 @@
         },
         "type": "Output",
         "cost": {
-          "type": "Constant",
+          "type": "Literal",
           "value": -10
         }
       },
@@ -54,7 +54,7 @@
         },
         "type": "Output",
         "cost": {
-          "type": "Constant",
+          "type": "Literal",
           "value": 10
         }
       }


### PR DESCRIPTION
This is to make it consistent with `ConstantValue`, and avoid confusion with `ConstantParameter`.