### PR TITLE
feat: Add multi-model to Python extension.

### DIFF
--- a/pywr-core/src/models/multi.rs
+++ b/pywr-core/src/models/multi.rs
@@ -6,14 +6,14 @@ use crate::network::{
 };
 use crate::recorders::RecorderInternalState;
 use crate::scenario::ScenarioIndex;
-#[cfg(feature = "ipm-ocl")]
+#[cfg(all(feature = "ipm-ocl", feature = "pyo3"))]
 use crate::solvers::{ClIpmF32Solver, ClIpmF64Solver, ClIpmSolverSettings};
-#[cfg(feature = "clp")]
+#[cfg(all(feature = "clp", feature = "pyo3"))]
 use crate::solvers::{ClpSolver, build_clp_settings_py};
-#[cfg(feature = "highs")]
+#[cfg(all(feature = "highs", feature = "pyo3"))]
 use crate::solvers::{HighsSolver, build_highs_settings_py};
 use crate::solvers::{MultiStateSolver, Solver, SolverSettings};
-#[cfg(feature = "ipm-simd")]
+#[cfg(all(feature = "ipm-simd", feature = "pyo3"))]
 use crate::solvers::{SimdIpmF64Solver, build_ipm_simd_settings_py};
 use crate::state::StateError;
 use crate::timestep::Timestep;

--- a/pywr-core/src/models/multi.rs
+++ b/pywr-core/src/models/multi.rs
@@ -6,11 +6,22 @@ use crate::network::{
 };
 use crate::recorders::RecorderInternalState;
 use crate::scenario::ScenarioIndex;
-use crate::solvers::{MultiStateSolver, Solver, SolverSettings};
+#[cfg(feature = "ipm-ocl")]
+use crate::solvers::{ClIpmF32Solver, ClIpmF64Solver, ClIpmSolverSettings};
+use crate::solvers::{ClpSolver, MultiStateSolver, Solver, SolverSettings, build_clp_settings_py};
+#[cfg(feature = "highs")]
+use crate::solvers::{HighsSolver, build_highs_settings_py};
+#[cfg(feature = "ipm-simd")]
+use crate::solvers::{SimdIpmF64Solver, build_ipm_simd_settings_py};
 use crate::state::StateError;
 use crate::timestep::Timestep;
 #[cfg(feature = "pyo3")]
-use pyo3::{PyResult, exceptions::PyKeyError, pyclass, pymethods};
+use pyo3::{
+    Bound, PyErr, PyResult, Python,
+    exceptions::{PyKeyError, PyRuntimeError},
+    pyclass, pymethods,
+    types::PyDict,
+};
 use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::fmt;
