### PR TITLE
fix: Swap "rows" and "cols" keys in table lookup definition.

### DIFF
--- a/pywr-schema/src/data_tables/mod.rs
+++ b/pywr-schema/src/data_tables/mod.rs
@@ -77,8 +77,8 @@ impl DataTable {
 #[strum_discriminants(derive(Display, IntoStaticStr, EnumString, EnumIter))]
 #[strum_discriminants(name(CsvDataTableLookupType))]
 pub enum CsvDataTableLookup {
-    Row { rows: usize },
-    Col { cols: usize },
+    Row { cols: usize },
+    Col { rows: usize },
     Both { rows: usize, cols: usize },
 }
 
@@ -104,10 +104,10 @@ impl CsvDataTable {
 
         match &self.ty {
             DataTableValueType::Scalar => match self.lookup {
-                CsvDataTableLookup::Row { rows } => {
+                CsvDataTableLookup::Row { cols: rows } => {
                     Ok(LoadedTable::FloatScalar(LoadedScalarTable::from_csv_row(&fp, rows)?))
                 }
-                CsvDataTableLookup::Col { cols } => {
+                CsvDataTableLookup::Col { rows: cols } => {
                     Ok(LoadedTable::FloatScalar(LoadedScalarTable::from_csv_col(&fp, cols)?))
                 }
                 CsvDataTableLookup::Both { rows, cols } => Ok(LoadedTable::FloatScalar(
@@ -115,8 +115,12 @@ impl CsvDataTable {
                 )),
             },
             DataTableValueType::Array => match self.lookup {
-                CsvDataTableLookup::Row { rows } => Ok(LoadedTable::FloatVec(LoadedVecTable::from_csv_row(&fp, rows)?)),
-                CsvDataTableLookup::Col { cols } => Ok(LoadedTable::FloatVec(LoadedVecTable::from_csv_col(&fp, cols)?)),
+                CsvDataTableLookup::Row { cols: rows } => {
+                    Ok(LoadedTable::FloatVec(LoadedVecTable::from_csv_row(&fp, rows)?))
+                }
+                CsvDataTableLookup::Col { rows: cols } => {
+                    Ok(LoadedTable::FloatVec(LoadedVecTable::from_csv_col(&fp, cols)?))
+                }
                 CsvDataTableLookup::Both { .. } => Err(TableError::FormatNotSupported(
                     "CSV row & column array table is not supported. Use either row or column based format.".to_string(),
                 )),
@@ -405,7 +409,7 @@ mod tests {
                 "format": "CSV",
                 "lookup": {{
                     "type": "Row",
-                    "rows": 1
+                    "cols": 1
                 }},
                 "url": {my_data_fn}
             }}"#,

--- a/pywr-schema/tests/tbl-formats1.json
+++ b/pywr-schema/tests/tbl-formats1.json
@@ -64,7 +64,7 @@
         "format": "CSV",
         "lookup": {
           "type": "Row",
-          "rows": 1
+          "cols": 1
         },
         "url": "tbl-scalar-row.csv"
       },
@@ -74,7 +74,7 @@
         "format": "CSV",
         "lookup": {
           "type": "Row",
-          "rows": 2
+          "cols": 2
         },
         "url": "tbl-scalar-row-row.csv"
       },
@@ -84,7 +84,7 @@
         "format": "CSV",
         "lookup": {
           "type": "Col",
-          "cols": 1
+          "rows": 1
         },
         "url": "tbl-scalar-col.csv"
       },
@@ -105,7 +105,7 @@
         "format": "CSV",
         "lookup": {
           "type": "Row",
-          "rows": 1
+          "cols": 1
         },
         "url": "tbl-array-row.csv"
       },
@@ -115,7 +115,7 @@
         "format": "CSV",
         "lookup": {
           "type": "Row",
-          "rows": 2
+          "cols": 2
         },
         "url": "tbl-array-row-row.csv"
       },
@@ -125,7 +125,7 @@
         "format": "CSV",
         "lookup": {
           "type": "Col",
-          "cols": 1
+          "rows": 1
         },
         "url": "tbl-array-col.csv"
       }


### PR DESCRIPTION
When using row orientated data you should specify the number of columns to use as the index. And vice-versa for column orientated data.

The change also impacts the mean of rows and cols keys in the "Both" lookup type. The internal function has been modified to follow this updated naming convention.

Fixes #556.