### PR TITLE
docs: Switch to mermaid for node diagrams.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -313,7 +313,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "shlex",
  "syn",
 ]
@@ -360,17 +360,6 @@ name = "boxcar"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26c4925bc979b677330a8c7fe7a8c94af2dbb4a2d37b4a20a80d884400f46baa"
-
-[[package]]
-name = "bstr"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234113d19d0d7d613b40e86fb654acf958910802bcceab913a4f9e7cda03b1a4"
-dependencies = [
- "memchr",
- "regex-automata",
- "serde",
-]
 
 [[package]]
 name = "bumpalo"
@@ -805,17 +794,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85d3cef41d236720ed453e102153a53e4cc3d2fde848c0078a50cf249e8e3e5b"
 
 [[package]]
-name = "derive-where"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e73f2692d4bd3cac41dca28934a39894200c9fabf49586d77d0e5954af1d7902"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -835,18 +813,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "doc-comment"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
-
-[[package]]
-name = "downcast-rs"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "dyn-clone"
@@ -1707,15 +1673,6 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
@@ -1825,12 +1782,6 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
-
-[[package]]
-name = "longest-increasing-subsequence"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3bd0dd2cd90571056fdb71f6275fada10131182f84899f4b2a916e565d81d86"
 
 [[package]]
 name = "lru-slab"
@@ -1954,22 +1905,6 @@ dependencies = [
 
 [[package]]
 name = "nalgebra"
-version = "0.32.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5c17de023a86f59ed79891b2e5d5a94c705dbe904a5b5c9c952ea6221b03e4"
-dependencies = [
- "approx",
- "matrixmultiply",
- "nalgebra-macros 0.2.2",
- "num-complex",
- "num-rational",
- "num-traits 0.2.19",
- "simba 0.8.1",
- "typenum",
-]
-
-[[package]]
-name = "nalgebra"
 version = "0.34.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4d5b3eff5cd580f93da45e64715e8c20a3996342f1e466599cf7a267a0c2f5f"
@@ -1992,23 +1927,12 @@ dependencies = [
  "glam 0.29.3",
  "glam 0.30.5",
  "matrixmultiply",
- "nalgebra-macros 0.3.0",
+ "nalgebra-macros",
  "num-complex",
  "num-rational",
  "num-traits 0.2.19",
- "simba 0.9.0",
+ "simba",
  "typenum",
-]
-
-[[package]]
-name = "nalgebra-macros"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "254a5372af8fc138e36684761d3c0cdb758a4410e938babcff1c860ce14ddbfc"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -2028,7 +1952,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df054d7815152d4e66955fc59a1f97f4036e5103134a381b6b54ec55babfa6b7"
 dependencies = [
- "nalgebra 0.34.1",
+ "nalgebra",
  "num-traits 0.2.19",
 ]
 
@@ -2322,27 +2246,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "parry2d"
-version = "0.13.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fd94bf962ead112f14223469aac6f76e3c24e2c399e348f638924498b238c56"
-dependencies = [
- "approx",
- "arrayvec",
- "bitflags 1.3.2",
- "downcast-rs",
- "either",
- "nalgebra 0.32.6",
- "num-derive",
- "num-traits 0.2.19",
- "rustc-hash 1.1.0",
- "simba 0.8.1",
- "slab",
- "smallvec",
- "spade",
-]
-
-[[package]]
 name = "parse-zoneinfo"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2369,7 +2272,6 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
- "phf_macros",
  "phf_shared",
 ]
 
@@ -2391,19 +2293,6 @@ checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared",
  "rand 0.8.5",
-]
-
-[[package]]
-name = "phf_macros"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
-dependencies = [
- "phf_generator",
- "phf_shared",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -3052,15 +2941,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pom"
-version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c972d8f86e943ad532d0b04e8965a749ad1d18bb981a9c7b3ae72fe7fd7744b"
-dependencies = [
- "bstr",
-]
-
-[[package]]
 name = "portable-atomic"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3113,29 +2993,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
-]
-
-[[package]]
 name = "proc-macro-error-attr2"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3163,19 +3020,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "535d180e0ecab6268a3e718bb9fd44db66bbbc256257165fc699dadf70d16fe7"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "proc-macro2-diagnostics"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "version_check",
- "yansi",
 ]
 
 [[package]]