@@ -143,6 +154,13 @@ pub enum MultiNetworkModelRunError {
     FinaliseError(#[from] MultiNetworkModelFinaliseError),
 }
 
+#[cfg(feature = "pyo3")]
+impl From<MultiNetworkModelRunError> for PyErr {
+    fn from(err: MultiNetworkModelRunError) -> PyErr {
+        PyRuntimeError::new_err(err.to_string())
+    }
+}
+
 #[derive(Debug, Error)]
 pub enum MultiNetworkModelError {
     #[error("Network name `{0}` already exists")]
@@ -178,6 +196,7 @@ impl MultiNetworkModelResult {
 }
 
 /// A MultiNetwork is a collection of models that can be run together.
+#[cfg_attr(feature = "pyo3", pyclass)]
 pub struct MultiNetworkModel {
     domain: ModelDomain,
     networks: Vec<MultiNetworkEntry>,
@@ -676,6 +695,73 @@ impl MultiNetworkModel {
         for (entry, timing) in self.networks.iter().zip(timings.iter()) {
             info!("Network: {}", entry.name);
             timing.print_table(total_duration, &entry.network);
+        }
+    }
+
+    /// Run a model using the specified solver unlocking the GIL
+    #[cfg(feature = "pyo3")]
+    fn run_allowing_threads_py<S>(
+        &self,
+        py: Python<'_>,
+        settings: &S::Settings,
+    ) -> Result<MultiNetworkModelResult, PyErr>
+    where
+        S: Solver,
+        <S as Solver>::Settings: SolverSettings + Sync,
+    {
+        let result = py.allow_threads(|| self.run::<S>(settings))?;
+        Ok(result)
+    }
+
+    /// Run a model using the specified multi solver unlocking the GIL
+    #[cfg(any(feature = "ipm-simd", feature = "ipm-ocl"))]
+    #[cfg(feature = "pyo3")]
+    fn run_multi_allowing_threads_py<S>(
+        &self,
+        py: Python<'_>,
+        settings: &S::Settings,
+    ) -> Result<MultiNetworkModelResult, PyErr>
+    where
+        S: MultiStateSolver,
+        <S as MultiStateSolver>::Settings: SolverSettings + Sync,
+    {
+        let result = py.allow_threads(|| self.run_multi_scenario::<S>(settings))?;
+        Ok(result)
+    }
+}
+
+/// Run a model using the specified multi solver unlocking the GIL
+#[cfg(feature = "pyo3")]
+#[pymethods]
+impl MultiNetworkModel {
+    #[pyo3(name = "run", signature = (solver_name, solver_kwargs=None))]
+    fn run_py(
+        &self,
+        py: Python<'_>,
+        solver_name: &str,
+        solver_kwargs: Option<&Bound<'_, PyDict>>,
+    ) -> PyResult<MultiNetworkModelResult> {
+        match solver_name {
+            "clp" => {
+                let settings = build_clp_settings_py(solver_kwargs)?;
+                self.run_allowing_threads_py::<ClpSolver>(py, &settings)
+            }
+            #[cfg(feature = "highs")]
+            "highs" => {
+                let settings = build_highs_settings_py(solver_kwargs)?;
+                self.run_allowing_threads_py::<HighsSolver>(py, &settings)
+            }
+            #[cfg(feature = "ipm-simd")]
+            "ipm-simd" => {
+                let settings = build_ipm_simd_settings_py(solver_kwargs)?;
+                self.run_multi_allowing_threads_py::<SimdIpmF64Solver>(py, &settings)
+            }
+            #[cfg(feature = "ipm-ocl")]
+            "clipm-f32" => self.run_multi_allowing_threads_py::<ClIpmF32Solver>(py, &ClIpmSolverSettings::default()),
+
+            #[cfg(feature = "ipm-ocl")]
+            "clipm-f64" => self.run_multi_allowing_threads_py::<ClIpmF64Solver>(py, &ClIpmSolverSettings::default()),
+            _ => Err(PyRuntimeError::new_err(format!("Unknown solver: {solver_name}",))),
         }
     }
 }

--- a/pywr-core/src/models/multi.rs
+++ b/pywr-core/src/models/multi.rs
@@ -701,6 +701,7 @@ impl MultiNetworkModel {
     }
 
     /// Run a model using the specified solver unlocking the GIL
+    #[cfg(any(feature = "clp", feature = "highs"))]
     #[cfg(feature = "pyo3")]
     fn run_allowing_threads_py<S>(
         &self,
@@ -739,8 +740,20 @@ impl MultiNetworkModel {
     #[pyo3(name = "run", signature = (solver_name, solver_kwargs=None))]
     fn run_py(
         &self,
+        #[cfg_attr(
+            not(any(feature = "clp", feature = "highs", feature = "ipm-simd", feature = "ipm-ocl")),
+            allow(unused_variables)
+        )]
         py: Python<'_>,
+        #[cfg_attr(
+            not(any(feature = "clp", feature = "highs", feature = "ipm-simd", feature = "ipm-ocl")),
+            allow(unused_variables)
+        )]
         solver_name: &str,
+        #[cfg_attr(
+            not(any(feature = "clp", feature = "highs", feature = "ipm-simd", feature = "ipm-ocl")),
+            allow(unused_variables)
+        )]
         solver_kwargs: Option<&Bound<'_, PyDict>>,
     ) -> PyResult<MultiNetworkModelResult> {
         match solver_name {

--- a/pywr-core/src/models/multi.rs
+++ b/pywr-core/src/models/multi.rs
@@ -744,6 +744,7 @@ impl MultiNetworkModel {
         solver_kwargs: Option<&Bound<'_, PyDict>>,
     ) -> PyResult<MultiNetworkModelResult> {
         match solver_name {
+            #[cfg(feature = "clp")]
             "clp" => {
                 let settings = build_clp_settings_py(solver_kwargs)?;
                 self.run_allowing_threads_py::<ClpSolver>(py, &settings)

--- a/pywr-core/src/models/multi.rs
+++ b/pywr-core/src/models/multi.rs
@@ -8,9 +8,11 @@ use crate::recorders::RecorderInternalState;
 use crate::scenario::ScenarioIndex;
 #[cfg(feature = "ipm-ocl")]
 use crate::solvers::{ClIpmF32Solver, ClIpmF64Solver, ClIpmSolverSettings};
-use crate::solvers::{ClpSolver, MultiStateSolver, Solver, SolverSettings, build_clp_settings_py};
+#[cfg(feature = "clp")]
+use crate::solvers::{ClpSolver, build_clp_settings_py};
 #[cfg(feature = "highs")]
 use crate::solvers::{HighsSolver, build_highs_settings_py};
+use crate::solvers::{MultiStateSolver, Solver, SolverSettings};
 #[cfg(feature = "ipm-simd")]
 use crate::solvers::{SimdIpmF64Solver, build_ipm_simd_settings_py};
 use crate::state::StateError;

--- a/pywr-core/src/models/simple.rs
+++ b/pywr-core/src/models/simple.rs
@@ -4,14 +4,14 @@ use crate::network::{
     NetworkSetupError, NetworkSolverSetupError, NetworkState, NetworkStepError, NetworkTimings, RunDuration,
 };
 use crate::recorders::RecorderInternalState;
-#[cfg(feature = "ipm-ocl")]
+#[cfg(all(feature = "ipm-ocl", feature = "pyo3"))]
 use crate::solvers::{ClIpmF32Solver, ClIpmF64Solver, ClIpmSolverSettings};
-#[cfg(feature = "clp")]
+#[cfg(all(feature = "clp", feature = "pyo3"))]
 use crate::solvers::{ClpSolver, build_clp_settings_py};
-#[cfg(feature = "highs")]
+#[cfg(all(feature = "highs", feature = "pyo3"))]
 use crate::solvers::{HighsSolver, build_highs_settings_py};
 use crate::solvers::{MultiStateSolver, Solver, SolverFeatures, SolverSettings};
-#[cfg(feature = "ipm-simd")]
+#[cfg(all(feature = "ipm-simd", feature = "pyo3"))]
 use crate::solvers::{SimdIpmF64Solver, build_ipm_simd_settings_py};
 use crate::timestep::Timestep;
 #[cfg(feature = "pyo3")]

--- a/pywr-core/src/models/simple.rs
+++ b/pywr-core/src/models/simple.rs
@@ -4,10 +4,16 @@ use crate::network::{
     NetworkSetupError, NetworkSolverSetupError, NetworkState, NetworkStepError, NetworkTimings, RunDuration,
 };
 use crate::recorders::RecorderInternalState;
-use crate::solvers::{MultiStateSolver, Solver, SolverFeatures, SolverSettings};
+#[cfg(feature = "ipm-ocl")]
+use crate::solvers::{ClIpmF32Solver, ClIpmF64Solver, ClIpmSolverSettings};
+use crate::solvers::{ClpSolver, MultiStateSolver, Solver, SolverFeatures, SolverSettings, build_clp_settings_py};
+#[cfg(feature = "highs")]
+use crate::solvers::{HighsSolver, build_highs_settings_py};
+#[cfg(feature = "ipm-simd")]
+use crate::solvers::{SimdIpmF64Solver, build_ipm_simd_settings_py};
 use crate::timestep::Timestep;
 #[cfg(feature = "pyo3")]
-use pyo3::{PyErr, exceptions::PyRuntimeError, pyclass, pymethods};
+use pyo3::{Bound, PyErr, PyResult, Python, exceptions::PyRuntimeError, pyclass, pymethods, types::PyDict};
 use rayon::ThreadPool;
 use std::collections::HashSet;
 use thiserror::Error;
@@ -115,6 +121,7 @@ impl ModelResult {
 }
 
 /// A standard Pywr model containing a single network.
+#[cfg_attr(feature = "pyo3", pyclass)]
 pub struct Model {
     domain: ModelDomain,
     network: Network,
@@ -470,5 +477,64 @@ impl Model {
         info!("{: <24} | {: <10}", "Metric", "Value");
         run_duration.print_table();
         timings.print_table(total_duration, &self.network);
+    }
+
+    /// Run a model using the specified solver unlocking the GIL
+    #[cfg(feature = "pyo3")]
+    fn run_allowing_threads_py<S>(&self, py: Python<'_>, settings: &S::Settings) -> Result<ModelResult, PyErr>
+    where
+        S: Solver,
+        <S as Solver>::Settings: SolverSettings + Sync,
+    {
+        let result = py.allow_threads(|| self.run::<S>(settings))?;
+        Ok(result)
+    }
+
+    /// Run a model using the specified multi solver unlocking the GIL
+    #[cfg(any(feature = "ipm-simd", feature = "ipm-ocl"))]
+    #[cfg(feature = "pyo3")]
+    fn run_multi_allowing_threads_py<S>(&self, py: Python<'_>, settings: &S::Settings) -> Result<ModelResult, PyErr>
+    where
+        S: MultiStateSolver,
+        <S as MultiStateSolver>::Settings: SolverSettings + Sync,
+    {
+        let result = py.allow_threads(|| self.run_multi_scenario::<S>(settings))?;
+        Ok(result)
+    }
+}
+
+/// Run a model using the specified multi solver unlocking the GIL
+#[cfg(feature = "pyo3")]
+#[pymethods]
+impl Model {
+    #[pyo3(name = "run", signature = (solver_name, solver_kwargs=None))]
+    fn run_py(
+        &self,
+        py: Python<'_>,
+        solver_name: &str,
+        solver_kwargs: Option<&Bound<'_, PyDict>>,
+    ) -> PyResult<ModelResult> {
+        match solver_name {
+            "clp" => {
+                let settings = build_clp_settings_py(solver_kwargs)?;
+                self.run_allowing_threads_py::<ClpSolver>(py, &settings)
+            }
+            #[cfg(feature = "highs")]
+            "highs" => {
+                let settings = build_highs_settings_py(solver_kwargs)?;
+                self.run_allowing_threads_py::<HighsSolver>(py, &settings)
+            }
+            #[cfg(feature = "ipm-simd")]
+            "ipm-simd" => {
+                let settings = build_ipm_simd_settings_py(solver_kwargs)?;
+                self.run_multi_allowing_threads_py::<SimdIpmF64Solver>(py, &settings)
+            }
+            #[cfg(feature = "ipm-ocl")]
+            "clipm-f32" => self.run_multi_allowing_threads_py::<ClIpmF32Solver>(py, &ClIpmSolverSettings::default()),
+
+            #[cfg(feature = "ipm-ocl")]
+            "clipm-f64" => self.run_multi_allowing_threads_py::<ClIpmF64Solver>(py, &ClIpmSolverSettings::default()),
+            _ => Err(PyRuntimeError::new_err(format!("Unknown solver: {solver_name}",))),
+        }
     }
 }

--- a/pywr-core/src/models/simple.rs
+++ b/pywr-core/src/models/simple.rs
@@ -6,9 +6,11 @@ use crate::network::{
 use crate::recorders::RecorderInternalState;
 #[cfg(feature = "ipm-ocl")]
 use crate::solvers::{ClIpmF32Solver, ClIpmF64Solver, ClIpmSolverSettings};
-use crate::solvers::{ClpSolver, MultiStateSolver, Solver, SolverFeatures, SolverSettings, build_clp_settings_py};
+#[cfg(feature = "clp")]
+use crate::solvers::{ClpSolver, build_clp_settings_py};
 #[cfg(feature = "highs")]
 use crate::solvers::{HighsSolver, build_highs_settings_py};
+use crate::solvers::{MultiStateSolver, Solver, SolverFeatures, SolverSettings};
 #[cfg(feature = "ipm-simd")]
 use crate::solvers::{SimdIpmF64Solver, build_ipm_simd_settings_py};
 use crate::timestep::Timestep;

--- a/pywr-core/src/models/simple.rs
+++ b/pywr-core/src/models/simple.rs
@@ -517,6 +517,7 @@ impl Model {
         solver_kwargs: Option<&Bound<'_, PyDict>>,
     ) -> PyResult<ModelResult> {
         match solver_name {
+            #[cfg(feature = "clp")]
             "clp" => {
                 let settings = build_clp_settings_py(solver_kwargs)?;
                 self.run_allowing_threads_py::<ClpSolver>(py, &settings)

--- a/pywr-core/src/models/simple.rs
+++ b/pywr-core/src/models/simple.rs
@@ -482,6 +482,7 @@ impl Model {
     }
 
     /// Run a model using the specified solver unlocking the GIL
+    #[cfg(any(feature = "clp", feature = "highs"))]
     #[cfg(feature = "pyo3")]
     fn run_allowing_threads_py<S>(&self, py: Python<'_>, settings: &S::Settings) -> Result<ModelResult, PyErr>
     where
@@ -512,8 +513,20 @@ impl Model {
     #[pyo3(name = "run", signature = (solver_name, solver_kwargs=None))]
     fn run_py(
         &self,
+        #[cfg_attr(
+            not(any(feature = "clp", feature = "highs", feature = "ipm-simd", feature = "ipm-ocl")),
+            allow(unused_variables)
+        )]
         py: Python<'_>,
+        #[cfg_attr(
+            not(any(feature = "clp", feature = "highs", feature = "ipm-simd", feature = "ipm-ocl")),
+            allow(unused_variables)
+        )]
         solver_name: &str,
+        #[cfg_attr(
+            not(any(feature = "clp", feature = "highs", feature = "ipm-simd", feature = "ipm-ocl")),
+            allow(unused_variables)
+        )]
         solver_kwargs: Option<&Bound<'_, PyDict>>,
     ) -> PyResult<ModelResult> {
         match solver_name {

--- a/pywr-core/src/solvers/clp/mod.rs
+++ b/pywr-core/src/solvers/clp/mod.rs
@@ -8,7 +8,9 @@ use crate::state::{ConstParameterValues, State};
 use crate::timestep::Timestep;
 use coin_or_sys::clp::*;
 use libc::{c_double, c_int};
-pub use settings::{ClpSolverSettings, ClpSolverSettingsBuilder, build_clp_settings_py};
+#[cfg(feature = "pyo3")]
+pub use settings::build_clp_settings_py;
+pub use settings::{ClpSolverSettings, ClpSolverSettingsBuilder};
 use std::ffi::CString;
 use std::fmt::Display;
 use std::slice;

--- a/pywr-core/src/solvers/clp/mod.rs
+++ b/pywr-core/src/solvers/clp/mod.rs
@@ -8,7 +8,7 @@ use crate::state::{ConstParameterValues, State};
 use crate::timestep::Timestep;
 use coin_or_sys::clp::*;
 use libc::{c_double, c_int};
-pub use settings::{ClpSolverSettings, ClpSolverSettingsBuilder};
+pub use settings::{ClpSolverSettings, ClpSolverSettingsBuilder, build_clp_settings_py};
 use std::ffi::CString;
 use std::fmt::Display;
 use std::slice;

--- a/pywr-core/src/solvers/highs/mod.rs
+++ b/pywr-core/src/solvers/highs/mod.rs
@@ -19,7 +19,7 @@ use highs_sys::{
     kHighsStatusWarning, kHighsVarTypeContinuous, kHighsVarTypeInteger,
 };
 use libc::c_void;
-pub use settings::{HighsSolverSettings, HighsSolverSettingsBuilder};
+pub use settings::{HighsSolverSettings, HighsSolverSettingsBuilder, build_highs_settings_py};
 use std::ffi::CString;
 use std::ops::Deref;
 use std::ptr::null;

--- a/pywr-core/src/solvers/highs/mod.rs
+++ b/pywr-core/src/solvers/highs/mod.rs
@@ -19,7 +19,9 @@ use highs_sys::{
     kHighsStatusWarning, kHighsVarTypeContinuous, kHighsVarTypeInteger,
 };
 use libc::c_void;
-pub use settings::{HighsSolverSettings, HighsSolverSettingsBuilder, build_highs_settings_py};
+#[cfg(feature = "pyo3")]
+pub use settings::build_highs_settings_py;
+pub use settings::{HighsSolverSettings, HighsSolverSettingsBuilder};
 use std::ffi::CString;
 use std::ops::Deref;
 use std::ptr::null;

--- a/pywr-core/src/solvers/highs/settings.rs
+++ b/pywr-core/src/solvers/highs/settings.rs
@@ -1,4 +1,6 @@
 use crate::solvers::SolverSettings;
+#[cfg(feature = "pyo3")]
+use pyo3::{Bound, PyResult, exceptions::PyRuntimeError, prelude::PyAnyMethods, types::PyDict};
 
 /// Settings for the OpenCL IPM solvers.
 ///
@@ -84,6 +86,35 @@ impl HighsSolverSettingsBuilder {
             ignore_feature_requirements: self.ignore_feature_requirements,
         }
     }
+}
+
+#[cfg(feature = "pyo3")]
+pub fn build_highs_settings_py(kwargs: Option<&Bound<'_, PyDict>>) -> PyResult<HighsSolverSettings> {
+    let mut builder = HighsSolverSettingsBuilder::default();
+
+    if let Some(kwargs) = kwargs {
+        if let Ok(threads) = kwargs.get_item("threads") {
+            builder = builder.threads(threads.extract::<usize>()?);
+
+            kwargs.del_item("threads")?;
+        }
+
+        if let Ok(parallel) = kwargs.get_item("parallel") {
+            if parallel.extract::<bool>()? {
+                builder = builder.parallel();
+            }
+
+            kwargs.del_item("parallel")?;
+        }
+
+        if !kwargs.is_empty()? {
+            return Err(PyRuntimeError::new_err(format!(
+                "Unknown keyword arguments: {kwargs:?}",
+            )));
+        }
+    }
+
+    Ok(builder.build())
 }
 
 #[cfg(test)]

--- a/pywr-core/src/solvers/ipm_simd/mod.rs
+++ b/pywr-core/src/solvers/ipm_simd/mod.rs
@@ -11,7 +11,9 @@ use ipm_simd::{PathFollowingDirectSimdSolver, Tolerances};
 use rayon::iter::IndexedParallelIterator;
 use rayon::iter::ParallelIterator;
 use rayon::prelude::ParallelSliceMut;
-pub use settings::{SimdIpmSolverSettings, SimdIpmSolverSettingsBuilder, build_ipm_simd_settings_py};
+#[cfg(feature = "pyo3")]
+pub use settings::build_ipm_simd_settings_py;
+pub use settings::{SimdIpmSolverSettings, SimdIpmSolverSettingsBuilder};
 use std::collections::BTreeMap;
 use std::num::NonZeroUsize;
 use std::ops::Deref;

--- a/pywr-core/src/solvers/ipm_simd/mod.rs
+++ b/pywr-core/src/solvers/ipm_simd/mod.rs
@@ -11,7 +11,7 @@ use ipm_simd::{PathFollowingDirectSimdSolver, Tolerances};
 use rayon::iter::IndexedParallelIterator;
 use rayon::iter::ParallelIterator;
 use rayon::prelude::ParallelSliceMut;
-pub use settings::{SimdIpmSolverSettings, SimdIpmSolverSettingsBuilder};
+pub use settings::{SimdIpmSolverSettings, SimdIpmSolverSettingsBuilder, build_ipm_simd_settings_py};
 use std::collections::BTreeMap;
 use std::num::NonZeroUsize;
 use std::ops::Deref;

--- a/pywr-core/src/solvers/mod.rs
+++ b/pywr-core/src/solvers/mod.rs
@@ -34,18 +34,21 @@ mod microlp;
 
 #[cfg(feature = "ipm-ocl")]
 pub use self::ipm_ocl::{ClIpmF32Solver, ClIpmF64Solver, ClIpmSolverSettings, ClIpmSolverSettingsBuilder};
+#[cfg(all(feature = "ipm-simd", feature = "pyo3"))]
+pub use self::ipm_simd::build_ipm_simd_settings_py;
 #[cfg(feature = "ipm-simd")]
-pub use self::ipm_simd::{
-    SimdIpmF64Solver, SimdIpmSolverSettings, SimdIpmSolverSettingsBuilder, build_ipm_simd_settings_py,
-};
+pub use self::ipm_simd::{SimdIpmF64Solver, SimdIpmSolverSettings, SimdIpmSolverSettingsBuilder};
 use crate::aggregated_node::AggregatedNodeIndex;
 use crate::node::NodeIndex;
 #[cfg(feature = "cbc")]
 pub use cbc::{CbcError, CbcSolver, CbcSolverSettings, CbcSolverSettingsBuilder};
-#[cfg(feature = "clp")]
-pub use clp::{ClpSolveStatusError, ClpSolver, ClpSolverSettings, ClpSolverSettingsBuilder, build_clp_settings_py};
+#[cfg(all(feature = "clp", feature = "pyo3"))]
+pub use clp::build_clp_settings_py;
+pub use clp::{ClpSolveStatusError, ClpSolver, ClpSolverSettings, ClpSolverSettingsBuilder};
+#[cfg(all(feature = "highs", feature = "pyo3"))]
+pub use highs::build_highs_settings_py;
 #[cfg(feature = "highs")]
-pub use highs::{HighsSolver, HighsSolverSettings, HighsSolverSettingsBuilder, build_highs_settings_py};
+pub use highs::{HighsSolver, HighsSolverSettings, HighsSolverSettingsBuilder};
 #[cfg(feature = "microlp")]
 pub use microlp::{MicroLpError, MicroLpSolver, MicroLpSolverSettings, MicroLpSolverSettingsBuilder};
 

--- a/pywr-core/src/solvers/mod.rs
+++ b/pywr-core/src/solvers/mod.rs
@@ -35,15 +35,17 @@ mod microlp;
 #[cfg(feature = "ipm-ocl")]
 pub use self::ipm_ocl::{ClIpmF32Solver, ClIpmF64Solver, ClIpmSolverSettings, ClIpmSolverSettingsBuilder};
 #[cfg(feature = "ipm-simd")]
-pub use self::ipm_simd::{SimdIpmF64Solver, SimdIpmSolverSettings, SimdIpmSolverSettingsBuilder};
+pub use self::ipm_simd::{
+    SimdIpmF64Solver, SimdIpmSolverSettings, SimdIpmSolverSettingsBuilder, build_ipm_simd_settings_py,
+};
 use crate::aggregated_node::AggregatedNodeIndex;
 use crate::node::NodeIndex;
 #[cfg(feature = "cbc")]
 pub use cbc::{CbcError, CbcSolver, CbcSolverSettings, CbcSolverSettingsBuilder};
 #[cfg(feature = "clp")]
-pub use clp::{ClpSolveStatusError, ClpSolver, ClpSolverSettings, ClpSolverSettingsBuilder};
+pub use clp::{ClpSolveStatusError, ClpSolver, ClpSolverSettings, ClpSolverSettingsBuilder, build_clp_settings_py};
 #[cfg(feature = "highs")]
-pub use highs::{HighsSolver, HighsSolverSettings, HighsSolverSettingsBuilder};
+pub use highs::{HighsSolver, HighsSolverSettings, HighsSolverSettingsBuilder, build_highs_settings_py};
 #[cfg(feature = "microlp")]
 pub use microlp::{MicroLpError, MicroLpSolver, MicroLpSolverSettings, MicroLpSolverSettingsBuilder};
 

--- a/pywr-core/src/solvers/mod.rs
+++ b/pywr-core/src/solvers/mod.rs
@@ -44,6 +44,7 @@ use crate::node::NodeIndex;
 pub use cbc::{CbcError, CbcSolver, CbcSolverSettings, CbcSolverSettingsBuilder};
 #[cfg(all(feature = "clp", feature = "pyo3"))]
 pub use clp::build_clp_settings_py;
+#[cfg(feature = "clp")]
 pub use clp::{ClpSolveStatusError, ClpSolver, ClpSolverSettings, ClpSolverSettingsBuilder};
 #[cfg(all(feature = "highs", feature = "pyo3"))]
 pub use highs::build_highs_settings_py;

--- a/pywr-python/pywr/__init__.py
+++ b/pywr-python/pywr/__init__.py
@@ -2,8 +2,10 @@ from pathlib import Path
 from typing import Optional
 
 from .pywr import (
-    Schema,
+    ModelSchema,
+    MultiNetworkModelSchema,
     Model,
+    MultiNetworkModel,
     ModelResult,
     Timestep,
     ScenarioIndex,
@@ -16,8 +18,10 @@ from .pywr import (
 )
 
 __all__ = [
-    "Schema",
+    "ModelSchema",
+    "MultiNetworkModelSchema",
     "Model",
+    "MultiNetworkModel",
     "ModelResult",
     "Timestep",
     "ScenarioIndex",

--- a/pywr-python/pywr/__init__.py
+++ b/pywr-python/pywr/__init__.py
@@ -52,6 +52,6 @@ def run_from_path(
     if output_path is None:
         output_path = filename.parent
 
-    schema = Schema.from_path(filename)
+    schema = ModelSchema.from_path(filename)
     model = schema.build(data_path=data_path, output_path=output_path)
     model.run(solver)

--- a/pywr-python/pywr/pywr.pyi
+++ b/pywr-python/pywr/pywr.pyi
@@ -108,9 +108,9 @@ class ScenarioIndex:
     def simulation_indices(self) -> List[int]:
         """Returns indices for each scenario group for this simulation."""
 
-class Schema:
+class ModelSchema:
     @classmethod
-    def from_path(cls, path: PathLike) -> "Schema":
+    def from_path(cls, path: PathLike) -> "ModelSchema":
         """Create a new schema object from a file path.
 
         Args:
@@ -118,7 +118,32 @@ class Schema:
         """
 
     @classmethod
-    def from_json_string(cls, json_string: str) -> "Schema":
+    def from_json_string(cls, json_string: str) -> "ModelSchema":
+        """Create a new schema object from a JSON string.
+
+        Args:
+            json_string: The JSON string representing the schema.
+        """
+
+    def to_json_string(self) -> str:
+        """Serialize the schema to a JSON string."""
+
+    def build(
+        self, data_path: Optional[PathLike], output_path: Optional[PathLike]
+    ) -> "Model":
+        """Build the schema in to a Pywr model."""
+
+class MultiNetworkModelSchema:
+    @classmethod
+    def from_path(cls, path: PathLike) -> "ModelSchema":
+        """Create a new schema object from a file path.
+
+        Args:
+            path: The path to the schema JSON file.
+        """
+
+    @classmethod
+    def from_json_string(cls, json_string: str) -> "ModelSchema":
         """Create a new schema object from a JSON string.
 
         Args:
@@ -134,6 +159,15 @@ class Schema:
         """Build the schema in to a Pywr model."""
 
 class Model:
+    def run(self, solver_name: str, solver_kwargs: Optional[dict] = None):
+        """Run the model using the specified solver.
+
+        Args:
+            solver_name: The name of the solver to use.
+            solver_kwargs: Optional keyword arguments to pass to the solver.
+        """
+
+class MultiNetworkModel:
     def run(self, solver_name: str, solver_kwargs: Optional[dict] = None):
         """Run the model using the specified solver.
 

--- a/pywr-python/src/lib.rs
+++ b/pywr-python/src/lib.rs
@@ -1,27 +1,17 @@
-use chrono::NaiveDateTime;
 use pyo3::IntoPyObjectExt;
 use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
-use pyo3::types::{PyDict, PyTuple, PyType};
-use pywr_core::models::{ModelResult, ModelRunError, MultiNetworkModelResult};
+use pyo3::types::PyTuple;
+use pywr_core::models::{Model, ModelResult, ModelRunError, MultiNetworkModel, MultiNetworkModelResult};
 use pywr_core::network::NetworkResult;
 use pywr_core::parameters::ParameterInfo;
 use pywr_core::scenario::ScenarioIndex;
-#[cfg(any(feature = "ipm-ocl", feature = "ipm-simd"))]
-use pywr_core::solvers::MultiStateSolver;
-#[cfg(feature = "ipm-ocl")]
-use pywr_core::solvers::{ClIpmF32Solver, ClIpmF64Solver, ClIpmSolverSettings};
-use pywr_core::solvers::{ClpSolver, ClpSolverSettings, ClpSolverSettingsBuilder, Solver, SolverSettings};
-#[cfg(feature = "highs")]
-use pywr_core::solvers::{HighsSolver, HighsSolverSettings, HighsSolverSettingsBuilder};
-#[cfg(feature = "ipm-simd")]
-use pywr_core::solvers::{SimdIpmF64Solver, SimdIpmSolverSettings, SimdIpmSolverSettingsBuilder};
 use pywr_core::timestep::Timestep;
-use pywr_schema::model::Date;
-use pywr_schema::{ComponentConversionError, ConversionData, ConversionError, TryIntoV2};
+use pywr_schema::metric::Metric;
+use pywr_schema::{
+    ComponentConversionError, ConversionData, ConversionError, PywrModel, PywrMultiNetworkModel, TryIntoV2,
+};
 use std::fmt;
-use std::path::PathBuf;
-use std::str::FromStr;
 
 #[derive(Debug)]
 struct PySchemaError {
@@ -59,86 +49,18 @@ impl fmt::Display for PyPywrError {
     }
 }
 
-#[pyclass]
-pub struct Schema {
-    schema: pywr_schema::PywrModel,
-}
-
-#[pymethods]
-impl Schema {
-    #[new]
-    fn new(title: &str, start: NaiveDateTime, end: NaiveDateTime) -> Self {
-        let start = Date::DateTime(start);
-        let end = Date::DateTime(end);
-
-        Self {
-            schema: pywr_schema::PywrModel::new(title, &start, &end),
-        }
-    }
-
-    /// Create a new schema object from a file path.
-    #[classmethod]
-    fn from_path(_cls: &Bound<'_, PyType>, path: PathBuf) -> PyResult<Self> {
-        Ok(Self {
-            schema: pywr_schema::PywrModel::from_path(path)?,
-        })
-    }
-
-    ///  Create a new schema object from a JSON string.
-    #[classmethod]
-    fn from_json_string(_cls: &Bound<'_, PyType>, data: &str) -> PyResult<Self> {
-        Ok(Self {
-            schema: pywr_schema::PywrModel::from_str(data)?,
-        })
-    }
-
-    /// Serialize the schema to a JSON string.
-    fn to_json_string(&self) -> PyResult<String> {
-        let data = serde_json::to_string_pretty(&self.schema).map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
-        Ok(data)
-    }
-
-    /// Build the schema in to a Pywr model.
-    #[pyo3(signature = (data_path=None, output_path=None))]
-    fn build(&mut self, data_path: Option<PathBuf>, output_path: Option<PathBuf>) -> PyResult<Model> {
-        let model = self.schema.build_model(data_path.as_deref(), output_path.as_deref())?;
-        Ok(Model { model })
-    }
-}
-
 /// Convert a Pywr v1.x JSON string to a Pywr v2.x schema.
 #[pyfunction]
 fn convert_model_from_v1_json_string(py: Python, data: &str) -> PyResult<Py<PyTuple>> {
     // Try to convert
-    let (schema, errors) =
-        pywr_schema::PywrModel::from_v1_str(data).map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
+    let (schema, errors) = PywrModel::from_v1_str(data).map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
 
-    // Create a new schema object
-    let py_schema = Schema { schema };
     let py_errors = errors
         .into_iter()
         .map(|e| e.into_pyobject(py))
         .collect::<Result<Vec<_>, _>>()?;
 
-    Ok(PyTuple::new(
-        py,
-        &[py_schema.into_bound_py_any(py)?, py_errors.into_bound_py_any(py)?],
-    )?
-    .unbind())
-}
-
-#[pyclass]
-pub struct Metric {
-    metric: pywr_schema::metric::Metric,
-}
-
-#[pymethods]
-impl Metric {
-    /// Serialize the metric to a JSON string.
-    fn to_json_string(&self) -> PyResult<String> {
-        let data = serde_json::to_string_pretty(&self.metric).map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
-        Ok(data)
-    }
+    Ok(PyTuple::new(py, &[schema.into_bound_py_any(py)?, py_errors.into_bound_py_any(py)?])?.unbind())
 }
 
 /// Convert a Pywr v1.x JSON string to a Pywr v2.x metric.
@@ -151,181 +73,7 @@ fn convert_metric_from_v1_json_string(_py: Python, data: &str) -> PyResult<Metri
         .try_into_v2(None, &mut ConversionData::default())
         .map_err(|e: ConversionError| PyRuntimeError::new_err(e.to_string()))?;
 
-    let py_metric = Metric { metric };
-    Ok(py_metric)
-}
-
-/// Run a model using the specified solver unlocking the GIL
-fn run_allowing_threads<S>(
-    py: Python<'_>,
-    model: &pywr_core::models::Model,
-    settings: &S::Settings,
-) -> Result<ModelResult, PyErr>
-where
-    S: Solver,
-    <S as Solver>::Settings: SolverSettings + Sync,
-{
-    let result = py.allow_threads(|| model.run::<S>(settings))?;
-    Ok(result)
-}
-
-/// Run a model using the specified multi solver unlocking the GIL
-#[cfg(any(feature = "ipm-ocl", feature = "ipm-simd"))]
-fn run_multi_allowing_threads<S>(
-    py: Python<'_>,
-    model: &pywr_core::models::Model,
-    settings: &S::Settings,
-) -> Result<ModelResult, PyErr>
-where
-    S: MultiStateSolver,
-    <S as MultiStateSolver>::Settings: SolverSettings + Sync,
-{
-    let result = py.allow_threads(|| model.run_multi_scenario::<S>(settings))?;
-    Ok(result)
-}
-
-#[pyclass]
-pub struct Model {
-    model: pywr_core::models::Model,
-}
-
-#[pymethods]
-impl Model {
-    #[pyo3(signature = (solver_name, solver_kwargs=None))]
-    fn run(
-        &self,
-        py: Python<'_>,
-        solver_name: &str,
-        solver_kwargs: Option<&Bound<'_, PyDict>>,
-    ) -> PyResult<ModelResult> {
-        match solver_name {
-            "clp" => {
-                let settings = build_clp_settings(solver_kwargs)?;
-                run_allowing_threads::<ClpSolver>(py, &self.model, &settings)
-            }
-            #[cfg(feature = "highs")]
-            "highs" => {
-                let settings = build_highs_settings(solver_kwargs)?;
-                run_allowing_threads::<HighsSolver>(py, &self.model, &settings)
-            }
-            #[cfg(feature = "ipm-simd")]
-            "ipm-simd" => {
-                let settings = build_ipm_simd_settings(solver_kwargs)?;
-                run_multi_allowing_threads::<SimdIpmF64Solver>(py, &self.model, &settings)
-            }
-            #[cfg(feature = "ipm-ocl")]
-            "clipm-f32" => {
-                run_multi_allowing_threads::<ClIpmF32Solver>(py, &self.model, &ClIpmSolverSettings::default())
-            }
-
-            #[cfg(feature = "ipm-ocl")]
-            "clipm-f64" => {
-                run_multi_allowing_threads::<ClIpmF64Solver>(py, &self.model, &ClIpmSolverSettings::default())
-            }
-            _ => Err(PyRuntimeError::new_err(format!("Unknown solver: {solver_name}",))),
-        }
-    }
-}
-
-fn build_clp_settings(kwargs: Option<&Bound<'_, PyDict>>) -> PyResult<ClpSolverSettings> {
-    let mut builder = ClpSolverSettingsBuilder::default();
-
-    if let Some(kwargs) = kwargs {
-        if let Ok(value) = kwargs.get_item("threads") {
-            if let Some(threads) = value {
-                builder = builder.threads(threads.extract::<usize>()?);
-            }
-            kwargs.del_item("threads")?;
-        }
-
-        if let Ok(value) = kwargs.get_item("parallel") {
-            if let Some(parallel) = value {
-                if parallel.extract::<bool>()? {
-                    builder = builder.parallel();
-                }
-            }
-            kwargs.del_item("parallel")?;
-        }
-
-        if !kwargs.is_empty() {
-            return Err(PyRuntimeError::new_err(format!(
-                "Unknown keyword arguments: {kwargs:?}",
-            )));
-        }
-    }
-
-    Ok(builder.build())
-}
-
-#[cfg(feature = "highs")]
-fn build_highs_settings(kwargs: Option<&Bound<'_, PyDict>>) -> PyResult<HighsSolverSettings> {
-    let mut builder = HighsSolverSettingsBuilder::default();
-
-    if let Some(kwargs) = kwargs {
-        if let Ok(value) = kwargs.get_item("threads") {
-            if let Some(threads) = value {
-                builder = builder.threads(threads.extract::<usize>()?);
-            }
-            kwargs.del_item("threads")?;
-        }
-
-        if let Ok(value) = kwargs.get_item("parallel") {
-            if let Some(parallel) = value {
-                if parallel.extract::<bool>()? {
-                    builder = builder.parallel();
-                }
-            }
-            kwargs.del_item("parallel")?;
-        }
-
-        if !kwargs.is_empty() {
-            return Err(PyRuntimeError::new_err(format!(
-                "Unknown keyword arguments: {kwargs:?}",
-            )));
-        }
-    }
-
-    Ok(builder.build())
-}
-
-#[cfg(feature = "ipm-simd")]
-fn build_ipm_simd_settings(kwargs: Option<&Bound<'_, PyDict>>) -> PyResult<SimdIpmSolverSettings> {
-    let mut builder = SimdIpmSolverSettingsBuilder::default();
-
-    if let Some(kwargs) = kwargs {
-        if let Ok(value) = kwargs.get_item("threads") {
-            if let Some(threads) = value {
-                builder = builder.threads(threads.extract::<usize>()?);
-            }
-            kwargs.del_item("threads")?;
-        }
-
-        if let Ok(value) = kwargs.get_item("parallel") {
-            if let Some(parallel) = value {
-                if parallel.extract::<bool>()? {
-                    builder = builder.parallel();
-                }
-            }
-            kwargs.del_item("parallel")?;
-        }
-
-        if let Ok(value) = kwargs.get_item("ignore_feature_requirements") {
-            if let Some(ignore) = value {
-                if ignore.extract::<bool>()? {
-                    builder = builder.ignore_feature_requirements();
-                }
-            }
-            kwargs.del_item("ignore_feature_requirements")?;
-        }
-
-        if !kwargs.is_empty() {
-            return Err(PyRuntimeError::new_err(format!(
-                "Unknown keyword arguments: {kwargs:?}",
-            )));
-        }
-    }
-
-    Ok(builder.build())
+    Ok(metric)
 }
 
 /// A Python module implemented in Rust.
@@ -335,9 +83,11 @@ fn pywr(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
 
     m.add_function(wrap_pyfunction!(convert_model_from_v1_json_string, m)?)?;
     m.add_function(wrap_pyfunction!(convert_metric_from_v1_json_string, m)?)?;
-    m.add_class::<Schema>()?;
+    m.add_class::<PywrModel>()?;
+    m.add_class::<PywrMultiNetworkModel>()?;
     m.add_class::<Model>()?;
     m.add_class::<ModelResult>()?;
+    m.add_class::<MultiNetworkModel>()?;
     m.add_class::<MultiNetworkModelResult>()?;
     m.add_class::<NetworkResult>()?;
     m.add_class::<Metric>()?;

--- a/pywr-python/tests/models/multi1/model.json
+++ b/pywr-python/tests/models/multi1/model.json
@@ -1,0 +1,35 @@
+{
+  "metadata": {
+    "title": "Multi-model 1",
+    "description": "A simple multi-model that passes data from sub-model1 to sub-model2.",
+    "minimum_version": "0.1"
+  },
+  "timestepper": {
+    "start": "2015-01-01",
+    "end": "2015-12-31",
+    "timestep": 1
+  },
+  "networks": [
+    {
+      "name": "network1",
+      "network": "network1.json",
+      "transfers": []
+    },
+    {
+      "name": "network2",
+      "network": "network2.json",
+      "transfers": [
+        {
+          "from_network": "network1",
+          "metric": {
+            "type": "Node",
+            "name": "demand1",
+            "attribute": "Inflow"
+          },
+          "name": "inflow"
+        }
+      ]
+    }
+  ]
+
+}

--- a/pywr-python/tests/models/multi1/network1.json
+++ b/pywr-python/tests/models/multi1/network1.json
@@ -1,0 +1,56 @@
+{
+  "nodes": [
+    {
+      "meta": {
+        "name": "supply1"
+      },
+      "type": "Input",
+      "max_flow": {
+        "type": "Literal",
+        "value": 15.0
+      }
+    },
+    {
+      "meta": {
+        "name": "link1"
+      },
+      "type": "Link"
+    },
+    {
+      "meta": {
+        "name": "demand1"
+      },
+      "type": "Output",
+      "max_flow": {
+        "type": "Parameter",
+        "name": "demand"
+      },
+      "cost": {
+        "type": "Literal",
+        "value": -10
+      }
+    }
+  ],
+  "edges": [
+    {
+      "from_node": "supply1",
+      "to_node": "link1"
+    },
+    {
+      "from_node": "link1",
+      "to_node": "demand1"
+    }
+  ],
+  "parameters": [
+    {
+      "meta": {
+        "name": "demand"
+      },
+      "type": "Constant",
+      "value": {
+        "type": "Literal",
+        "value": 10.0
+      }
+    }
+  ]
+}

--- a/pywr-python/tests/models/multi1/network2.json
+++ b/pywr-python/tests/models/multi1/network2.json
@@ -1,0 +1,56 @@
+{
+  "nodes": [
+    {
+      "meta": {
+        "name": "supply2"
+      },
+      "type": "Input",
+      "max_flow": {
+        "type": "InterNetworkTransfer",
+        "name": "inflow"
+      }
+    },
+    {
+      "meta": {
+        "name": "link2"
+      },
+      "type": "Link"
+    },
+    {
+      "meta": {
+        "name": "demand2"
+      },
+      "type": "Output",
+      "max_flow": {
+        "type": "Parameter",
+        "name": "demand"
+      },
+      "cost": {
+        "type": "Literal",
+        "value": -10
+      }
+    }
+  ],
+  "edges": [
+    {
+      "from_node": "supply2",
+      "to_node": "link2"
+    },
+    {
+      "from_node": "link2",
+      "to_node": "demand2"
+    }
+  ],
+  "parameters": [
+    {
+      "meta": {
+        "name": "demand"
+      },
+      "type": "Constant",
+      "value": {
+        "type": "Literal",
+        "value": 20.0
+      }
+    }
+  ]
+}

--- a/pywr-python/tests/test_models.py
+++ b/pywr-python/tests/test_models.py
@@ -2,7 +2,7 @@ import numpy as np
 import pandas
 import polars as pl
 from polars.testing import assert_frame_equal
-from pywr import Schema, ModelResult
+from pywr import ModelSchema, ModelResult, MultiNetworkModelSchema, MultiNetworkModel
 from pathlib import Path
 import h5py
 import pytest
@@ -25,7 +25,7 @@ def test_simple_timeseries(model_dir: Path, tmpdir: Path):
 
     output_fn = tmpdir / "outputs.h5"
 
-    schema = Schema.from_path(filename)
+    schema = ModelSchema.from_path(filename)
     model = schema.build(data_path=model_dir / "simple-timeseries", output_path=tmpdir)
     result = model.run("clp")
 
@@ -75,7 +75,7 @@ def test_model(model_dir: Path, tmpdir: Path, model_name: str):
     filename = model_dir / model_name / "model.json"
     output_fn = tmpdir / "outputs.h5"
 
-    schema = Schema.from_path(filename)
+    schema = ModelSchema.from_path(filename)
     model = schema.build(data_path=model_dir / model_name, output_path=tmpdir)
     model.run("clp")
 
@@ -93,3 +93,18 @@ def test_model(model_dir: Path, tmpdir: Path, model_name: str):
         for (node, attr), df in expected_data.items():
             simulated = np.squeeze(fh[f"{node}/{attr}"])
             np.testing.assert_allclose(simulated, df)
+
+
+@pytest.mark.parametrize(
+    "model_name",
+    [
+        "multi1",
+    ],
+)
+def test_multi_model(model_dir: Path, model_name: str):
+    """Test the multi-network model"""
+    filename = model_dir / model_name / "model.json"
+
+    schema = MultiNetworkModelSchema.from_path(filename)
+    model = schema.build(data_path=model_dir / model_name, output_path=None)
+    model.run("clp")

--- a/pywr-python/tests/test_models.py
+++ b/pywr-python/tests/test_models.py
@@ -2,7 +2,7 @@ import numpy as np
 import pandas
 import polars as pl
 from polars.testing import assert_frame_equal
-from pywr import ModelSchema, ModelResult, MultiNetworkModelSchema, MultiNetworkModel
+from pywr import ModelSchema, ModelResult, MultiNetworkModelSchema
 from pathlib import Path
 import h5py
 import pytest

--- a/pywr-schema/src/data_tables/mod.rs
+++ b/pywr-schema/src/data_tables/mod.rs
@@ -21,6 +21,7 @@ mod vec;
 use crate::ConversionError;
 use crate::digest::{Checksum, ChecksumError};
 use crate::parameters::TableIndex;
+#[cfg(feature = "pyo3")]
 use pyo3::pyclass;
 use pywr_schema_macros::{PywrVisitAll, skip_serializing_none};
 use pywr_v1_schema::parameters::TableDataRef as TableDataRefV1;

--- a/pywr-schema/src/data_tables/mod.rs
+++ b/pywr-schema/src/data_tables/mod.rs
@@ -21,6 +21,7 @@ mod vec;
 use crate::ConversionError;
 use crate::digest::{Checksum, ChecksumError};
 use crate::parameters::TableIndex;
+use pyo3::pyclass;
 use pywr_schema_macros::{PywrVisitAll, skip_serializing_none};
 use pywr_v1_schema::parameters::TableDataRef as TableDataRefV1;
 #[cfg(feature = "core")]
@@ -324,6 +325,7 @@ impl LoadedTableCollection {
 #[skip_serializing_none]
 #[derive(serde::Deserialize, serde::Serialize, Debug, Clone, JsonSchema, PywrVisitAll, PartialEq)]
 #[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "pyo3", pyclass)]
 pub struct TableDataRef {
     pub table: String,
     pub column: Option<TableIndex>,

--- a/pywr-schema/src/model.rs
+++ b/pywr-schema/src/model.rs
@@ -535,6 +535,7 @@ impl PywrModel {
     }
 
     /// Build the schema in to a Pywr model.
+    #[cfg(feature = "core")]
     #[pyo3(name="build", signature = (data_path=None, output_path=None))]
     fn build_py(&mut self, data_path: Option<PathBuf>, output_path: Option<PathBuf>) -> PyResult<Model> {
         let model = self.build_model(data_path.as_deref(), output_path.as_deref())?;
@@ -875,6 +876,7 @@ impl PywrMultiNetworkModel {
     }
 
     /// Build the schema in to a Pywr model.
+    #[cfg(feature = "core")]
     #[pyo3(name="build", signature = (data_path=None, output_path=None))]
     fn build_py(
         &mut self,

--- a/pywr-schema/src/timeseries/mod.rs
+++ b/pywr-schema/src/timeseries/mod.rs
@@ -21,8 +21,7 @@ use polars::prelude::{
 };
 pub use polars_dataset::PolarsTimeseries;
 #[cfg(feature = "pyo3")]
-use pyo3::PyErr;
-use pyo3::pyclass;
+use pyo3::{PyErr, pyclass};
 #[cfg(feature = "core")]
 use pywr_core::{
     models::ModelDomain,

--- a/pywr-schema/src/timeseries/mod.rs
+++ b/pywr-schema/src/timeseries/mod.rs
@@ -22,6 +22,7 @@ use polars::prelude::{
 pub use polars_dataset::PolarsTimeseries;
 #[cfg(feature = "pyo3")]
 use pyo3::PyErr;
+use pyo3::pyclass;
 #[cfg(feature = "core")]
 use pywr_core::{
     models::ModelDomain,
@@ -470,6 +471,7 @@ pub enum TimeseriesColumns {
 #[skip_serializing_none]
 #[derive(serde::Deserialize, serde::Serialize, Debug, Clone, JsonSchema, PartialEq)]
 #[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "pyo3", pyclass)]
 pub struct TimeseriesReference {
     pub name: String,
     pub columns: Option<TimeseriesColumns>,


### PR DESCRIPTION
Refactor Python extension code to remove wrappers, and expose schema and model structs directly. Add MultiNetworkModel to the extension so these models can be run from Python.