### PR TITLE
perf: Box ComponentConversionError when returned as an error.

### DIFF
--- a/pywr-schema/src/error.rs
+++ b/pywr-schema/src/error.rs
@@ -146,7 +146,6 @@ impl TryFrom<SchemaError> for PyErr {
 
 #[derive(Error, Debug, PartialEq, Eq, Clone)]
 #[cfg_attr(feature = "pyo3", pyclass)]
-#[allow(clippy::large_enum_variant)]
 pub enum ComponentConversionError {
     #[error("Failed to convert `{attr}` on node `{name}`: {error}")]
     Node {

--- a/pywr-schema/src/metric.rs
+++ b/pywr-schema/src/metric.rs
@@ -253,16 +253,15 @@ impl TryFromV1<ParameterValueV1> for Metric {
                 // Inline parameters are converted to either a parameter or a timeseries
                 // The actual component is extracted into the conversion data leaving a reference
                 // to the component in the metric.
-                let definition: ParameterOrTimeseriesRef =
-                    (*param)
-                        .try_into_v2(parent_node, conversion_data)
-                        .map_err(|e| match e {
-                            ComponentConversionError::Parameter { error, .. } => error,
-                            ComponentConversionError::Node { error, .. } => error,
-                            ComponentConversionError::Scenarios { error } => error,
-                            ComponentConversionError::Table { error, .. } => error,
-                            ComponentConversionError::Edge { error, .. } => error,
-                        })?;
+                let definition: ParameterOrTimeseriesRef = (*param).try_into_v2(parent_node, conversion_data).map_err(
+                    |e: Box<ComponentConversionError>| match *e {
+                        ComponentConversionError::Parameter { error, .. } => error,
+                        ComponentConversionError::Node { error, .. } => error,
+                        ComponentConversionError::Scenarios { error } => error,
+                        ComponentConversionError::Table { error, .. } => error,
+                        ComponentConversionError::Edge { error, .. } => error,
+                    },
+                )?;
                 match definition {
                     ParameterOrTimeseriesRef::Parameter(p) => {
                         let reference = ParameterReference {
@@ -731,16 +730,15 @@ impl TryFromV1<ParameterValueV1> for IndexMetric {
                 // Inline parameters are converted to either a parameter or a timeseries
                 // The actual component is extracted into the conversion data leaving a reference
                 // to the component in the metric.
-                let definition: ParameterOrTimeseriesRef =
-                    (*param)
-                        .try_into_v2(parent_node, conversion_data)
-                        .map_err(|e| match e {
-                            ComponentConversionError::Parameter { error, .. } => error,
-                            ComponentConversionError::Node { error, .. } => error,
-                            ComponentConversionError::Scenarios { error } => error,
-                            ComponentConversionError::Table { error, .. } => error,
-                            ComponentConversionError::Edge { error, .. } => error,
-                        })?;
+                let definition: ParameterOrTimeseriesRef = (*param).try_into_v2(parent_node, conversion_data).map_err(
+                    |e: Box<ComponentConversionError>| match *e {
+                        ComponentConversionError::Parameter { error, .. } => error,
+                        ComponentConversionError::Node { error, .. } => error,
+                        ComponentConversionError::Scenarios { error } => error,
+                        ComponentConversionError::Table { error, .. } => error,
+                        ComponentConversionError::Edge { error, .. } => error,
+                    },
+                )?;
                 match definition {
                     ParameterOrTimeseriesRef::Parameter(p) => {
                         let reference = ParameterReference {

--- a/pywr-schema/src/network.rs
+++ b/pywr-schema/src/network.rs
@@ -299,7 +299,7 @@ impl NetworkSchema {
                         NodeOrVirtualNode::Virtual(vn) => virtual_nodes.push(*vn),
                     },
                     Err(e) => {
-                        errors.push(e);
+                        errors.push(*e);
                     }
                 }
             }
@@ -340,7 +340,7 @@ impl NetworkSchema {
                         ParameterOrTimeseriesRef::Parameter(p) => parameters.push(*p),
                         ParameterOrTimeseriesRef::Timeseries(t) => timeseries_refs.push(t),
                     },
-                    Err(e) => errors.push(e),
+                    Err(e) => errors.push(*e),
                 }
             }
         }

--- a/pywr-schema/src/nodes/core.rs
+++ b/pywr-schema/src/nodes/core.rs
@@ -172,7 +172,7 @@ impl InputNode {
 }
 
 impl TryFromV1<InputNodeV1> for InputNode {
-    type Error = ComponentConversionError;
+    type Error = Box<ComponentConversionError>;
 
     fn try_from_v1(
         v1: InputNodeV1,
@@ -720,7 +720,7 @@ impl LinkNode {
 }
 
 impl TryFromV1<LinkNodeV1> for LinkNode {
-    type Error = ComponentConversionError;
+    type Error = Box<ComponentConversionError>;
 
     fn try_from_v1(
         v1: LinkNodeV1,
@@ -750,7 +750,7 @@ impl TryFromV1<LinkNodeV1> for LinkNode {
 }
 
 impl TryFromV1<BreakLinkNodeV1> for LinkNode {
-    type Error = ComponentConversionError;
+    type Error = Box<ComponentConversionError>;
 
     fn try_from_v1(
         v1: BreakLinkNodeV1,
@@ -929,7 +929,7 @@ impl OutputNode {
 }
 
 impl TryFromV1<OutputNodeV1> for OutputNode {
-    type Error = ComponentConversionError;
+    type Error = Box<ComponentConversionError>;
 
     fn try_from_v1(
         v1: OutputNodeV1,
@@ -1127,7 +1127,7 @@ impl StorageNode {
 }
 
 impl TryFromV1<StorageNodeV1> for StorageNode {
-    type Error = ComponentConversionError;
+    type Error = Box<ComponentConversionError>;
 
     fn try_from_v1(
         v1: StorageNodeV1,
@@ -1156,7 +1156,7 @@ impl TryFromV1<StorageNodeV1> for StorageNode {
 }
 
 impl TryFromV1<ReservoirNodeV1> for StorageNode {
-    type Error = ComponentConversionError;
+    type Error = Box<ComponentConversionError>;
 
     fn try_from_v1(
         v1: ReservoirNodeV1,
@@ -1330,7 +1330,7 @@ impl CatchmentNode {
 }
 
 impl TryFromV1<CatchmentNodeV1> for CatchmentNode {
-    type Error = ComponentConversionError;
+    type Error = Box<ComponentConversionError>;
 
     fn try_from_v1(
         v1: CatchmentNodeV1,

--- a/pywr-schema/src/nodes/delay.rs
+++ b/pywr-schema/src/nodes/delay.rs
@@ -213,7 +213,7 @@ impl DelayNode {
 }
 
 impl TryFrom<DelayNodeV1> for DelayNode {
-    type Error = ComponentConversionError;
+    type Error = Box<ComponentConversionError>;
 
     fn try_from(v1: DelayNodeV1) -> Result<Self, Self::Error> {
         let meta: NodeMeta = v1.meta.into();
@@ -224,13 +224,13 @@ impl TryFrom<DelayNodeV1> for DelayNode {
             None => match v1.timesteps {
                 Some(ts) => ts,
                 None => {
-                    return Err(ComponentConversionError::Node {
+                    return Err(Box::new(ComponentConversionError::Node {
                         name: meta.name,
                         attr: "delay".to_string(),
                         error: ConversionError::MissingAttribute {
                             attrs: vec!["days".to_string(), "timesteps".to_string()],
                         },
-                    });
+                    }));
                 }
             },
         } as u64;

--- a/pywr-schema/src/nodes/loss_link.rs
+++ b/pywr-schema/src/nodes/loss_link.rs
@@ -348,7 +348,7 @@ impl LossLinkNode {
 }
 
 impl TryFromV1<LossLinkNodeV1> for LossLinkNode {
-    type Error = ComponentConversionError;
+    type Error = Box<ComponentConversionError>;
 
     fn try_from_v1(
         v1: LossLinkNodeV1,

--- a/pywr-schema/src/nodes/mod.rs
+++ b/pywr-schema/src/nodes/mod.rs
@@ -662,7 +662,7 @@ impl Node {
 }
 
 impl TryFromV1<NodeV1> for NodeOrVirtualNode {
-    type Error = ComponentConversionError;
+    type Error = Box<ComponentConversionError>;
 
     fn try_from_v1(
         v1: NodeV1,
@@ -674,11 +674,11 @@ impl TryFromV1<NodeV1> for NodeOrVirtualNode {
                 let nv2: Self = n.try_into_v2(parent_node, conversion_data)?;
                 Ok(nv2)
             }
-            NodeV1::Custom(n) => Err(ComponentConversionError::Node {
+            NodeV1::Custom(n) => Err(Box::new(ComponentConversionError::Node {
                 name: n.meta.name,
                 attr: "".to_string(),
                 error: ConversionError::CustomTypeNotSupported { ty: n.ty },
-            }),
+            })),
         }
     }
 }
@@ -711,7 +711,7 @@ impl From<VirtualNode> for NodeOrVirtualNode {
 }
 
 impl TryFromV1<Box<CoreNodeV1>> for NodeOrVirtualNode {
-    type Error = ComponentConversionError;
+    type Error = Box<ComponentConversionError>;
 
     fn try_from_v1(
         v1: Box<CoreNodeV1>,

--- a/pywr-schema/src/nodes/piecewise_link.rs
+++ b/pywr-schema/src/nodes/piecewise_link.rs
@@ -224,7 +224,7 @@ impl PiecewiseLinkNode {
 }
 
 impl TryFromV1<PiecewiseLinkNodeV1> for PiecewiseLinkNode {
-    type Error = ComponentConversionError;
+    type Error = Box<ComponentConversionError>;
 
     fn try_from_v1(
         v1: PiecewiseLinkNodeV1,

--- a/pywr-schema/src/nodes/river.rs
+++ b/pywr-schema/src/nodes/river.rs
@@ -524,37 +524,37 @@ impl RiverNode {
 }
 
 impl TryFrom<LinkNodeV1> for RiverNode {
-    type Error = ComponentConversionError;
+    type Error = Box<ComponentConversionError>;
 
     fn try_from(v1: LinkNodeV1) -> Result<Self, Self::Error> {
         let meta: NodeMeta = v1.meta.into();
 
         if v1.max_flow.is_some() {
-            return Err(ComponentConversionError::Node {
+            return Err(Box::new(ComponentConversionError::Node {
                 name: meta.name,
                 attr: "max_flow".to_string(),
                 error: ConversionError::ExtraAttribute {
                     attr: "max_flow".to_string(),
                 },
-            });
+            }));
         }
         if v1.min_flow.is_some() {
-            return Err(ComponentConversionError::Node {
+            return Err(Box::new(ComponentConversionError::Node {
                 name: meta.name,
                 attr: "min_flow".to_string(),
                 error: ConversionError::ExtraAttribute {
                     attr: "min_flow".to_string(),
                 },
-            });
+            }));
         }
         if v1.cost.is_some() {
-            return Err(ComponentConversionError::Node {
+            return Err(Box::new(ComponentConversionError::Node {
                 name: meta.name,
                 attr: "cost".to_string(),
                 error: ConversionError::ExtraAttribute {
                     attr: "cost".to_string(),
                 },
-            });
+            }));
         }
 
         let n = Self {

--- a/pywr-schema/src/nodes/river_gauge.rs
+++ b/pywr-schema/src/nodes/river_gauge.rs
@@ -212,7 +212,7 @@ impl RiverGaugeNode {
 }
 
 impl TryFromV1<RiverGaugeNodeV1> for RiverGaugeNode {
-    type Error = ComponentConversionError;
+    type Error = Box<ComponentConversionError>;
 
     fn try_from_v1(
         v1: RiverGaugeNodeV1,

--- a/pywr-schema/src/nodes/river_split_with_gauge.rs
+++ b/pywr-schema/src/nodes/river_split_with_gauge.rs
@@ -380,7 +380,7 @@ impl RiverSplitWithGaugeNode {
 }
 
 impl TryFromV1<RiverSplitWithGaugeNodeV1> for RiverSplitWithGaugeNode {
-    type Error = ComponentConversionError;
+    type Error = Box<ComponentConversionError>;
 
     fn try_from_v1(
         v1: RiverSplitWithGaugeNodeV1,

--- a/pywr-schema/src/nodes/virtual_nodes/aggregated.rs
+++ b/pywr-schema/src/nodes/virtual_nodes/aggregated.rs
@@ -240,7 +240,7 @@ impl AggregatedNode {
 }
 
 impl TryFromV1<AggregatedNodeV1> for AggregatedNode {
-    type Error = ComponentConversionError;
+    type Error = Box<ComponentConversionError>;
 
     fn try_from_v1(
         v1: AggregatedNodeV1,

--- a/pywr-schema/src/nodes/virtual_nodes/virtual_storage.rs
+++ b/pywr-schema/src/nodes/virtual_nodes/virtual_storage.rs
@@ -351,7 +351,7 @@ impl VirtualStorageNode {
 }
 
 impl TryFromV1<VirtualStorageNodeV1> for VirtualStorageNode {
-    type Error = ComponentConversionError;
+    type Error = Box<ComponentConversionError>;
 
     fn try_from_v1(
         v1: VirtualStorageNodeV1,
@@ -387,7 +387,7 @@ impl TryFromV1<VirtualStorageNodeV1> for VirtualStorageNode {
 }
 
 impl TryFromV1<AnnualVirtualStorageNodeV1> for VirtualStorageNode {
-    type Error = ComponentConversionError;
+    type Error = Box<ComponentConversionError>;
 
     fn try_from_v1(
         v1: AnnualVirtualStorageNodeV1,
@@ -432,7 +432,7 @@ impl TryFromV1<AnnualVirtualStorageNodeV1> for VirtualStorageNode {
 }
 
 impl TryFromV1<MonthlyVirtualStorageNodeV1> for VirtualStorageNode {
-    type Error = ComponentConversionError;
+    type Error = Box<ComponentConversionError>;
 
     fn try_from_v1(
         v1: MonthlyVirtualStorageNodeV1,
@@ -474,7 +474,7 @@ impl TryFromV1<MonthlyVirtualStorageNodeV1> for VirtualStorageNode {
 }
 
 impl TryFromV1<RollingVirtualStorageNodeV1> for VirtualStorageNode {
-    type Error = ComponentConversionError;
+    type Error = Box<ComponentConversionError>;
 
     fn try_from_v1(
         v1: RollingVirtualStorageNodeV1,
@@ -494,34 +494,34 @@ impl TryFromV1<RollingVirtualStorageNodeV1> for VirtualStorageNode {
             if let Some(days) = NonZeroUsize::new(days as usize) {
                 RollingWindow::Days { days }
             } else {
-                return Err(ComponentConversionError::Node {
+                return Err(Box::new(ComponentConversionError::Node {
                     name: meta.name.clone(),
                     attr: "window".to_string(),
                     error: ConversionError::UnsupportedFeature {
                         feature: "Rolling window with zero `days` is not supported".to_string(),
                     },
-                });
+                }));
             }
         } else if let Some(timesteps) = v1.timesteps {
             if let Some(timesteps) = NonZeroUsize::new(timesteps as usize) {
                 RollingWindow::Timesteps { timesteps }
             } else {
-                return Err(ComponentConversionError::Node {
+                return Err(Box::new(ComponentConversionError::Node {
                     name: meta.name.clone(),
                     attr: "window".to_string(),
                     error: ConversionError::UnsupportedFeature {
                         feature: "Rolling window with zero `timesteps` is not supported".to_string(),
                     },
-                });
+                }));
             }
         } else {
-            return Err(ComponentConversionError::Node {
+            return Err(Box::new(ComponentConversionError::Node {
                 name: meta.name.clone(),
                 attr: "window".to_string(),
                 error: ConversionError::MissingAttribute {
                     attrs: vec!["days".to_string(), "timesteps".to_string()],
                 },
-            });
+            }));
         };
 
         let nodes = v1.nodes.into_iter().map(|n| n.into()).collect();
@@ -544,7 +544,7 @@ impl TryFromV1<RollingVirtualStorageNodeV1> for VirtualStorageNode {
 }
 
 impl TryFromV1<SeasonalVirtualStorageNodeV1> for VirtualStorageNode {
-    type Error = ComponentConversionError;
+    type Error = Box<ComponentConversionError>;
 
     fn try_from_v1(
         v1: SeasonalVirtualStorageNodeV1,

--- a/pywr-schema/src/parameters/aggregated.rs
+++ b/pywr-schema/src/parameters/aggregated.rs
@@ -72,7 +72,7 @@ impl AggregatedParameter {
 }
 
 impl TryFromV1<AggregatedParameterV1> for AggregatedParameter {
-    type Error = ComponentConversionError;
+    type Error = Box<ComponentConversionError>;
 
     fn try_from_v1(
         v1: AggregatedParameterV1,
@@ -144,7 +144,7 @@ impl AggregatedIndexParameter {
 }
 
 impl TryFromV1<AggregatedIndexParameterV1> for AggregatedIndexParameter {
-    type Error = ComponentConversionError;
+    type Error = Box<ComponentConversionError>;
 
     fn try_from_v1(
         v1: AggregatedIndexParameterV1,

--- a/pywr-schema/src/parameters/asymmetric_switch.rs
+++ b/pywr-schema/src/parameters/asymmetric_switch.rs
@@ -43,7 +43,7 @@ impl AsymmetricSwitchIndexParameter {
 }
 
 impl TryFromV1<AsymmetricSwitchIndexParameterV1> for AsymmetricSwitchIndexParameter {
-    type Error = ComponentConversionError;
+    type Error = Box<ComponentConversionError>;
 
     fn try_from_v1(
         v1: AsymmetricSwitchIndexParameterV1,

--- a/pywr-schema/src/parameters/control_curves.rs
+++ b/pywr-schema/src/parameters/control_curves.rs
@@ -61,7 +61,7 @@ impl ControlCurveInterpolatedParameter {
 }
 
 impl TryFromV1<ControlCurveInterpolatedParameterV1> for ControlCurveInterpolatedParameter {
-    type Error = ComponentConversionError;
+    type Error = Box<ComponentConversionError>;
 
     fn try_from_v1(
         v1: ControlCurveInterpolatedParameterV1,
@@ -81,22 +81,22 @@ impl TryFromV1<ControlCurveInterpolatedParameterV1> for ControlCurveInterpolated
         // Handle the case where neither or both "values" and "parameters" are defined.
         let values = match (v1.values, v1.parameters) {
             (None, None) => {
-                return Err(ComponentConversionError::Parameter {
+                return Err(Box::new(ComponentConversionError::Parameter {
                     name: meta.name,
                     attr: "control_curves".to_string(),
                     error: ConversionError::MissingAttribute {
                         attrs: vec!["values".to_string(), "parameters".to_string()],
                     },
-                });
+                }));
             }
             (Some(_), Some(_)) => {
-                return Err(ComponentConversionError::Parameter {
+                return Err(Box::new(ComponentConversionError::Parameter {
                     name: meta.name,
                     attr: "control_curves".to_string(),
                     error: ConversionError::UnexpectedAttribute {
                         attrs: vec!["values".to_string(), "parameters".to_string()],
                     },
-                });
+                }));
             }
             (Some(values), None) => values.into_iter().map(Metric::from).collect(),
             (None, Some(parameters)) => parameters
@@ -164,7 +164,7 @@ impl ControlCurveIndexParameter {
 }
 
 impl TryFromV1<ControlCurveIndexParameterV1> for ControlCurveIndexParameter {
-    type Error = ComponentConversionError;
+    type Error = Box<ComponentConversionError>;
 
     fn try_from_v1(
         v1: ControlCurveIndexParameterV1,
@@ -206,7 +206,7 @@ impl TryFromV1<ControlCurveIndexParameterV1> for ControlCurveIndexParameter {
 /// Pywr v1.x ControlCurveParameter can be an index parameter if it is not given "values"
 /// or "parameters" keys.
 impl TryFromV1<ControlCurveParameterV1> for ControlCurveIndexParameter {
-    type Error = ComponentConversionError;
+    type Error = Box<ComponentConversionError>;
 
     fn try_from_v1(
         v1: ControlCurveParameterV1,
@@ -224,13 +224,13 @@ impl TryFromV1<ControlCurveParameterV1> for ControlCurveIndexParameter {
         )?;
 
         if v1.values.is_some() || v1.parameters.is_some() {
-            return Err(ComponentConversionError::Parameter {
+            return Err(Box::new(ComponentConversionError::Parameter {
                 name: meta.name,
                 attr: "values".to_string(),
                 error: ConversionError::UnexpectedAttribute {
                     attrs: vec!["values".to_string(), "parameters".to_string()],
                 },
-            });
+            }));
         };
 
         // v1 uses proportional volume for control curves
@@ -290,7 +290,7 @@ impl ControlCurveParameter {
 }
 
 impl TryFromV1<ControlCurveParameterV1> for ControlCurveParameter {
-    type Error = ComponentConversionError;
+    type Error = Box<ComponentConversionError>;
 
     fn try_from_v1(
         v1: ControlCurveParameterV1,
@@ -315,13 +315,13 @@ impl TryFromV1<ControlCurveParameterV1> for ControlCurveParameter {
                 .map(|p| try_convert_parameter_attr(&meta.name, "parameters", p, parent_node, conversion_data))
                 .collect::<Result<Vec<_>, _>>()?
         } else {
-            return Err(ComponentConversionError::Parameter {
+            return Err(Box::new(ComponentConversionError::Parameter {
                 name: meta.name,
                 attr: "values".to_string(),
                 error: ConversionError::MissingAttribute {
                     attrs: vec!["values".to_string(), "parameters".to_string()],
                 },
-            });
+            }));
         };
 
         // v1 uses proportional volume for control curves
@@ -395,7 +395,7 @@ impl ControlCurvePiecewiseInterpolatedParameter {
 }
 
 impl TryFromV1<ControlCurvePiecewiseInterpolatedParameterV1> for ControlCurvePiecewiseInterpolatedParameter {
-    type Error = ComponentConversionError;
+    type Error = Box<ComponentConversionError>;
 
     fn try_from_v1(
         v1: ControlCurvePiecewiseInterpolatedParameterV1,

--- a/pywr-schema/src/parameters/core.rs
+++ b/pywr-schema/src/parameters/core.rs
@@ -5,14 +5,15 @@ use crate::metric::Metric;
 #[cfg(feature = "core")]
 use crate::network::LoadArgs;
 use crate::parameters::{ConstantFloatVec, ConstantValue, ConversionData, ParameterMeta};
-use crate::v1::{try_convert_parameter_attr, try_convert_values, IntoV2, TryFromV1};
+use crate::v1::{IntoV2, TryFromV1, try_convert_parameter_attr, try_convert_values};
 #[cfg(feature = "core")]
 use pywr_core::parameters::{ParameterIndex, ParameterName};
 use pywr_schema_macros::{PywrVisitAll, skip_serializing_none};
 use pywr_v1_schema::parameters::{
-    ConstantParameter as ConstantParameterV1, ConstantScenarioParameter as ConstantScenarioParameterV1, DivisionParameter as DivisionParameterV1, MaxParameter as MaxParameterV1,
-    MinParameter as MinParameterV1, NegativeMaxParameter as NegativeMaxParameterV1,
-    NegativeMinParameter as NegativeMinParameterV1, NegativeParameter as NegativeParameterV1,
+    ConstantParameter as ConstantParameterV1, ConstantScenarioParameter as ConstantScenarioParameterV1,
+    DivisionParameter as DivisionParameterV1, MaxParameter as MaxParameterV1, MinParameter as MinParameterV1,
+    NegativeMaxParameter as NegativeMaxParameterV1, NegativeMinParameter as NegativeMinParameterV1,
+    NegativeParameter as NegativeParameterV1,
 };
 use schemars::JsonSchema;
 use strum_macros::{Display, EnumDiscriminants, EnumIter, EnumString, IntoStaticStr};
@@ -183,7 +184,7 @@ impl ConstantParameter {
 }
 
 impl TryFromV1<ConstantParameterV1> for ConstantParameter {
-    type Error = ComponentConversionError;
+    type Error = Box<ComponentConversionError>;
 
     fn try_from_v1(
         v1: ConstantParameterV1,
@@ -213,7 +214,6 @@ impl TryFromV1<ConstantParameterV1> for ConstantParameter {
     }
 }
 
-
 /// A constant scenario parameter.
 ///
 /// A parameter that provides a constant value for each scenario in a scenario group.
@@ -221,7 +221,6 @@ impl TryFromV1<ConstantParameterV1> for ConstantParameter {
 #[derive(serde::Deserialize, serde::Serialize, Debug, Clone, JsonSchema, PywrVisitAll)]
 #[serde(deny_unknown_fields)]
 pub struct ConstantScenarioParameter {
-
     pub meta: ParameterMeta,
     /// The values the parameter should return.
     ///
@@ -259,7 +258,7 @@ impl ConstantScenarioParameter {
 }
 
 impl TryFromV1<ConstantScenarioParameterV1> for ConstantScenarioParameter {
-    type Error = ComponentConversionError;
+    type Error = Box<ComponentConversionError>;
 
     fn try_from_v1(
         v1: ConstantScenarioParameterV1,
@@ -305,7 +304,7 @@ impl MaxParameter {
 }
 
 impl TryFromV1<MaxParameterV1> for MaxParameter {
-    type Error = ComponentConversionError;
+    type Error = Box<ComponentConversionError>;
 
     fn try_from_v1(
         v1: MaxParameterV1,
@@ -363,7 +362,7 @@ impl DivisionParameter {
 }
 
 impl TryFromV1<DivisionParameterV1> for DivisionParameter {
-    type Error = ComponentConversionError;
+    type Error = Box<ComponentConversionError>;
 
     fn try_from_v1(
         v1: DivisionParameterV1,
@@ -424,7 +423,7 @@ impl MinParameter {
 }
 
 impl TryFromV1<MinParameterV1> for MinParameter {
-    type Error = ComponentConversionError;
+    type Error = Box<ComponentConversionError>;
 
     fn try_from_v1(
         v1: MinParameterV1,
@@ -468,7 +467,7 @@ impl NegativeParameter {
 }
 
 impl TryFromV1<NegativeParameterV1> for NegativeParameter {
-    type Error = ComponentConversionError;
+    type Error = Box<ComponentConversionError>;
 
     fn try_from_v1(
         v1: NegativeParameterV1,
@@ -529,7 +528,7 @@ impl NegativeMaxParameter {
 }
 
 impl TryFromV1<NegativeMaxParameterV1> for NegativeMaxParameter {
-    type Error = ComponentConversionError;
+    type Error = Box<ComponentConversionError>;
 
     fn try_from_v1(
         v1: NegativeMaxParameterV1,
@@ -594,7 +593,7 @@ impl NegativeMinParameter {
 }
 
 impl TryFromV1<NegativeMinParameterV1> for NegativeMinParameter {
-    type Error = ComponentConversionError;
+    type Error = Box<ComponentConversionError>;
 
     fn try_from_v1(
         v1: NegativeMinParameterV1,

--- a/pywr-schema/src/parameters/hydropower.rs
+++ b/pywr-schema/src/parameters/hydropower.rs
@@ -125,7 +125,7 @@ impl HydropowerTargetParameter {
 }
 
 impl TryFromV1<HydropowerTargetParameterV1> for HydropowerTargetParameter {
-    type Error = ComponentConversionError;
+    type Error = Box<ComponentConversionError>;
 
     fn try_from_v1(
         v1: HydropowerTargetParameterV1,

--- a/pywr-schema/src/parameters/indexed_array.rs
+++ b/pywr-schema/src/parameters/indexed_array.rs
@@ -49,7 +49,7 @@ impl IndexedArrayParameter {
 }
 
 impl TryFromV1<IndexedArrayParameterV1> for IndexedArrayParameter {
-    type Error = ComponentConversionError;
+    type Error = Box<ComponentConversionError>;
 
     fn try_from_v1(
         v1: IndexedArrayParameterV1,

--- a/pywr-schema/src/parameters/interpolated.rs
+++ b/pywr-schema/src/parameters/interpolated.rs
@@ -75,7 +75,7 @@ impl InterpolatedParameter {
 }
 
 impl TryFromV1<InterpolatedFlowParameterV1> for InterpolatedParameter {
-    type Error = ComponentConversionError;
+    type Error = Box<ComponentConversionError>;
 
     fn try_from_v1(
         v1: InterpolatedFlowParameterV1,
@@ -118,13 +118,13 @@ impl TryFromV1<InterpolatedFlowParameterV1> for InterpolatedParameter {
             if let Some(kind) = interp_kwargs.get("kind") {
                 if let Some(kind_str) = kind.as_str() {
                     if kind_str != "linear" {
-                        return Err(ComponentConversionError::Parameter {
+                        return Err(Box::new(ComponentConversionError::Parameter {
                             name: meta.name.clone(),
                             attr: "interp_kwargs".to_string(),
                             error: ConversionError::UnsupportedFeature {
                                 feature: "Interpolation with `kind` other than `linear` is not supported.".to_string(),
                             },
-                        });
+                        }));
                     }
                 }
             }
@@ -141,7 +141,7 @@ impl TryFromV1<InterpolatedFlowParameterV1> for InterpolatedParameter {
 }
 
 impl TryFromV1<InterpolatedVolumeParameterV1> for InterpolatedParameter {
-    type Error = ComponentConversionError;
+    type Error = Box<ComponentConversionError>;
 
     fn try_from_v1(
         v1: InterpolatedVolumeParameterV1,
@@ -184,13 +184,13 @@ impl TryFromV1<InterpolatedVolumeParameterV1> for InterpolatedParameter {
             if let Some(kind) = interp_kwargs.get("kind") {
                 if let Some(kind_str) = kind.as_str() {
                     if kind_str != "linear" {
-                        return Err(ComponentConversionError::Parameter {
+                        return Err(Box::new(ComponentConversionError::Parameter {
                             name: meta.name.clone(),
                             attr: "interp_kwargs".to_string(),
                             error: ConversionError::UnsupportedFeature {
                                 feature: "Interpolation with `kind` other than `linear` is not supported.".to_string(),
                             },
-                        });
+                        }));
                     }
                 }
             }

--- a/pywr-schema/src/parameters/mod.rs
+++ b/pywr-schema/src/parameters/mod.rs
@@ -462,7 +462,7 @@ impl From<ConvertedTimeseriesReference> for ParameterOrTimeseriesRef {
 }
 
 impl TryFromV1<ParameterV1> for ParameterOrTimeseriesRef {
-    type Error = ComponentConversionError;
+    type Error = Box<ComponentConversionError>;
 
     fn try_from_v1(
         v1: ParameterV1,
@@ -545,14 +545,14 @@ impl TryFromV1<ParameterV1> for ParameterOrTimeseriesRef {
                     .into()
                 }
                 CoreParameter::Deficit(p) => {
-                    return Err(ComponentConversionError::Parameter {
+                    return Err(Box::new(ComponentConversionError::Parameter {
                         name: p.meta.and_then(|m| m.name).unwrap_or("unnamed".to_string()),
                         attr: "".to_string(),
                         error: ConversionError::DeprecatedParameter {
                             ty: "DeficitParameter".to_string(),
                             instead: "Use a derived metric instead.".to_string(),
                         },
-                    });
+                    }));
                 }
                 CoreParameter::DiscountFactor(p) => {
                     Parameter::DiscountFactor(p.into_v2(parent_node, conversion_data)).into()
@@ -570,28 +570,28 @@ impl TryFromV1<ParameterV1> for ParameterOrTimeseriesRef {
                     Parameter::WeeklyProfile(p.try_into_v2(parent_node, conversion_data)?).into()
                 }
                 CoreParameter::Storage(p) => {
-                    return Err(ComponentConversionError::Parameter {
+                    return Err(Box::new(ComponentConversionError::Parameter {
                         name: p.meta.and_then(|m| m.name).unwrap_or("unnamed".to_string()),
                         attr: "".to_string(),
                         error: ConversionError::DeprecatedParameter {
                             ty: "StorageParameter".to_string(),
                             instead: "Use a derived metric instead.".to_string(),
                         },
-                    });
+                    }));
                 }
                 CoreParameter::RollingMeanFlowNode(p) => {
                     Parameter::Rolling(p.try_into_v2(parent_node, conversion_data)?).into()
                 }
                 CoreParameter::ScenarioWrapper(_) => todo!("Implement ScenarioWrapperParameter"),
                 CoreParameter::Flow(p) => {
-                    return Err(ComponentConversionError::Parameter {
+                    return Err(Box::new(ComponentConversionError::Parameter {
                         name: p.meta.and_then(|m| m.name).unwrap_or("unnamed".to_string()),
                         attr: "".to_string(),
                         error: ConversionError::DeprecatedParameter {
                             ty: "FlowParameter".to_string(),
                             instead: "Use a derived metric instead.".to_string(),
                         },
-                    });
+                    }));
                 }
                 CoreParameter::RbfProfile(p) => {
                     Parameter::RbfProfile(p.try_into_v2(parent_node, conversion_data)?).into()
@@ -604,11 +604,11 @@ impl TryFromV1<ParameterV1> for ParameterOrTimeseriesRef {
                 }
             },
             ParameterV1::Custom(p) => {
-                return Err(ComponentConversionError::Parameter {
+                return Err(Box::new(ComponentConversionError::Parameter {
                     name: p.meta.name.unwrap_or_else(|| "unnamed".to_string()),
                     attr: "".to_string(),
                     error: ConversionError::UnrecognisedType { ty: p.ty },
-                });
+                }));
             }
         };
 

--- a/pywr-schema/src/parameters/profiles.rs
+++ b/pywr-schema/src/parameters/profiles.rs
@@ -63,7 +63,7 @@ impl DailyProfileParameter {
 }
 
 impl TryFromV1<DailyProfileParameterV1> for DailyProfileParameter {
-    type Error = ComponentConversionError;
+    type Error = Box<ComponentConversionError>;
 
     fn try_from_v1(
         v1: DailyProfileParameterV1,
@@ -138,7 +138,7 @@ impl From<MonthInterpDayV1> for MonthlyInterpDay {
 }
 
 impl TryFromV1<MonthlyProfileParameterV1> for MonthlyProfileParameter {
-    type Error = ComponentConversionError;
+    type Error = Box<ComponentConversionError>;
 
     fn try_from_v1(
         v1: MonthlyProfileParameterV1,
@@ -383,7 +383,7 @@ impl RbfProfileParameter {
 }
 
 impl TryFromV1<RbfProfileParameterV1> for RbfProfileParameter {
-    type Error = ComponentConversionError;
+    type Error = Box<ComponentConversionError>;
 
     fn try_from_v1(
         v1: RbfProfileParameterV1,
@@ -395,23 +395,23 @@ impl TryFromV1<RbfProfileParameterV1> for RbfProfileParameter {
         let points = v1.days_of_year.into_iter().zip(v1.values).collect();
 
         if v1.rbf_kwargs.contains_key("smooth") {
-            return Err(ComponentConversionError::Parameter {
+            return Err(Box::new(ComponentConversionError::Parameter {
                 name: meta.name,
                 attr: "smooth".to_string(),
                 error: ConversionError::UnsupportedFeature {
                     feature: "The RBF `smooth` keyword argument is not supported.".to_string(),
                 },
-            });
+            }));
         }
 
         if v1.rbf_kwargs.contains_key("norm") {
-            return Err(ComponentConversionError::Parameter {
+            return Err(Box::new(ComponentConversionError::Parameter {
                 name: meta.name,
                 attr: "norm".to_string(),
                 error: ConversionError::UnsupportedFeature {
                     feature: "The RBF `norm` keyword argument is not supported.".to_string(),
                 },
-            });
+            }));
         }
 
         // Parse any epsilon value; we expect a float here.
@@ -419,14 +419,14 @@ impl TryFromV1<RbfProfileParameterV1> for RbfProfileParameter {
             if let Some(epsilon_f64) = epsilon_value.as_f64() {
                 Some(epsilon_f64)
             } else {
-                return Err(ComponentConversionError::Parameter {
+                return Err(Box::new(ComponentConversionError::Parameter {
                     name: meta.name,
                     attr: "epsilon".to_string(),
                     error: ConversionError::UnexpectedType {
                         expected: "float".to_string(),
                         actual: format!("{epsilon_value}"),
                     },
-                });
+                }));
             }
         } else {
             None
@@ -443,24 +443,24 @@ impl TryFromV1<RbfProfileParameterV1> for RbfProfileParameter {
                     "cubic" => RadialBasisFunction::Cubic,
                     "thin_plate" => RadialBasisFunction::ThinPlateSpline,
                     _ => {
-                        return Err(ComponentConversionError::Parameter {
+                        return Err(Box::new(ComponentConversionError::Parameter {
                             name: meta.name,
                             attr: "rbf_kwargs".to_string(),
                             error: ConversionError::UnsupportedFeature {
                                 feature: format!("Radial basis function `{function_str}` not supported."),
                             },
-                        });
+                        }));
                     }
                 }
             } else {
-                return Err(ComponentConversionError::Parameter {
+                return Err(Box::new(ComponentConversionError::Parameter {
                     name: meta.name,
                     attr: "rbf_kwargs".to_string(),
                     error: ConversionError::UnexpectedType {
                         expected: "string".to_string(),
                         actual: format!("{function_value}"),
                     },
-                });
+                }));
             }
         } else {
             // Default to multi-quadratic
@@ -587,7 +587,7 @@ impl WeeklyProfileParameter {
 }
 
 impl TryFromV1<WeeklyProfileParameterV1> for WeeklyProfileParameter {
-    type Error = ComponentConversionError;
+    type Error = Box<ComponentConversionError>;
 
     fn try_from_v1(
         v1: WeeklyProfileParameterV1,

--- a/pywr-schema/src/parameters/rolling.rs
+++ b/pywr-schema/src/parameters/rolling.rs
@@ -94,7 +94,7 @@ impl RollingIndexParameter {
 }
 
 impl TryFromV1<RollingMeanFlowNodeParameterV1> for RollingParameter {
-    type Error = ComponentConversionError;
+    type Error = Box<ComponentConversionError>;
 
     fn try_from_v1(
         v1: RollingMeanFlowNodeParameterV1,
@@ -106,31 +106,31 @@ impl TryFromV1<RollingMeanFlowNodeParameterV1> for RollingParameter {
         let window_size = match (v1.timesteps, v1.days) {
             (Some(timesteps), None) => timesteps as u64,
             (None, Some(_)) => {
-                return Err(ComponentConversionError::Parameter {
+                return Err(Box::new(ComponentConversionError::Parameter {
                         attr: "days".to_string(),
                         name: meta.name.clone(),
                         error: ConversionError::UnsupportedFeature {
                             feature: "`RollingMeanFlowNodeParameter` days window size must be specified as a number of time-steps. Use `window_size` in the updated schema, or convert a v1.x parameter with the `timesteps` attribute.".to_string(),
                         },
-                    });
+                    }));
             }
             (Some(_), Some(_)) => {
-                return Err(ComponentConversionError::Parameter {
+                return Err(Box::new(ComponentConversionError::Parameter {
                     attr: "timesteps".to_string(),
                     name: meta.name.clone(),
                     error: ConversionError::UnsupportedFeature {
                         feature: "`RollingMeanFlowNodeParameter` cannot have both `timesteps` and `days` specified. Use `window_size` in the updated schema, or correct the v1.x definition.".to_string(),
                     },
-                });
+                }));
             }
             (None, None) => {
-                return Err(ComponentConversionError::Parameter {
+                return Err(Box::new(ComponentConversionError::Parameter {
                     attr: "timesteps".to_string(),
                     name: meta.name.clone(),
                     error: ConversionError::UnsupportedFeature {
                         feature: "`RollingMeanFlowNodeParameter` must have `timesteps` specified. Use `window_size` in the updated schema.".to_string(),
                     },
-                });
+                }));
             }
         };
 

--- a/pywr-schema/src/parameters/tables.rs
+++ b/pywr-schema/src/parameters/tables.rs
@@ -111,7 +111,7 @@ impl TablesArrayParameter {
 }
 
 impl TryFromV1<TablesArrayParameterV1> for TablesArrayParameter {
-    type Error = ComponentConversionError;
+    type Error = Box<ComponentConversionError>;
     fn try_from_v1(
         v1: TablesArrayParameterV1,
         parent_node: Option<&str>,

--- a/pywr-schema/src/parameters/thresholds.rs
+++ b/pywr-schema/src/parameters/thresholds.rs
@@ -154,7 +154,7 @@ impl ThresholdParameter {
 }
 
 impl TryFromV1<ParameterThresholdParameterV1> for ThresholdParameter {
-    type Error = ComponentConversionError;
+    type Error = Box<ComponentConversionError>;
 
     fn try_from_v1(
         v1: ParameterThresholdParameterV1,
@@ -173,14 +173,14 @@ impl TryFromV1<ParameterThresholdParameterV1> for ThresholdParameter {
                 match values.try_into() {
                     Ok(array) => Some(array),
                     Err(v) => {
-                        return Err(ComponentConversionError::Parameter {
+                        return Err(Box::new(ComponentConversionError::Parameter {
                             name: meta.name.to_string(),
                             attr: "values".to_string(),
                             error: ConversionError::IncorrectNumberOfValues {
                                 expected: 2,
                                 found: v.len(),
                             },
-                        });
+                        }));
                     }
                 }
             }
@@ -200,7 +200,7 @@ impl TryFromV1<ParameterThresholdParameterV1> for ThresholdParameter {
 }
 
 impl TryFromV1<NodeThresholdParameterV1> for ThresholdParameter {
-    type Error = ComponentConversionError;
+    type Error = Box<ComponentConversionError>;
 
     fn try_from_v1(
         v1: NodeThresholdParameterV1,
@@ -220,14 +220,14 @@ impl TryFromV1<NodeThresholdParameterV1> for ThresholdParameter {
                 match values.try_into() {
                     Ok(array) => Some(array),
                     Err(v) => {
-                        return Err(ComponentConversionError::Parameter {
+                        return Err(Box::new(ComponentConversionError::Parameter {
                             name: meta.name.to_string(),
                             attr: "values".to_string(),
                             error: ConversionError::IncorrectNumberOfValues {
                                 expected: 2,
                                 found: v.len(),
                             },
-                        });
+                        }));
                     }
                 }
             }
@@ -247,7 +247,7 @@ impl TryFromV1<NodeThresholdParameterV1> for ThresholdParameter {
 }
 
 impl TryFromV1<StorageThresholdParameterV1> for ThresholdParameter {
-    type Error = ComponentConversionError;
+    type Error = Box<ComponentConversionError>;
 
     fn try_from_v1(
         v1: StorageThresholdParameterV1,
@@ -264,14 +264,14 @@ impl TryFromV1<StorageThresholdParameterV1> for ThresholdParameter {
                 match values.try_into() {
                     Ok(array) => Some(array),
                     Err(v) => {
-                        return Err(ComponentConversionError::Parameter {
+                        return Err(Box::new(ComponentConversionError::Parameter {
                             name: meta.name.to_string(),
                             attr: "values".to_string(),
                             error: ConversionError::IncorrectNumberOfValues {
                                 expected: 2,
                                 found: v.len(),
                             },
-                        });
+                        }));
                     }
                 }
             }
@@ -377,7 +377,7 @@ impl MultiThresholdParameter {
 }
 
 impl TryFromV1<MultiThresholdIndexParameterV1> for MultiThresholdParameter {
-    type Error = ComponentConversionError;
+    type Error = Box<ComponentConversionError>;
 
     fn try_from_v1(
         v1: MultiThresholdIndexParameterV1,
@@ -407,7 +407,7 @@ impl TryFromV1<MultiThresholdIndexParameterV1> for MultiThresholdParameter {
 }
 
 impl TryFromV1<MultipleThresholdParameterIndexParameterV1> for MultiThresholdParameter {
-    type Error = ComponentConversionError;
+    type Error = Box<ComponentConversionError>;
 
     fn try_from_v1(
         v1: MultipleThresholdParameterIndexParameterV1,

--- a/pywr-schema/src/timeseries/mod.rs
+++ b/pywr-schema/src/timeseries/mod.rs
@@ -506,7 +506,7 @@ pub struct ConvertedTimeseriesReference {
 }
 
 impl TryFromV1<DataFrameParameterV1> for ConvertedTimeseriesReference {
-    type Error = ComponentConversionError;
+    type Error = Box<ComponentConversionError>;
 
     fn try_from_v1(
         v1: DataFrameParameterV1,
@@ -557,13 +557,13 @@ impl TryFromV1<DataFrameParameterV1> for ConvertedTimeseriesReference {
             // ignore the original parameter's name entirely.
             ts_name = table;
         } else {
-            return Err(ComponentConversionError::Parameter {
+            return Err(Box::new(ComponentConversionError::Parameter {
                 name: meta.name,
                 attr: "url".to_string(),
                 error: ConversionError::MissingAttribute {
                     attrs: vec!["url".to_string(), "table".to_string()],
                 },
-            });
+            }));
         };
 
         // Create the reference to the timeseries data
@@ -571,13 +571,13 @@ impl TryFromV1<DataFrameParameterV1> for ConvertedTimeseriesReference {
             (Some(name), None) => Some(TimeseriesColumns::Column { name }),
             (None, Some(name)) => Some(TimeseriesColumns::Scenario { name }),
             (Some(_), Some(_)) => {
-                return Err(ComponentConversionError::Parameter {
+                return Err(Box::new(ComponentConversionError::Parameter {
                     name: meta.name.clone(),
                     attr: "column".to_string(),
                     error: ConversionError::AmbiguousAttributes {
                         attrs: vec!["column".to_string(), "scenario".to_string()],
                     },
-                });
+                }));
             }
             (None, None) => None,
         };

--- a/pywr-schema/src/v1.rs
+++ b/pywr-schema/src/v1.rs
@@ -131,90 +131,90 @@ impl FromV1<Option<ParameterMetaV1>> for ParameterMeta {
 }
 
 /// Helper function to convert a node attribute from v1 to v2.
-#[allow(clippy::result_large_err)]
 pub fn try_convert_node_attr<V1, V2>(
     name: &str,
     attr: &str,
     v1_value: V1,
     parent_node: Option<&str>,
     conversion_data: &mut ConversionData,
-) -> Result<V2, ComponentConversionError>
+) -> Result<V2, Box<ComponentConversionError>>
 where
     V1: TryIntoV2<V2, Error = ConversionError>,
 {
     v1_value
         .try_into_v2(parent_node.or(Some(name)), conversion_data)
-        .map_err(|error| ComponentConversionError::Node {
-            attr: attr.to_string(),
-            name: name.to_string(),
-            error,
+        .map_err(|error| {
+            Box::new(ComponentConversionError::Node {
+                attr: attr.to_string(),
+                name: name.to_string(),
+                error,
+            })
         })
 }
 
 /// Helper function to convert a parameter attribute from v1 to v2.
-#[allow(clippy::result_large_err)]
 pub fn try_convert_parameter_attr<V1, V2>(
     name: &str,
     attr: &str,
     v1_value: V1,
     parent_node: Option<&str>,
     conversion_data: &mut ConversionData,
-) -> Result<V2, ComponentConversionError>
+) -> Result<V2, Box<ComponentConversionError>>
 where
     V1: TryIntoV2<V2, Error = ConversionError>,
 {
     v1_value
         .try_into_v2(parent_node.or(Some(name)), conversion_data)
-        .map_err(|error| ComponentConversionError::Parameter {
-            attr: attr.to_string(),
-            name: name.to_string(),
-            error,
+        .map_err(|error| {
+            Box::new(ComponentConversionError::Parameter {
+                attr: attr.to_string(),
+                name: name.to_string(),
+                error,
+            })
         })
 }
 
 /// Helper function to convert initial storage from v1 to v2.
-#[allow(clippy::result_large_err)]
 pub fn try_convert_initial_storage(
     name: &str,
     attr: &str,
     v1_initial_volume: Option<f64>,
     v1_initial_volume_pc: Option<f64>,
-) -> Result<StorageInitialVolume, ComponentConversionError> {
+) -> Result<StorageInitialVolume, Box<ComponentConversionError>> {
     let initial_volume = if let Some(volume) = v1_initial_volume {
         StorageInitialVolume::Absolute { volume }
     } else if let Some(proportion) = v1_initial_volume_pc {
         StorageInitialVolume::Proportional { proportion }
     } else {
-        return Err(ComponentConversionError::Node {
+        return Err(Box::new(ComponentConversionError::Node {
             attr: attr.to_string(),
             name: name.to_string(),
             error: ConversionError::MissingAttribute {
                 attrs: vec!["initial_volume".to_string(), "initial_volume_pc".to_string()],
             },
-        });
+        }));
     };
 
     Ok(initial_volume)
 }
 
-#[allow(clippy::result_large_err)]
 pub fn try_convert_values(
     name: &str,
     v1_values: Option<Vec<f64>>,
     v1_external: Option<ExternalDataRef>,
     v1_table_ref: Option<TableDataRef>,
-) -> Result<ConstantFloatVec, ComponentConversionError> {
+) -> Result<ConstantFloatVec, Box<ComponentConversionError>> {
     let values: ConstantFloatVec = if let Some(values) = v1_values {
         ConstantFloatVec::Literal { values }
     } else if let Some(_external) = v1_external {
-        return Err(ComponentConversionError::Parameter {
+        return Err(Box::new(ComponentConversionError::Parameter {
             name: name.to_string(),
             attr: "url".to_string(),
             error: ConversionError::UnsupportedFeature {
                 feature: "External data references are not supported in Pywr v2. Please use a table instead."
                     .to_string(),
             },
-        });
+        }));
     } else if let Some(table_ref) = v1_table_ref {
         ConstantFloatVec::Table(
             table_ref
@@ -226,26 +226,25 @@ pub fn try_convert_values(
                 })?,
         )
     } else {
-        return Err(ComponentConversionError::Parameter {
+        return Err(Box::new(ComponentConversionError::Parameter {
             name: name.to_string(),
             attr: "table".to_string(),
             error: ConversionError::MissingAttribute {
                 attrs: vec!["values".to_string(), "table".to_string(), "url".to_string()],
             },
-        });
+        }));
     };
 
     Ok(values)
 }
 
-#[allow(clippy::result_large_err)]
 pub fn try_convert_control_curves(
     name: &str,
     v1_control_curves: Option<ParameterValues>,
     v1_control_curve: Option<ParameterValue>,
     parent_node: Option<&str>,
     conversion_data: &mut ConversionData,
-) -> Result<Vec<Metric>, ComponentConversionError> {
+) -> Result<Vec<Metric>, Box<ComponentConversionError>> {
     let control_curves = if let Some(control_curves) = v1_control_curves {
         control_curves
             .into_iter()
@@ -260,13 +259,13 @@ pub fn try_convert_control_curves(
             conversion_data,
         )?]
     } else {
-        return Err(ComponentConversionError::Parameter {
+        return Err(Box::new(ComponentConversionError::Parameter {
             name: name.to_string(),
             attr: "control_curves".to_string(),
             error: ConversionError::MissingAttribute {
                 attrs: vec!["control_curves".to_string(), "control_curve".to_string()],
             },
-        });
+        }));
     };
 
     Ok(control_curves)


### PR DESCRIPTION
This large type was previously ignored with
`#[allow(clippy::result_large_err)]`, but Clippy has spotted that some closures return this large type and is warning about that. Therefore, have boxed all error returns of this type which should make things a bit more efficient at the expense of creating and handling the boxes. All those clippy allows are now removed.