@@ -3311,7 +3155,7 @@ dependencies = [
  "ipm-simd",
  "libc",
  "microlp",
- "nalgebra 0.34.1",
+ "nalgebra",
  "ndarray",
  "num",
  "ocl",
@@ -3369,7 +3213,6 @@ dependencies = [
  "sha2",
  "strum",
  "strum_macros",
- "svgbobdoc",
  "tempfile",
  "thiserror 2.0.17",
  "tracing",
@@ -3431,7 +3274,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "rustls",
  "socket2",
  "thiserror 2.0.17",
@@ -3451,7 +3294,7 @@ dependencies = [
  "lru-slab",
  "rand 0.9.2",
  "ring",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "rustls",
  "rustls-pki-types",
  "slab",
@@ -3749,36 +3592,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "robust"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e27ee8bb91ca0adcf0ecb116293afa12d393f9c2b9b9cd54d33e8078fe19839"
-
-[[package]]
-name = "rstml"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe542870b8f59dd45ad11d382e5339c9a1047cde059be136a7016095bbdefa77"
-dependencies = [
- "proc-macro2",
- "proc-macro2-diagnostics",
- "quote",
- "syn",
- "syn_derive",
- "thiserror 1.0.69",
-]
-
-[[package]]
 name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
-
-[[package]]
-name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
@@ -3895,54 +3712,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sauron"
-version = "0.61.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ae1e6099fdd837e98f78b1365637aaf81e737a9441058b0c6a5f7cb1ec69f21"
-dependencies = [
- "sauron-core",
- "sauron-macro",
-]
-
-[[package]]
-name = "sauron-core"
-version = "0.61.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af4146cee7056509846bad75dc3ee5d49af3eb22725723a2ebada4977a309888"
-dependencies = [
- "cfg-if",
- "derive-where",
- "doc-comment",
- "futures 0.3.30",
- "indexmap",
- "js-sys",
- "log",
- "longest-increasing-subsequence",
- "once_cell",
- "phf",
- "serde-wasm-bindgen",
- "thiserror 1.0.69",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
-name = "sauron-macro"
-version = "0.61.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd37ab91758f25ea92a216dfed0e2f9103bdf7357d3af148b744cb8941e19d28"
-dependencies = [
- "once_cell",
- "phf",
- "proc-macro2",
- "quote",
- "rstml",
- "sauron-core",
- "syn",
-]
-
-[[package]]
 name = "schannel"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4020,17 +3789,6 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
-]
-
-[[package]]
-name = "serde-wasm-bindgen"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3b143e2833c57ab9ad3ea280d21fd34e285a42837aeb0ee301f4f41890fa00e"
-dependencies = [
- "js-sys",
- "serde",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -4146,19 +3904,6 @@ dependencies = [
 
 [[package]]
 name = "simba"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "061507c94fc6ab4ba1c9a0305018408e312e17c041eb63bef8aa726fa33aceae"
-dependencies = [
- "approx",
- "num-complex",
- "num-traits 0.2.19",
- "paste",
- "wide 0.7.33",
-]
-
-[[package]]
-name = "simba"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3a386a501cd104797982c15ae17aafe8b9261315b5d07e3ec803f2ea26be0fa"
@@ -4230,18 +3975,6 @@ checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "spade"
-version = "2.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ece03ff43cd2a9b57ebf776ea5e78bd30b3b4185a619f041079f4109f385034"
-dependencies = [
- "hashbrown 0.15.3",
- "num-traits 0.2.19",
- "robust",
- "smallvec",
 ]
 
 [[package]]
@@ -4355,36 +4088,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
-name = "svgbob"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5a8328fdacbd198bf72062a6dada3990d30f2f0bd95b6f3f0859776a5bc87c2"
-dependencies = [
- "indexmap",
- "itertools 0.11.0",
- "log",
- "nalgebra 0.32.6",
- "once_cell",
- "parry2d",
- "pom",
- "sauron",
- "unicode-width 0.1.14",
-]
-
-[[package]]
-name = "svgbobdoc"
-version = "0.3.0"
-source = "git+https://github.com/jetuk/svgbobdoc.git?branch=svgbob-0_7_5#f717c6d062302a51642778ba7a65580faf2c9c9d"
-dependencies = [
- "base64",
- "proc-macro2",
- "quote",
- "svgbob",
- "syn",
- "unicode-width 0.2.0",
-]
-
-[[package]]
 name = "syn"
 version = "2.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4393,18 +4096,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "syn_derive"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1329189c02ff984e9736652b1631330da25eaa6bc639089ed4915d25446cbe7b"
-dependencies = [
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -4746,18 +4437,6 @@ name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
-
-[[package]]
-name = "unicode-width"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
-
-[[package]]
-name = "unicode-width"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "unindent"
@@ -5282,12 +4961,6 @@ name = "xxhash-rust"
 version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
-
-[[package]]
-name = "yansi"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"

--- a/pywr-schema/Cargo.toml
+++ b/pywr-schema/Cargo.toml
@@ -53,7 +53,6 @@ serde_json = { workspace = true }
 sha2 = { workspace = true }
 strum = "0.27"
 strum_macros = "0.27"
-svgbobdoc = { git = "https://github.com/jetuk/svgbobdoc.git", features = ["enable"], branch = "svgbob-0_7_5" }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 

--- a/pywr-schema/src/lib.rs
+++ b/pywr-schema/src/lib.rs
@@ -9,6 +9,7 @@ pub mod data_tables;
 mod digest;
 pub mod edge;
 mod error;
+mod mermaid;
 pub mod metric;
 pub mod metric_sets;
 pub mod model;

--- a/pywr-schema/src/mermaid.rs
+++ b/pywr-schema/src/mermaid.rs
@@ -1,0 +1,54 @@
+#[macro_export]
+macro_rules! mermaid {
+    ($file:literal)               => { $crate::_mermaid_inner!($file center transparent) };
+    ($file:literal left framed)   => { $crate::_mermaid_inner!($file left framed) };
+    ($file:literal framed left)   => { $crate::_mermaid_inner!($file left framed) };
+    ($file:literal center framed) => { $crate::_mermaid_inner!($file center framed) };
+    ($file:literal framed center) => { $crate::_mermaid_inner!($file center framed) };
+    ($file:literal right framed)  => { $crate::_mermaid_inner!($file right framed) };
+    ($file:literal framed right)  => { $crate::_mermaid_inner!($file right framed) };
+    ($file:literal framed)        => { $crate::_mermaid_inner!($file center framed) };
+    ($file:literal left)          => { $crate::_mermaid_inner!($file left transparent) };
+    ($file:literal right)         => { $crate::_mermaid_inner!($file right transparent) };
+    ($file:literal center)        => { $crate::_mermaid_inner!($file center transparent) };
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! _mermaid_inner {
+    ($file:literal $pos:ident $style:ident) => {
+        concat!(
+            "<pre class=\"mermaid\" style=\"text-align:",
+            stringify!($pos),
+            ";",
+            $crate::_mermaid_background!($style),
+            "\">\n",
+            include_str!($file),
+            "classDef inputNode fill:#377eb8,stroke:#a0a0a0,stroke-width:4px,color:white;",
+            "classDef linkNode fill:#fafafa,stroke:#a0a0a0,stroke-width:4px;",
+            "classDef outputNode fill:#ffff33,stroke:#a0a0a0,stroke-width:4px;",
+            "classDef storageNode fill:#e41a1d,stroke:#a0a0a0,stroke-width:4px,color:white;",
+            "classDef aggNode fill:#e8f4f8,stroke:#4a90e2,stroke-width:2px,stroke-dasharray:10,5;",
+            "classDef thisNode fill:none,stroke:#000,stroke-width:4px;",
+            "classDef slot fill:none,stroke:#a0a0a0,stroke-width:1px;",
+            "\n",
+            "</pre>",
+            "<script type=\"module\">",
+            "import mermaid from \"https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs\";",
+            "var doc_theme = localStorage.getItem(\"rustdoc-theme\");",
+            "if (doc_theme === \"dark\" || doc_theme === \"ayu\") mermaid.initialize({theme: \"dark\"});",
+            "</script>"
+        )
+    };
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! _mermaid_background {
+    (framed) => {
+        ""
+    };
+    (transparent) => {
+        "background: transparent;"
+    };
+}

--- a/pywr-schema/src/nodes/abstraction.rs
+++ b/pywr-schema/src/nodes/abstraction.rs
@@ -6,7 +6,7 @@ use crate::network::LoadArgs;
 use crate::nodes::{NodeAttribute, NodeComponent};
 use crate::nodes::{NodeMeta, NodeSlot};
 use crate::parameters::Parameter;
-use crate::{node_attribute_subset_enum, node_component_subset_enum};
+use crate::{mermaid, node_attribute_subset_enum, node_component_subset_enum};
 #[cfg(feature = "core")]
 use pywr_core::metric::MetricF64;
 use pywr_schema_macros::{PywrVisitAll, skip_serializing_none};
@@ -56,9 +56,8 @@ impl TryFrom<NodeSlot> for AbstractionOutputNodeSlot {
     }
 }
 
-#[doc = svgbobdoc::transform!(
 /// This node represents a river abstraction.
-/// 
+///
 /// The abstraction can optionally be constrained by a minimum residual flow (MRF) requirement. If
 /// this is defined an internal MRF node is created.
 ///
@@ -66,28 +65,13 @@ impl TryFrom<NodeSlot> for AbstractionOutputNodeSlot {
 /// river and the 'abstraction' slot is where the abstracted flow is directed.
 ///
 ///
-/// ```svgbob
-///            <node>.mrf
-///          .------>L -----.
-///      U  |                |     D[downstream]
-///     -*--|                |--->*- - ->
-///         |                |
-///         |'------>L -----'
-///         |   <node>.bypass
-///         |
-///         |
-///         |                     D[abstraction]
-///         +------>L ---------->*- - ->
-///            <node>.abstraction
-///
-/// ```
+#[doc = mermaid!("doc_diagrams/abstraction.mmd")]
 ///
 /// # Available attributes and components
 ///
 /// The enums [`AbstractionNodeAttribute`] and [`AbstractionNodeComponent`] define the available
 /// attributes and components for this node.
 ///
-)]
 #[skip_serializing_none]
 #[derive(serde::Deserialize, serde::Serialize, Clone, Default, Debug, JsonSchema, PywrVisitAll)]
 #[serde(deny_unknown_fields)]

--- a/pywr-schema/src/nodes/core.rs
+++ b/pywr-schema/src/nodes/core.rs
@@ -8,7 +8,7 @@ use crate::nodes::{NodeAttribute, NodeComponent};
 use crate::nodes::{NodeMeta, NodeSlot};
 use crate::parameters::Parameter;
 use crate::v1::{ConversionData, TryFromV1, try_convert_initial_storage, try_convert_node_attr};
-use crate::{node_attribute_subset_enum, node_component_subset_enum};
+use crate::{mermaid, node_attribute_subset_enum, node_component_subset_enum};
 #[cfg(feature = "core")]
 use pywr_core::{
     derived_metric::DerivedMetric, metric::MetricF64, node::StorageInitialVolume as CoreStorageInitialVolume,
@@ -221,98 +221,59 @@ node_component_subset_enum! {
     }
 }
 
-#[doc = svgbobdoc::transform!(
-/// A node with cost, and min and max flow constraints. The node `L`, when connected to an upstream
-/// node `U` and downstream node `D`, will look like this on the model schematic:
+/// A node with cost, and min and max flow constraints. The node `[name]`, when connected to an upstream
+/// node and downstream node, will look like this on the model schematic:
 ///
-/// ```svgbob
-///
-///          U         L         D
-///    - - ->*-------->*--------->*- - -
-/// ```
+#[doc = mermaid!("doc_diagrams/link-node-simple.mmd")]
 ///
 /// # Soft constraints
 /// This node allows setting optional maximum and minimum soft constraints via the `soft_min.flow`
 /// and `soft_max.flow` properties. These may be breached depending on the costs set on the
 /// optional nodes. However, the combined flow through the internal nodes will always be bound
-/// between the `min_flow` and `max_flow` attributes. When the two attributes are provided, the
-/// internal representation of the link will look like this:
+/// between the `min_flow` and `max_flow` attributes.
 ///
-/// ```svgbob
-///                <Link>.soft_max
-///              .------>L_max -----.
-///             |                   |
-///          U  |                   |     D
-///     - - -*--|-------->L --------|--->*- - -
-///             |                   |
-///             |                   |
-///             '------>L_min -----'
-///                <Link>.soft_min
-/// ```
 /// ## Implementation
 ///
 ///
 /// ### Only `soft_min` is defined
-/// Normally the minimum flow is delivered through `L_min` depending on the cost `soft_min.cost`. Any
-/// additional flow goes through `L`. Depending on the network demand and the value of `soft_min.cost`,
-/// the delivered flow via `L_min` may go below `soft_min.flow`.
-/// ```svgbob
-///          U                            D
-///     - - -*----------->L ------------>*- - -
-///             |                   |
-///             |                   |                () <Link>.aggregated_node
-///             '------>L_min -----'                         [ L_min, L ]
-///                <Link>.soft_min
-/// ```
+/// Normally the minimum flow is delivered through `[name].soft_min` depending on the cost `soft_min.cost`. Any
+/// additional flow goes through `[name]`. Depending on the network demand and the value of `soft_min.cost`,
+/// the delivered flow via `[name].soft_min` may go below `soft_min.flow`.
+///
+#[doc = mermaid!("doc_diagrams/link-node-soft-min-only.mmd")]
 ///
 /// The network is set up as follows:
-///  - `L_max` is not added to the network
-///  - `L_min` is added with `soft_min` data
-///  - `L` is added with `cost`, `min_flow` is set to 0 and `max_flow` is unconstrained.
-///  - An aggregated node is added to ensure that combined flow in `L_min` and `L` never exceeds
+///  - `[name].soft_max` is not added to the network
+///  - `[name].soft_min` is added with `soft_min` data
+///  - `[name]` is added with `cost`, `min_flow` is set to 0 and `max_flow` is unconstrained.
+///  - An aggregated node is added to ensure that combined flow in `[name].soft_min` and `[name]` never exceeds
 ///    the hard constraints `min_flow` and `max_flow`.
 ///
 /// ### Only `soft_max` is defined
-/// Normally the maximum flow `soft_max.max` is delivered through the `L_max` node and no flow
-/// goes through `L`. When needed, based on the value of `soft_max.cost`, the maximum `soft_max.max`
+/// Normally the maximum flow `soft_max.max` is delivered through the `[name].soft_max` node and no flow
+/// goes through `[name]`. When needed, based on the value of `soft_max.cost`, the maximum `soft_max.max`
 /// value can be breached up to a combined flow of `max_flow`.
-/// ```svgbob
-///          U                            D
-///     - - -*----------->L ------------>*- - -
-///             |                   |
-///             |                   |                () <Link>.aggregated_node
-///             '------>L_max -----'                         [ L_max, L ]
-///                <Link>.soft_max
-/// ```
+///
+#[doc = mermaid!("doc_diagrams/link-node-soft-max-only.mmd")]
 ///
 /// The network is set up as follows:
-///  - `L_min` is not added to the network.
-///  - `L` is added with the cost in `soft_max.cost` (i.e. cost of going above soft max).
-///  - `L_max` is added with max flow of `soft_max.max` and cost of `cost`.
-///  - An aggregated node is added to ensure that combined flow in `L_max` and `L` never exceeds
+///  - `[name].soft_min` is not added to the network.
+///  - `[name]` is added with the cost in `soft_max.cost` (i.e. cost of going above soft max).
+///  - `[name].soft_max` is added with max flow of `soft_max.max` and cost of `cost`.
+///  - An aggregated node is added to ensure that combined flow in `[name].soft_max` and `[name]` never exceeds
 ///    the hard constraints `min_flow` and `max_flow`.
 ///
 /// ### Both `soft_min` and `soft_max` are defined
 ///
-/// ```svgbob
-///                <Link>.soft_max
-///              .------>L_max -----.
-///             |                   |                    () <Link>.aggregated_node
-///          U  |                   |     D                   [ L_max, L_min, L ]
-///     - - -*--|-------->L --------|--->*- - -
-///             |                   |                    () <Link>.aggregate_node_l_l_min
-///             |                   |                            [ L_min, L ]
-///             '------>L_min -----'
-///                <Link>.soft_min
-/// ```
+#[doc = mermaid!("doc_diagrams/link-node-soft-cons.mmd")]
 ///
 /// The network is set up as follows:
-/// - `L_max`'s flow is unconstrained with a cost equal to `soft_max.cost`.
-/// - `L`'s flow is unconstrained with a cost equal to `cost`.
-/// - `L_min`'s max flow is constrained to `soft_min.flow` with a cost equal to `soft_min.cost`.
-/// - An aggregated node is added with `L` and `L_min` to ensure the max flow does not exceed
+/// - `[name].soft_max`'s flow is unconstrained with a cost equal to `soft_max.cost`.
+/// - `[name]`'s flow is unconstrained with a cost equal to `cost`.
+/// - `[name].soft_min`'s max flow is constrained to `soft_min.flow` with a cost equal to `soft_min.cost`.
+/// - An aggregated node is added with `[name]` and `[name].soft_min` to ensure the max flow does not exceed
 ///   `soft_max.flow`.
-/// - An aggregated node is added with `L`, `L_max` and `L_min` to ensure the flow is between
+/// - An aggregated node is added with `[name].soft_max`, `[name]` and `[name].soft_min` to ensure the flow is between
 ///   `min_flow` and `max_flow`.
 ///
 /// # Available attributes and components
@@ -330,7 +291,6 @@ node_component_subset_enum! {
 ///   with a negative cost to allow the minimum flow requirement. However, when this cannot be met
 ///   (for example when the abstraction license or the source runs out), the minimum flow will not
 ///   be honoured and the solver will find a solution.
-)]
 #[skip_serializing_none]
 #[derive(serde::Deserialize, serde::Serialize, Clone, Default, Debug, JsonSchema, PywrVisitAll)]
 #[serde(deny_unknown_fields)]
@@ -355,11 +315,11 @@ impl LinkNode {
     const DEFAULT_COMPONENT: LinkNodeComponent = LinkNodeComponent::Outflow;
 
     fn soft_min_node_sub_name() -> Option<&'static str> {
-        Some("soft_min_node")
+        Some("soft_min")
     }
 
     fn soft_max_node_sub_name() -> Option<&'static str> {
-        Some("soft_max_node")
+        Some("soft_max")
     }
 
     pub fn input_connectors(&self, slot: Option<&NodeSlot>) -> Result<Vec<(&str, Option<String>)>, SchemaError> {
@@ -419,7 +379,7 @@ impl LinkNode {
         Some("aggregate_node")
     }
 
-    /// The aggregated node name of `L` and `L_min` when both soft constraints are provided.
+    /// The aggregated node name of `[name]` and `[name].soft_min` when both soft constraints are provided.
     fn aggregated_node_l_l_min_sub_name() -> Option<&'static str> {
         Some("aggregate_node_l_l_min")
     }
@@ -631,7 +591,7 @@ impl LinkNode {
                     network.set_aggregated_node_min_flow(node_name, Self::aggregated_node_sub_name(), value.into())?;
                 }
 
-                // add constraints on node aggregating `L` and `L_min`
+                // add constraints on node aggregating `[name]` and `[name].soft_min`
                 if let Some(soft_max_flow) = &soft_max.flow {
                     let value = soft_max_flow.load(network, args, Some(&self.meta.name))?;
                     network.set_aggregated_node_max_flow(
@@ -1199,23 +1159,17 @@ node_component_subset_enum! {
     }
 }
 
-#[doc = svgbobdoc::transform!(
 /// A node to represent a catchment inflow.
 ///
 /// Catchment nodes create a single [`InputNode`] node in the network, but
 /// ensure that the maximum and minimum flow are equal to [`Self::flow`].
 ///
-/// ```svgbob
-///  <node>     D
-///     *----->*- - -
-/// ```
 ///
 /// # Available attributes and components
 ///
 /// The enums [`CatchmentNodeAttribute`] and [`CatchmentNodeComponent`] define the available
 /// attributes and components for this node.
 ///
-)]
 #[skip_serializing_none]
 #[derive(serde::Deserialize, serde::Serialize, Clone, Default, Debug, JsonSchema, PywrVisitAll)]
 #[serde(deny_unknown_fields)]

--- a/pywr-schema/src/nodes/delay.rs
+++ b/pywr-schema/src/nodes/delay.rs
@@ -6,7 +6,7 @@ use crate::network::LoadArgs;
 use crate::nodes::{NodeAttribute, NodeComponent};
 use crate::nodes::{NodeMeta, NodeSlot};
 use crate::parameters::{ConstantValue, Parameter};
-use crate::{node_attribute_subset_enum, node_component_subset_enum};
+use crate::{mermaid, node_attribute_subset_enum, node_component_subset_enum};
 #[cfg(feature = "core")]
 use pywr_core::{metric::MetricF64, parameters::ParameterName};
 use pywr_schema_macros::{PywrVisitAll, skip_serializing_none};
@@ -29,7 +29,6 @@ node_component_subset_enum! {
     }
 }
 
-#[doc = svgbobdoc::transform!(
 /// This node is used to introduce a delay between flows entering and leaving the node.
 ///
 /// This is often useful in long river reaches as a simply way to model time-of-travel. Internally
@@ -40,19 +39,13 @@ node_component_subset_enum! {
 /// "-delay".
 ///
 ///
-/// ```svgbob
-///
-///      U  <node.inflow>  D
-///     -*---> O    I --->*-
-///             <node.outflow>
-/// ```
+#[doc = mermaid!("doc_diagrams/delay.mmd")]
 ///
 /// # Available attributes and components
 ///
 /// The enums [`DelayNodeAttribute`] and [`DelayNodeComponent`] define the available
 /// attributes and components for this node.
 ///
-)]
 #[skip_serializing_none]
 #[derive(serde::Deserialize, serde::Serialize, Clone, Default, Debug, JsonSchema, PywrVisitAll)]
 #[serde(deny_unknown_fields)]

--- a/pywr-schema/src/nodes/doc_diagrams/abstraction.mmd
+++ b/pywr-schema/src/nodes/doc_diagrams/abstraction.mmd
@@ -1,0 +1,30 @@
+graph LR
+    subgraph ThisNode["Abstraction"]
+
+        s_in@{ shape: small-circle, label: "Incoming slot" }
+        s_out@{ shape: framed-circle, label: "Outgoing slot" }
+        s_out_abs@{ shape: framed-circle, label: "Outgoing slot" }
+
+        s_in --> L_mrf("[name].mrf")
+        s_in --> L_bypass("[name]".bypass)
+        s_in --> L_abs("[name]".abstraction)
+
+
+        L_mrf --> s_out
+        L_bypass --> s_out
+        L_abs --> s_out_abs
+
+
+    end
+
+    U(Upstream) --> s_in
+    s_out -->|River| D1(Downstream 1)
+    s_out_abs -->|Abstraction| D2(Downstream 2)
+
+    class L_mrf linkNode;
+    class L_bypass linkNode;
+    class L_abs linkNode;
+    class ThisNode thisNode;
+    class s_in slot;
+    class s_out slot;
+    class s_out_abs slot;

--- a/pywr-schema/src/nodes/doc_diagrams/delay.mmd
+++ b/pywr-schema/src/nodes/doc_diagrams/delay.mmd
@@ -1,0 +1,23 @@
+graph LR
+    subgraph ThisNode["Delay"]
+
+        s_in@{ shape: small-circle, label: "Incoming slot" }
+        s_out@{ shape: framed-circle, label: "Outgoing slot" }
+
+        s_in --> O("[name].inflow")
+        O -.->|Delay| I
+        I("[name].outflow") --> s_out
+
+
+    end
+
+    U(Upstream) --> s_in
+    s_out --> D1(Downstream )
+
+    class I inputNode;
+    class O outputNode;
+    class L_net linkNode;
+    class ThisNode thisNode;
+    class AG1 aggNode;
+    class s_in slot;
+    class s_out slot;

--- a/pywr-schema/src/nodes/doc_diagrams/link-node-simple.mmd
+++ b/pywr-schema/src/nodes/doc_diagrams/link-node-simple.mmd
@@ -1,0 +1,19 @@
+graph LR
+    subgraph ThisNode["Link"]
+
+        s_in@{ shape: small-circle, label: "Incoming slot" }
+        s_out@{ shape: framed-circle, label: "Outgoing slot" }
+
+        L("[name]")
+
+        s_in --> L --> s_out
+
+    end
+
+    U(Upstream) --> s_in
+    s_out --> D1(Downstream)
+
+    class L linkNode;
+    class ThisNode thisNode;
+    class s_in slot;
+    class s_out slot;

--- a/pywr-schema/src/nodes/doc_diagrams/link-node-soft-cons.mmd
+++ b/pywr-schema/src/nodes/doc_diagrams/link-node-soft-cons.mmd
@@ -1,0 +1,32 @@
+graph LR
+    subgraph ThisNode["Link"]
+
+        s_in@{ shape: small-circle, label: "Incoming slot" }
+        s_out@{ shape: framed-circle, label: "Outgoing slot" }
+
+        subgraph AG1["Max flow constraint"]
+
+        L_soft_max("[name].soft_max")
+        subgraph AG2["Soft max flow constraint"]
+        L("[name]")
+        L_soft_min("[name].soft_min")
+        end
+        end
+
+        s_in --> L_soft_max --> s_out
+        s_in --> L --> s_out
+        s_in --> L_soft_min --> s_out
+
+    end
+
+    U(Upstream) --> s_in
+    s_out --> D1(Downstream)
+
+    class L linkNode;
+    class L_soft_max linkNode;
+    class L_soft_min linkNode;
+    class AG1 aggNode;
+    class AG2 aggNode;
+    class ThisNode thisNode;
+    class s_in slot;
+    class s_out slot;

--- a/pywr-schema/src/nodes/doc_diagrams/link-node-soft-max-only.mmd
+++ b/pywr-schema/src/nodes/doc_diagrams/link-node-soft-max-only.mmd
@@ -1,0 +1,27 @@
+graph LR
+    subgraph ThisNode["Link"]
+
+        s_in@{ shape: small-circle, label: "Incoming slot" }
+        s_out@{ shape: framed-circle, label: "Outgoing slot" }
+
+        subgraph AG1["Max flow constraint"]
+
+        L_soft_max("[name].soft_max")
+        L("[name]")
+
+        end
+
+        s_in --> L_soft_max --> s_out
+        s_in --> L --> s_out
+
+    end
+
+    U(Upstream) --> s_in
+    s_out --> D1(Downstream)
+
+    class L linkNode;
+    class L_soft_max linkNode;
+    class AG1 aggNode;
+    class ThisNode thisNode;
+    class s_in slot;
+    class s_out slot;

--- a/pywr-schema/src/nodes/doc_diagrams/link-node-soft-min-only.mmd
+++ b/pywr-schema/src/nodes/doc_diagrams/link-node-soft-min-only.mmd
@@ -1,0 +1,25 @@
+graph LR
+    subgraph ThisNode["Link"]
+
+        s_in@{ shape: small-circle, label: "Incoming slot" }
+        s_out@{ shape: framed-circle, label: "Outgoing slot" }
+
+        subgraph AG1["Max flow constraint"]
+        L("[name]")
+        L_soft_min("[name].soft_min")
+        end
+
+        s_in --> L --> s_out
+        s_in --> L_soft_min --> s_out
+
+    end
+
+    U(Upstream) --> s_in
+    s_out --> D1(Downstream)
+
+    class L linkNode;
+    class L_soft_min linkNode;
+    class AG1 aggNode;
+    class ThisNode thisNode;
+    class s_in slot;
+    class s_out slot;

--- a/pywr-schema/src/nodes/doc_diagrams/loss-link.mmd
+++ b/pywr-schema/src/nodes/doc_diagrams/loss-link.mmd
@@ -1,0 +1,25 @@
+graph LR
+    subgraph ThisNode["LossLink"]
+
+        subgraph AG1["Aggregated node"]
+            L_net
+            O_loss
+        end
+
+        s_in@{ shape: small-circle, label: "Incoming slot" }
+        s_out@{ shape: framed-circle, label: "Outgoing slot" }
+
+        s_in --> L_net("[name].net") --> s_out
+        s_in --> O_loss("[name].loss")
+
+    end
+
+    U(Upstream) --> s_in
+    s_out --> D1(Downstream )
+
+    class O_loss outputNode;
+    class L_net linkNode;
+    class ThisNode thisNode;
+    class AG1 aggNode;
+    class s_in slot;
+    class s_out slot;

--- a/pywr-schema/src/nodes/doc_diagrams/piecewise-storage.mmd
+++ b/pywr-schema/src/nodes/doc_diagrams/piecewise-storage.mmd
@@ -1,0 +1,27 @@
+graph LR
+    subgraph ThisNode["PiecewiseStorage"]
+
+        s_in@{ shape: small-circle, label: "Incoming slot" }
+        s_out@{ shape: framed-circle, label: "Outgoing slot" }
+
+        S0("[name].00")
+        S1("[name].01")
+        Sn("[name].n")
+
+        S0 --> S1
+        S1 --> S0
+        S1 -.-> Sn
+        Sn -.-> S1
+
+        s_in --> S0 --> s_out
+    end
+
+    U(Upstream) --> s_in
+    s_out --> D1(Downstream)
+
+    class S0 storageNode;
+    class S1 storageNode;
+    class Sn storageNode;
+    class ThisNode thisNode;
+    class s_in slot;
+    class s_out slot;

--- a/pywr-schema/src/nodes/doc_diagrams/piecewise.mmd
+++ b/pywr-schema/src/nodes/doc_diagrams/piecewise.mmd
@@ -1,0 +1,25 @@
+graph LR
+    subgraph ThisNode["Link"]
+
+        s_in@{ shape: small-circle, label: "Incoming slot" }
+        s_out@{ shape: framed-circle, label: "Outgoing slot" }
+
+        L0("[name].00")
+        L1("[name].01")
+        Ln("[name].n")
+
+        s_in --> L0 --> s_out
+        s_in --> L1 --> s_out
+        s_in -.-> Ln -.-> s_out
+
+    end
+
+    U(Upstream) --> s_in
+    s_out --> D1(Downstream)
+
+    class L0 linkNode;
+    class L1 linkNode;
+    class Ln linkNode;
+    class ThisNode thisNode;
+    class s_in slot;
+    class s_out slot;

--- a/pywr-schema/src/nodes/doc_diagrams/reservoir-spill-link.mmd
+++ b/pywr-schema/src/nodes/doc_diagrams/reservoir-spill-link.mmd
@@ -1,0 +1,41 @@
+graph LR
+    subgraph ThisNode["Reservoir (with spill as link)"]
+
+        s_in@{ shape: small-circle, label: "Incoming slot" }
+        s_out@{ shape: framed-circle, label: "Outgoing slot" }
+        s_out_comp@{ shape: framed-circle, label: "Outgoing slot" }
+        s_out_spill@{ shape: framed-circle, label: "Outgoing slot" }
+
+        L_rain("[name].rainfall")
+        L_spill("[name].spill")
+        L_comp("[name].compensation")
+        O_evap("[name].evaporation")
+        O_leak("[name].leakage")
+        S("[name]")
+
+        s_in --> S --> s_out
+
+        L_rain --> S
+        S --> L_spill --> s_out_spill
+        S --> O_evap
+        S --> O_leak
+        S -.-> L_comp -.-> s_out_comp
+
+    end
+
+    U(Upstream) --> s_in
+    s_out -->|Storage| D1(Downstream 1)
+    s_out_comp -->|Compensation| D2(Downstream 2)
+    s_out_spill --> |Spill| D3(Downstream 3)
+
+    class L_rain linkNode;
+    class L_spill linkNode;
+    class L_comp linkNode;
+    class O_evap outputNode;
+    class O_leak outputNode;
+    class S storageNode;
+    class ThisNode thisNode;
+    class s_in slot;
+    class s_out slot;
+    class s_out_comp slot;
+    class s_out_spill slot;

--- a/pywr-schema/src/nodes/doc_diagrams/reservoir-spill-output.mmd
+++ b/pywr-schema/src/nodes/doc_diagrams/reservoir-spill-output.mmd
@@ -1,0 +1,39 @@
+graph LR
+    subgraph ThisNode["Reservoir (with spill as output)"]
+
+        s_in@{ shape: small-circle, label: "Incoming slot" }
+        s_out@{ shape: framed-circle, label: "Outgoing slot" }
+        s_out_comp@{ shape: framed-circle, label: "Outgoing slot" }
+
+        L_rain("[name].rainfall")
+        O_spill("[name].spill")
+        L_comp("[name].compensation")
+        O_evap("[name].evaporation")
+        O_leak("[name].leakage")
+        S("[name]")
+
+        s_in --> S --> s_out
+
+        L_rain --> S
+        S --> O_spill
+        S --> O_evap
+        S --> O_leak
+        S -.-> L_comp -.-> s_out_comp
+
+    end
+
+    U(Upstream) --> s_in
+    s_out -->|Storage| D1(Downstream 1)
+    s_out_comp -->|Compensation| D2(Downstream 2)
+
+    class L_rain linkNode;
+    class O_spill outputNode;
+    class L_comp linkNode;
+    class O_evap outputNode;
+    class O_leak outputNode;
+    class S storageNode;
+    class ThisNode thisNode;
+    class s_in slot;
+    class s_out slot;
+    class s_out_comp slot;
+    class s_out_spill slot;

--- a/pywr-schema/src/nodes/doc_diagrams/river-delay-with-loss.mmd
+++ b/pywr-schema/src/nodes/doc_diagrams/river-delay-with-loss.mmd
@@ -1,0 +1,32 @@
+graph LR
+    subgraph ThisNode["River"]
+
+        subgraph AG1["Aggregated node"]
+            L_net
+            O_loss
+        end
+    
+        s_in@{ shape: small-circle, label: "Incoming slot" } 
+        s_out@{ shape: framed-circle, label: "Outgoing slot" }
+        
+        s_in --> O("[name].inflow") 
+        O -.->|Routing| I
+        I("[name].outflow")
+
+        I --> L_net("[name].net") --> s_out
+        I --> O_loss("[name].loss")
+        
+               
+    end
+
+    U(Upstream) --> s_in
+    s_out --> D1(Downstream )
+
+    class I inputNode;    
+    class O outputNode;    
+    class O_loss outputNode;    
+    class L_net linkNode;     
+    class ThisNode thisNode;
+    class AG1 aggNode;
+    class s_in slot;
+    class s_out slot;

--- a/pywr-schema/src/nodes/doc_diagrams/river-delay.mmd
+++ b/pywr-schema/src/nodes/doc_diagrams/river-delay.mmd
@@ -1,0 +1,23 @@
+graph LR
+    subgraph ThisNode["River"]
+
+        s_in@{ shape: small-circle, label: "Incoming slot" }
+        s_out@{ shape: framed-circle, label: "Outgoing slot" }
+
+        s_in --> O("[name].inflow")
+        O -.->|Routing| I
+        I("[name].outflow") --> s_out
+
+
+    end
+
+    U(Upstream) --> s_in
+    s_out --> D1(Downstream )
+
+    class I inputNode;
+    class O outputNode;
+    class L_net linkNode;
+    class ThisNode thisNode;
+    class AG1 aggNode;
+    class s_in slot;
+    class s_out slot;

--- a/pywr-schema/src/nodes/doc_diagrams/river-gauge.mmd
+++ b/pywr-schema/src/nodes/doc_diagrams/river-gauge.mmd
@@ -1,0 +1,25 @@
+graph LR
+    subgraph ThisNode["RiverGauge"]
+
+        s_in@{ shape: small-circle, label: "Incoming slot" }
+        s_out@{ shape: framed-circle, label: "Outgoing slot" }
+
+        s_in --> L_mrf("[name].mrf")
+        s_in --> L_bypass("[name]".bypass)
+
+
+        L_mrf --> s_out
+        L_bypass --> s_out
+
+
+
+    end
+
+    U(Upstream) --> s_in
+    s_out -->|River| D1(Downstream)
+
+    class L_mrf linkNode;
+    class L_bypass linkNode;
+    class ThisNode thisNode;
+    class s_in slot;
+    class s_out slot;

--- a/pywr-schema/src/nodes/doc_diagrams/river-no-routing.mmd
+++ b/pywr-schema/src/nodes/doc_diagrams/river-no-routing.mmd
@@ -1,0 +1,25 @@
+graph LR
+    subgraph ThisNode["River"]
+
+        subgraph AG1["Aggregated node"]
+            L_net
+            O_loss
+        end
+
+        s_in@{ shape: small-circle, label: "Incoming slot" }
+        s_out@{ shape: framed-circle, label: "Outgoing slot" }
+
+        s_in --> L_net("[name].net") --> s_out
+        s_in --> O_loss("[name].loss")
+
+    end
+
+    U(Upstream) --> s_in
+    s_out --> D1(Downstream )
+
+    class O_loss outputNode;
+    class L_net linkNode;
+    class ThisNode thisNode;
+    class AG1 aggNode;
+    class s_in slot;
+    class s_out slot;

--- a/pywr-schema/src/nodes/doc_diagrams/river-split-with-gauge.mmd
+++ b/pywr-schema/src/nodes/doc_diagrams/river-split-with-gauge.mmd
@@ -1,0 +1,39 @@
+graph LR
+    subgraph ThisNode["RiverSplitWithGauge"]
+
+        subgraph AG0["Aggregated node 0"]
+            L_bypass("[name].bypass")
+            L_split_0("[name].split-0")
+        end
+
+
+        s_in@{ shape: small-circle, label: "Incoming slot" }
+        s_out@{ shape: framed-circle, label: "Outgoing slot" }
+
+        s_out_0@{ shape: framed-circle, label: "slot_name[0]" }
+        s_out_i@{ shape: framed-circle, label: "slot_name[i]" }
+
+        s_in --> L_mrf("[name].mrf") --> s_out
+        s_in --> L_bypass --> s_out
+        s_in --> L_split_0 --> s_out
+        L_split_0 --> s_out_0
+
+        s_in -.-> L_split_i("[name].split-i") -.-> s_out
+        L_split_i -.->s_out_i
+    end
+
+    U(Upstream) --> s_in
+    s_out -->|"River"| D1(Downstream 1)
+    s_out_0 -->|"slot_name[0]"| D2(Downstream 2)
+    s_out_i -.->|"slot_name[i]"| D3(Downstream 3)
+
+    class L_mrf linkNode;
+    class L_bypass linkNode;
+    class L_split_0 linkNode;
+    class L_split_i linkNode;
+    class ThisNode thisNode;
+    class AG0 aggNode
+    class s_in slot;
+    class s_out slot;
+    class s_out_0 slot;
+    class s_out_i slot;

--- a/pywr-schema/src/nodes/doc_diagrams/wtw.mmd
+++ b/pywr-schema/src/nodes/doc_diagrams/wtw.mmd
@@ -1,0 +1,26 @@
+graph LR
+    subgraph ThisNode["WaterTreatmentWorks"]
+
+        subgraph AG["Aggregated node"]
+                L_net("[name].net")
+                O_loss("[name].loss")
+        end
+
+        s_in@{ shape: sm-circ, label: "Incoming slot" } --> L_net("[name].net") --> L_smf
+        L_smf("[name].net_soft_min_flow") --> s_out@{ shape: framed-circle, label: "Outgoing slot" }
+        L_net --> L_asmf("[name].net_above_soft_min_flow") --> s_out
+        s_in --> O_loss("[name].loss")
+
+    end
+
+    U(Upstream) --> s_in
+    s_out --> D(Downstream)
+
+    class O_loss outputNode;
+    class L_net linkNode;
+    class L_asmf linkNode;
+    class L_smf linkNode;
+    class AG aggNode;
+    class ThisNode thisNode;
+    class s_in slot;
+    class s_out slot;

--- a/pywr-schema/src/nodes/loss_link.rs
+++ b/pywr-schema/src/nodes/loss_link.rs
@@ -8,7 +8,7 @@ use crate::nodes::{NodeAttribute, NodeComponent};
 use crate::nodes::{NodeMeta, NodeSlot};
 use crate::parameters::Parameter;
 use crate::v1::{ConversionData, TryFromV1, try_convert_node_attr};
-use crate::{node_attribute_subset_enum, node_component_subset_enum};
+use crate::{mermaid, node_attribute_subset_enum, node_component_subset_enum};
 #[cfg(feature = "core")]
 use pywr_core::{aggregated_node::Relationship, metric::MetricF64};
 use pywr_schema_macros::PywrVisitAll;
@@ -84,7 +84,6 @@ node_component_subset_enum! {
     }
 }
 
