### PR TITLE
fix(core): Fix memory leak in the Cbc solver.

### DIFF
--- a/pywr-core/src/solvers/cbc/mod.rs
+++ b/pywr-core/src/solvers/cbc/mod.rs
@@ -43,6 +43,14 @@ impl Default for Cbc {
     }
 }
 
+impl Drop for Cbc {
+    fn drop(&mut self) {
+        unsafe {
+            Cbc_deleteModel(self.ptr);
+        }
+    }
+}
+
 impl Cbc {
     #[allow(dead_code)]
     pub fn print(&mut self) {


### PR DESCRIPTION
Implement Drop for Cbc to ensure Cbc cleans up the model when the struct is dropped.