### PR TITLE
fix: update storage attribute of ControlCurvePiecewiseInterpolatedParameter

### DIFF
--- a/pywr-schema/src/metric.rs
+++ b/pywr-schema/src/metric.rs
@@ -86,6 +86,12 @@ impl From<NodeAttrReference> for Metric {
     }
 }
 
+impl From<VirtualNodeAttrReference> for Metric {
+    fn from(v: VirtualNodeAttrReference) -> Self {
+        Self::VirtualNode(v)
+    }
+}
+
 #[cfg(feature = "core")]
 impl Metric {
     pub fn load(

--- a/pywr-schema/src/network.rs
+++ b/pywr-schema/src/network.rs
@@ -275,7 +275,10 @@ impl PywrNetwork {
                 match result {
                     Ok(node) => match node {
                         NodeOrVirtualNode::Node(n) => nodes.push(*n),
-                        NodeOrVirtualNode::Virtual(vn) => virtual_nodes.push(*vn),
+                        NodeOrVirtualNode::Virtual(vn) => {
+                            conversion_data.virtual_nodes.push(vn.name().to_owned());
+                            virtual_nodes.push(*vn);
+                        }
                     },
                     Err(e) => {
                         errors.push(e);

--- a/pywr-schema/src/v1.rs
+++ b/pywr-schema/src/v1.rs
@@ -24,6 +24,7 @@ use pywr_v1_schema::parameters::{
 #[derive(Default)]
 pub struct ConversionData {
     unnamed_count: usize,
+    pub virtual_nodes: Vec<String>,
     pub parameters: Vec<Parameter>,
     pub timeseries: Vec<Timeseries>,
 }


### PR DESCRIPTION
This update converts it from a storage node reference to a metric reference. Some logic is also added to the v1 to v2 conversion to handle to determine if a node is virtual or not.