-#[doc = svgbobdoc::transform!(
 /// This is used to represent a link with losses.
 ///
 /// The loss is applied using a loss factor, [`LossFactor`], which can be applied to either the
@@ -93,23 +92,13 @@ node_component_subset_enum! {
 ///
 /// The default output metric for this node is the net flow.
 ///
-/// ```svgbob
-///
-///            <node>.net    D
-///          .------>L ---->*
-///      U  |
-///     -*--|
-///         |
-///          '------>O
-///            <node>.loss
-/// ```
+#[doc = mermaid!("doc_diagrams/loss-link.mmd")]
 ///
 /// # Available attributes and components
 ///
 /// The enums [`LossLinkNodeAttribute`] and [`LossLinkNodeComponent`] define the available
 /// attributes and components for this node.
 ///
-)]
 #[skip_serializing_none]
 #[derive(serde::Deserialize, serde::Serialize, Clone, Default, Debug, JsonSchema, PywrVisitAll)]
 #[serde(deny_unknown_fields)]

--- a/pywr-schema/src/nodes/piecewise_link.rs
+++ b/pywr-schema/src/nodes/piecewise_link.rs
@@ -8,7 +8,7 @@ use crate::nodes::{NodeAttribute, NodeComponent};
 use crate::nodes::{NodeMeta, NodeSlot};
 use crate::parameters::Parameter;
 use crate::v1::{ConversionData, TryFromV1, try_convert_node_attr};
-use crate::{node_attribute_subset_enum, node_component_subset_enum};
+use crate::{mermaid, node_attribute_subset_enum, node_component_subset_enum};
 #[cfg(feature = "core")]
 use pywr_core::metric::MetricF64;
 use pywr_schema_macros::PywrVisitAll;
@@ -40,33 +40,18 @@ node_component_subset_enum! {
     }
 }
 
-#[doc = svgbobdoc::transform!(
 /// This node is used to create a sequence of link nodes with separate costs and constraints.
 ///
 /// Typically this node is used to model an non-linear cost by providing increasing cost
 /// values at different flows limits.
 ///
-/// ```svgbob
-///
-///            <node>.00    D
-///          .------>L ---.
-///      U  |             |         D
-///     -*--|             |-------->*-
-///         |  <node>.01  |
-///          '------>L --'
-///         :             :
-///         :             :
-///         :  <node>.n   :
-///          '~~~~~~>L ~~'
-///
-/// ```
+#[doc = mermaid!("doc_diagrams/piecewise.mmd")]
 ///
 /// # Available attributes and components
 ///
 /// The enums [`PiecewiseLinkNodeAttribute`] and [`PiecewiseLinkNodeComponent`] define the available
 /// attributes and components for this node.
 ///
-)]
 #[skip_serializing_none]
 #[derive(serde::Deserialize, serde::Serialize, Clone, Default, Debug, JsonSchema, PywrVisitAll)]
 #[serde(deny_unknown_fields)]

--- a/pywr-schema/src/nodes/piecewise_storage.rs
+++ b/pywr-schema/src/nodes/piecewise_storage.rs
@@ -2,11 +2,11 @@ use crate::error::SchemaError;
 use crate::metric::Metric;
 #[cfg(feature = "core")]
 use crate::network::LoadArgs;
-use crate::node_attribute_subset_enum;
 #[cfg(feature = "core")]
 use crate::nodes::NodeAttribute;
 use crate::nodes::{NodeMeta, NodeSlot, StorageInitialVolume};
 use crate::parameters::Parameter;
+use crate::{mermaid, node_attribute_subset_enum};
 #[cfg(feature = "core")]
 use pywr_core::{
     derived_metric::DerivedMetric,
@@ -32,7 +32,6 @@ node_attribute_subset_enum! {
     }
 }
 
-#[doc = svgbobdoc::transform!(
 /// This node is used to create a series of storage nodes with separate costs.
 ///
 /// The series of storage nodes are created with bi-directional transfers to enable transfer
@@ -46,26 +45,13 @@ node_attribute_subset_enum! {
 ///
 /// Note that this node adds additional complexity to models over the standard storage node.
 ///
-/// ```svgbob
-///
-///            <node>.00            D
-///     -*---------->S ----------->*-
-///      U           ^
-///                  |
-///                  v
-///       <node>.01  S
-///                  ^
-///                  :
-///                  v
-///      <node>.n    S
-/// ```
+#[doc = mermaid!("doc_diagrams/piecewise-storage.mmd")]
 ///
 /// # Available attributes and components
 ///
 /// The enum [`PiecewiseStorageNodeAttribute`] defines the available attributes. There are no components
 /// to choose from.
 ///
-)]
 #[skip_serializing_none]
 #[derive(serde::Deserialize, serde::Serialize, Clone, Default, Debug, JsonSchema, PywrVisitAll)]
 #[serde(deny_unknown_fields)]

--- a/pywr-schema/src/nodes/reservoir.rs
+++ b/pywr-schema/src/nodes/reservoir.rs
@@ -1,4 +1,3 @@
-use crate::SchemaError;
 use crate::metric::Metric;
 #[cfg(feature = "core")]
 use crate::network::LoadArgs;
@@ -6,6 +5,7 @@ use crate::network::LoadArgs;
 use crate::nodes::{NodeAttribute, NodeComponent};
 use crate::nodes::{NodeMeta, NodeSlot, StorageNode, StorageNodeAttribute};
 use crate::parameters::ConstantFloatVec;
+use crate::{SchemaError, mermaid};
 use crate::{node_attribute_subset_enum, node_component_subset_enum};
 #[cfg(feature = "core")]
 use pywr_core::agg_funcs::AggFuncF64;
@@ -154,33 +154,10 @@ impl TryFrom<NodeSlot> for ReservoirOutputNodeSlot {
 /// A reservoir node with compensation, leakage, direct rainfall and evaporation.
 ///
 /// # Implementation
-#[doc = svgbobdoc::transform!(
-/// ```svgbob
 ///
-///             <Reservoir>.Rainfall
-///                      *
-///     U                |            if OutputNode                if LinkNode
-/// - - *--.             |                                         D[from_spill]
-///        |             |           <Reservoir>.Spill   - or -     <Reservoir>.Spill
-///        V             V             D[to_spill]                 D[to_spill]
-///        .----------------+----------------->o               --------->*- - -
-///        |                |
-///        |  StorageNode   |
-///        |                |-------------->o   <Reservoir>.Evaporation
-///        +-------------+--+---------------------------.
-///        |             |                              |
-///        |             +--------->*- -                +------>o  <Reservoir>.Leakage
-///        |               <Reservoir>.Compensation
-///        |                   D[compensation]
-///        +---->*- - -
-///             D[<default>]
-///
-/// ```
-)]
-///
-/// This is a [`StorageNode`] connected to an upstream node `U` and downstream network node `D`. When
+/// This is a [`StorageNode`] connected to an upstream node `Upstream` and downstream network node `D`. When
 /// an edge to this component is created without slots, the target nodes are directly connected to
-/// `D[<default>]`.
+/// `Downstream 1` via the "Storage" slot.
 ///
 /// This component has the following internal nodes, which the modeller still needs to connect to
 /// other network nodes using slots:
@@ -200,6 +177,12 @@ impl TryFrom<NodeSlot> for ReservoirOutputNodeSlot {
 ///   the node's behaviour.
 /// - Leakage: this is an optional [`pywr_core::node::OutputNode`] with a `max_flow` equal to the
 ///   provided [`Metric`]'s value.
+///
+/// The internal layout when configured with a `LinkNode` spill:
+#[doc = mermaid!("doc_diagrams/reservoir-spill-link.mmd")]
+///
+/// The internal layout when configured with an `OutputNode` spill:
+#[doc = mermaid!("doc_diagrams/reservoir-spill-output.mmd")]
 ///
 /// ## Rainfall and evaporation calculation
 /// The rainfall and evaporation volumes are calculated by multiplying the reservoir current
@@ -231,12 +214,15 @@ impl TryFrom<NodeSlot> for ReservoirOutputNodeSlot {
 ///
 /// # JSON Examples
 /// ## Reservoir with output spill
+///
+///
 /// ```json
 #[doc = include_str!("../../tests/reservoir_with_spill1.json")]
 /// ```
 ///
 /// ## Reservoir with link spill
 /// The compensation goes into the spill which routes water to the "River termination" node.
+///
 /// ```json
 #[doc = include_str!("../../tests/reservoir_with_river1.json")]
 /// ```

--- a/pywr-schema/src/nodes/river.rs
+++ b/pywr-schema/src/nodes/river.rs
@@ -7,7 +7,7 @@ use crate::nodes::{LossFactor, NodeMeta, NodeSlot};
 #[cfg(feature = "core")]
 use crate::nodes::{NodeAttribute, NodeComponent};
 use crate::parameters::{ConstantValue, Parameter};
-use crate::{node_attribute_subset_enum, node_component_subset_enum};
+use crate::{mermaid, node_attribute_subset_enum, node_component_subset_enum};
 #[cfg(feature = "core")]
 use pywr_core::{
     aggregated_node::Relationship,
@@ -76,49 +76,22 @@ pub enum RoutingMethod {
 #[skip_serializing_none]
 #[derive(serde::Deserialize, serde::Serialize, Clone, Default, Debug, JsonSchema, PywrVisitAll)]
 #[serde(deny_unknown_fields)]
-#[doc = svgbobdoc::transform!(
 /// A link node representing a river with an optional proportional loss and routing method.
 ///
 /// With no routing method or loss this is simply a link node. With only a loss factor it
 /// creates a link node with an output node to represent the loss:
 ///
-/// ```svgbob
-///
-///             <RiverNode>.net    D
-///          .-------->L---------->*
-///      U  |
-///     -*--|
-///         !
-///         '-.-.-.-.->O
-///               <RiverNode>.loss
-///
-/// ```
+#[doc = mermaid!("doc_diagrams/river-no-routing.mmd")]
 ///
 /// With only a routing method it creates an input and output node with an aggregated node
 /// to represent the routing:
 ///
-/// ```svgbob
-///
-///
-///      U                D
-///     -*---> O    I --->*
-///
-/// ```
+#[doc = mermaid!("doc_diagrams/river-delay.mmd")]
 ///
 /// With both a loss factor and routing method it creates a link node, output node, input node
 /// and two aggregated nodes to represent the loss and routing:
 ///
-/// ```svgbob
-///
-///                            <RiverNode>.net    D
-///                         .-------->L---------->*
-///      U                  |
-///     -*---> O    I --->*-|
-///                         !
-///                         '-.-.-.-.->O
-///                                 <RiverNode>.loss
-///
-/// ```
+#[doc = mermaid!("doc_diagrams/river-delay-with-loss.mmd")]
 ///
 /// # Routing methods
 ///
@@ -134,7 +107,6 @@ pub enum RoutingMethod {
 /// The enums [`RiverNodeAttribute`] and [`RiverNodeComponent`] define the available
 /// attributes and components for this node.
 ///
-)]
 pub struct RiverNode {
     pub meta: NodeMeta,
     /// Optional local parameters.

--- a/pywr-schema/src/nodes/river_gauge.rs
+++ b/pywr-schema/src/nodes/river_gauge.rs
@@ -8,7 +8,7 @@ use crate::nodes::{NodeAttribute, NodeComponent};
 use crate::nodes::{NodeMeta, NodeSlot};
 use crate::parameters::Parameter;
 use crate::v1::{ConversionData, TryFromV1, try_convert_node_attr};
-use crate::{node_attribute_subset_enum, node_component_subset_enum};
+use crate::{mermaid, node_attribute_subset_enum, node_component_subset_enum};
 #[cfg(feature = "core")]
 use pywr_core::metric::MetricF64;
 use pywr_schema_macros::PywrVisitAll;
@@ -32,26 +32,16 @@ node_component_subset_enum! {
     }
 }
 
-#[doc = svgbobdoc::transform!(
 /// This is used to represent a minimum residual flow (MRF) at a gauging station.
 ///
 ///
-/// ```svgbob
-///            <node>.mrf
-///          .------>L -----.
-///      U  |                |     D
-///     -*--|                |--->*- - -
-///         |                |
-///          '------>L -----'
-///            <node>.bypass
-/// ```
+#[doc = mermaid!("doc_diagrams/river-gauge.mmd")]
 ///
 /// # Available attributes and components
 ///
 /// The enums [`RiverGaugeNodeAttribute`] and [`RiverGaugeNodeComponent`] define the available
 /// attributes and components for this node.
 ///
-)]
 #[skip_serializing_none]
 #[derive(serde::Deserialize, serde::Serialize, Clone, Default, Debug, JsonSchema, PywrVisitAll)]
 #[serde(deny_unknown_fields)]

--- a/pywr-schema/src/nodes/river_split_with_gauge.rs
+++ b/pywr-schema/src/nodes/river_split_with_gauge.rs
@@ -9,7 +9,7 @@ use crate::nodes::{NodeAttribute, NodeComponent};
 use crate::nodes::{NodeMeta, NodeSlot};
 use crate::parameters::Parameter;
 use crate::v1::{ConversionData, TryFromV1, try_convert_node_attr};
-use crate::{ConversionError, TryIntoV2, node_attribute_subset_enum, node_component_subset_enum};
+use crate::{ConversionError, TryIntoV2, mermaid, node_attribute_subset_enum, node_component_subset_enum};
 #[cfg(feature = "core")]
 use pywr_core::{aggregated_node::Relationship, metric::MetricF64, node::NodeIndex};
 use pywr_schema_macros::PywrVisitAll;
@@ -71,7 +71,6 @@ impl TryFrom<NodeSlot> for RiverSplitWithGaugeOutputNodeSlot {
     }
 }
 
-#[doc = svgbobdoc::transform!(
 /// A node used to represent a proportional split above a minimum residual flow (MRF) at a gauging station.
 ///
 /// The maximum flow along each split is controlled by a factor. Internally an aggregated node
@@ -81,29 +80,13 @@ impl TryFrom<NodeSlot> for RiverSplitWithGaugeOutputNodeSlot {
 /// Here the split factors are defined as a proportion of the flow not going via the mrf route.
 /// Whereas in Pywr v1.x the factors are defined as ratios.
 ///
-/// ```svgbob
-///           <node>.mrf
-///          .------>L -----.
-///      U  | <node>.bypass  |     D[<default>]
-///     -*--|------->L ------|--->*- - -
-///         | <node>.split-0 |
-///          '------>L -----'
-///                  |             D[slot_name_0]
-///                   '---------->*- - -
-///
-///         |                |
-///         | <node>.split-i |
-///          '------>L -----'
-///                  |             D[slot_name_i]
-///                   '---------->*- - -
-/// ```
+#[doc = mermaid!("doc_diagrams/river-split-with-gauge.mmd")]
 ///
 /// # Available attributes and components
 ///
 /// The enums [`RiverSplitWithGaugeNodeAttribute`] and [`RiverSplitWithGaugeNodeComponent`] define the available
 /// attributes and components for this node.
 ///
-)]
 #[skip_serializing_none]
 #[derive(serde::Deserialize, serde::Serialize, Clone, Default, Debug, JsonSchema, PywrVisitAll)]
 #[serde(deny_unknown_fields)]

--- a/pywr-schema/src/nodes/water_treatment_works.rs
+++ b/pywr-schema/src/nodes/water_treatment_works.rs
@@ -7,7 +7,7 @@ use crate::nodes::loss_link::LossFactor;
 use crate::nodes::{NodeAttribute, NodeComponent};
 use crate::nodes::{NodeMeta, NodeSlot};
 use crate::parameters::Parameter;
-use crate::{node_attribute_subset_enum, node_component_subset_enum};
+use crate::{mermaid, node_attribute_subset_enum, node_component_subset_enum};
 #[cfg(feature = "core")]
 use pywr_core::metric::MetricF64;
 use pywr_schema_macros::{PywrVisitAll, skip_serializing_none};
@@ -31,7 +31,6 @@ node_component_subset_enum! {
     }
 }
 
-#[doc = svgbobdoc::transform!(
 /// A node used to represent a water treatment works (WTW) with optional losses.
 ///
 /// This node comprises an internal structure that allows specifying a minimum and
@@ -43,24 +42,13 @@ node_component_subset_enum! {
 /// nodes are created.
 ///
 ///
-/// ```svgbob
-///                          <node>.net_soft_min_flow
-///                           .--->L ---.
-///            <node>.net    |           |     D
-///          .------>L ------|           |--->*- - -
-///      U  |                |           |
-///     -*--|                 '--->L ---'
-///         |                <node>.net_above_soft_min_flow
-///          '------>O
-///            <node>.loss
-/// ```
+#[doc = mermaid!("doc_diagrams/wtw.mmd")]
 ///
 /// # Available attributes and components
 ///
 /// The enums [`WaterTreatmentWorksNodeAttribute`] and [`WaterTreatmentWorksNodeComponent`] define the available
 /// attributes and components for this node.
 ///
-)]
 #[skip_serializing_none]
 #[derive(serde::Deserialize, serde::Serialize, Clone, Default, Debug, JsonSchema, PywrVisitAll)]
 #[serde(deny_unknown_fields)]


### PR DESCRIPTION
Removes the dependency on `svgbobdoc` and its whole tree. Include a simple diagram for embedding mermaid.js diagrams into the documentation.

Fixes #548.