### PR TITLE
Refactoring of core parameters

### DIFF
--- a/pywr-book/listings/adding-a-parameter/src/main.rs
+++ b/pywr-book/listings/adding-a-parameter/src/main.rs
@@ -2,8 +2,9 @@
 use pywr_core::metric::{MetricF64, UnresolvedMetricF64};
 use pywr_core::network::ResolutionMaps;
 use pywr_core::parameters::{
-    BuiltParameter, GeneralCalculationError, GeneralParameter, GeneralParameterContext, MaybeBuiltParameter, Parameter,
-    ParameterBuildError, ParameterBuilder, ParameterMeta, ParameterName, ParameterState,
+    BuiltParameter, GeneralBeforeParameter, GeneralCalculationError, GeneralParameter, GeneralParameterContext,
+    GeneralParameterEntry, MaybeBuiltParameter, Parameter, ParameterBuildError, ParameterBuilder, ParameterMeta,
+    ParameterName, ParameterState,
 };
 use pywr_core::resolve_metric_f64;
 
@@ -23,17 +24,7 @@ impl Parameter for MaxParameter {
     }
 }
 
-impl GeneralParameter<f64> for MaxParameter {
-    fn before(
-        &self,
-        ctx: GeneralParameterContext<'_>,
-        _internal_state: &mut Option<Box<dyn ParameterState>>,
-    ) -> Result<Option<f64>, GeneralCalculationError> {
-        // Current value
-        let x = self.metric.get_value(ctx.network, ctx.state)?;
-        Ok(Some(x.max(self.threshold)))
-    }
-
+impl GeneralParameter for MaxParameter {
     fn as_parameter(&self) -> &dyn Parameter
     where
         Self: Sized,
@@ -42,6 +33,17 @@ impl GeneralParameter<f64> for MaxParameter {
     }
 }
 
+impl GeneralBeforeParameter<f64> for MaxParameter {
+    fn before(
+        &self,
+        ctx: GeneralParameterContext<'_>,
+        _internal_state: &mut Option<Box<dyn ParameterState>>,
+    ) -> Result<f64, GeneralCalculationError> {
+        // Current value
+        let x = self.metric.get_value(ctx.network, ctx.state)?;
+        Ok(x.max(self.threshold))
+    }
+}
 // ANCHOR: impl-builder
 #[derive(Debug)]
 pub struct MaxParameterBuilder {
@@ -77,7 +79,7 @@ impl ParameterBuilder<f64> for MaxParameterBuilder {
             threshold: self.threshold,
         };
 
-        Ok(MaybeBuiltParameter::Built(BuiltParameter::General(Box::new(p))))
+        Ok(BuiltParameter::General(GeneralParameterEntry::before(p)).into())
     }
 }
 // ANCHOR_END: impl-builder

--- a/pywr-book/listings/adding-a-parameter/src/main.rs
+++ b/pywr-book/listings/adding-a-parameter/src/main.rs
@@ -1,14 +1,11 @@
 #![allow(dead_code)]
 use pywr_core::metric::{MetricF64, UnresolvedMetricF64};
-use pywr_core::network::{Network, ResolutionMaps};
+use pywr_core::network::ResolutionMaps;
 use pywr_core::parameters::{
-    BuiltParameter, GeneralCalculationError, GeneralParameter, MaybeBuiltParameter, Parameter, ParameterBuildError,
-    ParameterBuilder, ParameterMeta, ParameterName, ParameterState,
+    BuiltParameter, GeneralCalculationError, GeneralParameter, GeneralParameterContext, MaybeBuiltParameter, Parameter,
+    ParameterBuildError, ParameterBuilder, ParameterMeta, ParameterName, ParameterState,
 };
 use pywr_core::resolve_metric_f64;
-use pywr_core::scenario::ScenarioIndex;
-use pywr_core::state::State;
-use pywr_core::timestep::Timestep;
 
 // ANCHOR: parameter
 #[derive(Debug)]
@@ -29,14 +26,11 @@ impl Parameter for MaxParameter {
 impl GeneralParameter<f64> for MaxParameter {
     fn before(
         &self,
-        _timestep: &Timestep,
-        _scenario_index: &ScenarioIndex,
-        model: &Network,
-        state: &State,
+        ctx: GeneralParameterContext<'_>,
         _internal_state: &mut Option<Box<dyn ParameterState>>,
     ) -> Result<Option<f64>, GeneralCalculationError> {
         // Current value
-        let x = self.metric.get_value(model, state)?;
+        let x = self.metric.get_value(ctx.network, ctx.state)?;
         Ok(Some(x.max(self.threshold)))
     }
 

--- a/pywr-core/src/metric.rs
+++ b/pywr-core/src/metric.rs
@@ -396,6 +396,36 @@ impl TryFrom<SimpleMetricF64> for ConstantMetricF64 {
     }
 }
 
+impl TryFrom<MetricF64> for ConstantMetricF64 {
+    type Error = MetricF64Error;
+
+    fn try_from(value: MetricF64) -> Result<Self, Self::Error> {
+        let simple_metric: SimpleMetricF64 = value.try_into()?;
+        let constant_metric: ConstantMetricF64 = simple_metric.try_into()?;
+        Ok(constant_metric)
+    }
+}
+
+/// Try to convert a slice of [`MetricF64`] into a vector of [`ConstantMetricF64`].
+/// If any of the metrics cannot be converted, return `None`.
+pub fn try_into_constant_metrics_f64(metrics: &[MetricF64]) -> Option<Vec<ConstantMetricF64>> {
+    metrics
+        .iter()
+        .map(|m| m.clone().try_into())
+        .collect::<Result<Vec<_>, _>>()
+        .ok()
+}
+
+/// Try to convert a slice of [`MetricF64`] into a vector of [`SimpleMetricF64`].
+/// If any of the metrics cannot be converted, return `None`.
+pub fn try_into_simple_metrics_f64(metrics: &[MetricF64]) -> Option<Vec<SimpleMetricF64>> {
+    metrics
+        .iter()
+        .map(|m| m.clone().try_into())
+        .collect::<Result<Vec<_>, _>>()
+        .ok()
+}
+
 impl From<f64> for ConstantMetricF64 {
     fn from(v: f64) -> Self {
         ConstantMetricF64::Constant(v)
@@ -934,6 +964,36 @@ impl TryFrom<SimpleMetricU64> for ConstantMetricU64 {
             _ => Err(SimpleMetricU64Error::CannotSimplifyMetric),
         }
     }
+}
+
+impl TryFrom<MetricU64> for ConstantMetricU64 {
+    type Error = MetricU64Error;
+
+    fn try_from(value: MetricU64) -> Result<Self, Self::Error> {
+        let simple_metric: SimpleMetricU64 = value.try_into()?;
+        let constant_metric: ConstantMetricU64 = simple_metric.try_into()?;
+        Ok(constant_metric)
+    }
+}
+
+/// Try to convert a slice of [`MetricU64`] into a vector of [`ConstantMetricU64`].
+/// If any of the metrics cannot be converted, return `None`.
+pub fn try_into_constant_metrics_u64(metrics: &[MetricU64]) -> Option<Vec<ConstantMetricU64>> {
+    metrics
+        .iter()
+        .map(|m| m.clone().try_into())
+        .collect::<Result<Vec<_>, _>>()
+        .ok()
+}
+
+/// Try to convert a slice of [`MetricU64`] into a vector of [`SimpleMetricU64`].
+/// If any of the metrics cannot be converted, return `None`.
+pub fn try_into_simple_metrics_u64(metrics: &[MetricU64]) -> Option<Vec<SimpleMetricU64>> {
+    metrics
+        .iter()
+        .map(|m| m.clone().try_into())
+        .collect::<Result<Vec<_>, _>>()
+        .ok()
 }
 
 #[derive(Debug, Error)]

--- a/pywr-core/src/metric.rs
+++ b/pywr-core/src/metric.rs
@@ -5,26 +5,18 @@ use crate::network::{
     VirtualStorageIndex,
 };
 use crate::node::{NodeError, UnresolvedNode};
-use crate::parameters::{
-    ConstParameterIndex, GeneralParameterIndex, ParameterIndex, ParameterName, SimpleParameterIndex,
-};
+use crate::parameters::{ConstParameterIndex, GeneralParameterIndex, ParameterName, SimpleParameterIndex};
 use crate::state::{
-    ConstParameterValues, MultiValue, NetworkStateError, ParameterReturnValue, SimpleParameterValues, State, StateError,
+    ConstParameterValues, ConstParameterValuesError, MultiValue, NetworkStateError, ParameterReturnValue,
+    SimpleParameterValues, SimpleParameterValuesError, State, StateError,
 };
 use num::Zero;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum ConstantMetricF64Error {
-    #[error("Parameter not found: {index}")]
-    ParameterNotFound { index: ConstParameterIndex<f64> },
-    #[error("Index parameter not found: {index}")]
-    IndexParameterNotFound { index: ConstParameterIndex<u64> },
-    #[error("Multi-parameter not found: {index}, key: {key}")]
-    MultiParameterNotFound {
-        index: ConstParameterIndex<MultiValue>,
-        key: String,
-    },
+    #[error("Simple parameter value error: {0}")]
+    ConstParameterValuesError(#[from] ConstParameterValuesError),
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -41,19 +33,9 @@ pub enum ConstantMetricF64 {
 impl ConstantMetricF64 {
     pub fn get_value(&self, values: &ConstParameterValues) -> Result<f64, ConstantMetricF64Error> {
         match self {
-            ConstantMetricF64::ParameterValue(idx) => values
-                .get_const_parameter_f64(*idx)
-                .ok_or(ConstantMetricF64Error::ParameterNotFound { index: *idx }),
-            ConstantMetricF64::IndexParameterValue(idx) => values
-                .get_const_parameter_u64(*idx)
-                .ok_or(ConstantMetricF64Error::IndexParameterNotFound { index: *idx })
-                .map(|v| v as f64),
-            ConstantMetricF64::MultiParameterValue { index, key } => values
-                .get_const_multi_parameter_f64(*index, key)
-                .ok_or_else(|| ConstantMetricF64Error::MultiParameterNotFound {
-                    index: *index,
-                    key: key.clone(),
-                }),
+            ConstantMetricF64::ParameterValue(idx) => Ok(values.get_f64(*idx)?),
+            ConstantMetricF64::IndexParameterValue(idx) => Ok(values.get_u64(*idx)? as f64),
+            ConstantMetricF64::MultiParameterValue { index, key } => Ok(values.get_multi_f64(*index, key)?),
             ConstantMetricF64::Constant(v) => Ok(*v),
         }
     }
@@ -69,15 +51,8 @@ impl ConstantMetricF64 {
 
 #[derive(Debug, Error)]
 pub enum SimpleMetricF64Error {
-    #[error("Parameter not found: {index}")]
-    ParameterNotFound { index: SimpleParameterIndex<f64> },
-    #[error("Index parameter not found: {index}")]
-    IndexParameterNotFound { index: SimpleParameterIndex<u64> },
-    #[error("Multi-parameter not found: {index}, key: {key}")]
-    MultiParameterNotFound {
-        index: SimpleParameterIndex<MultiValue>,
-        key: String,
-    },
+    #[error("Simple parameter value error: {0}")]
+    SimpleParameterValuesError(#[from] SimpleParameterValuesError),
     #[error("Constant metric error: {0}")]
     ConstantMetricError(#[from] ConstantMetricF64Error),
     #[error("Cannot simplify metric to a constant metric")]
@@ -86,11 +61,18 @@ pub enum SimpleMetricF64Error {
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum SimpleMetricF64 {
-    ParameterValue(SimpleParameterIndex<f64>),
-    IndexParameterValue(SimpleParameterIndex<u64>),
+    ParameterValue {
+        index: SimpleParameterIndex<f64>,
+        return_value: ParameterReturnValue,
+    },
+    IndexParameterValue {
+        index: SimpleParameterIndex<u64>,
+        return_value: ParameterReturnValue,
+    },
     MultiParameterValue {
         index: SimpleParameterIndex<MultiValue>,
         key: String,
+        return_value: ParameterReturnValue,
     },
     Constant(ConstantMetricF64),
 }
@@ -98,19 +80,15 @@ pub enum SimpleMetricF64 {
 impl SimpleMetricF64 {
     pub fn get_value(&self, values: &SimpleParameterValues) -> Result<f64, SimpleMetricF64Error> {
         match self {
-            SimpleMetricF64::ParameterValue(idx) => values
-                .get_simple_parameter_f64(*idx)
-                .ok_or(SimpleMetricF64Error::ParameterNotFound { index: *idx }),
-            SimpleMetricF64::IndexParameterValue(idx) => values
-                .get_simple_parameter_u64(*idx)
-                .ok_or(SimpleMetricF64Error::IndexParameterNotFound { index: *idx })
-                .map(|v| v as f64),
-            SimpleMetricF64::MultiParameterValue { index, key } => values
-                .get_simple_multi_parameter_f64(*index, key)
-                .ok_or_else(|| SimpleMetricF64Error::MultiParameterNotFound {
-                    index: *index,
-                    key: key.clone(),
-                }),
+            SimpleMetricF64::ParameterValue { index, return_value } => Ok(values.get_f64(*index, *return_value)?),
+            SimpleMetricF64::IndexParameterValue { index, return_value } => {
+                Ok(values.get_u64(*index, *return_value)? as f64)
+            }
+            SimpleMetricF64::MultiParameterValue {
+                index,
+                key,
+                return_value,
+            } => Ok(values.get_multi_f64(*index, key, *return_value)?),
             SimpleMetricF64::Constant(m) => Ok(m.get_value(values.get_constant_values())?),
         }
     }
@@ -139,15 +117,6 @@ impl SimpleMetricF64 {
 
 #[derive(Debug, Error)]
 pub enum MetricF64Error {
-    #[error("Parameter not found: {index}")]
-    ParameterNotFound { index: SimpleParameterIndex<f64> },
-    #[error("Index parameter not found: {index}")]
-    IndexParameterNotFound { index: SimpleParameterIndex<u64> },
-    #[error("Multi-parameter not found: {index}, key: {key}")]
-    MultiParameterNotFound {
-        index: SimpleParameterIndex<MultiValue>,
-        key: String,
-    },
     #[error("Node index not found: {0}")]
     NodeIndexNotFound(NodeIndex),
     #[error("Virtual storage node index not found: {0}")]
@@ -449,27 +418,27 @@ where
     }
 }
 
-impl TryFrom<ParameterIndex<f64>> for SimpleMetricF64 {
-    type Error = MetricF64Error;
-    fn try_from(idx: ParameterIndex<f64>) -> Result<Self, Self::Error> {
-        match idx {
-            ParameterIndex::Simple(idx) => Ok(Self::ParameterValue(idx)),
-            ParameterIndex::Const(idx) => Ok(Self::Constant(ConstantMetricF64::ParameterValue(idx))),
-            ParameterIndex::General(_) => Err(MetricF64Error::CannotSimplifyMetric),
-        }
-    }
-}
-
-impl TryFrom<ParameterIndex<u64>> for SimpleMetricU64 {
-    type Error = MetricU64Error;
-    fn try_from(idx: ParameterIndex<u64>) -> Result<Self, Self::Error> {
-        match idx {
-            ParameterIndex::Simple(idx) => Ok(Self::IndexParameterValue(idx)),
-            ParameterIndex::Const(idx) => Ok(Self::Constant(ConstantMetricU64::IndexParameterValue(idx))),
-            ParameterIndex::General(_) => Err(MetricU64Error::CannotSimplifyMetric),
-        }
-    }
-}
+// impl TryFrom<ParameterIndex<f64>> for SimpleMetricF64 {
+//     type Error = MetricF64Error;
+//     fn try_from(idx: ParameterIndex<f64>) -> Result<Self, Self::Error> {
+//         match idx {
+//             ParameterIndex::Simple(idx) => Ok(Self::ParameterValue(idx)),
+//             ParameterIndex::Const(idx) => Ok(Self::Constant(ConstantMetricF64::ParameterValue(idx))),
+//             ParameterIndex::General(_) => Err(MetricF64Error::CannotSimplifyMetric),
+//         }
+//     }
+// }
+//
+// impl TryFrom<ParameterIndex<u64>> for SimpleMetricU64 {
+//     type Error = MetricU64Error;
+//     fn try_from(idx: ParameterIndex<u64>) -> Result<Self, Self::Error> {
+//         match idx {
+//             ParameterIndex::Simple(idx) => Ok(Self::IndexParameterValue(idx)),
+//             ParameterIndex::Const(idx) => Ok(Self::Constant(ConstantMetricU64::IndexParameterValue(idx))),
+//             ParameterIndex::General(_) => Err(MetricU64Error::CannotSimplifyMetric),
+//         }
+//     }
+// }
 
 #[derive(Debug, Error)]
 pub enum MetricF64ResolutionError {
@@ -793,13 +762,8 @@ impl From<f64> for UnresolvedMetricF64 {
 
 #[derive(Debug, Error)]
 pub enum ConstantMetricU64Error {
-    #[error("Index parameter not found: {index}")]
-    IndexParameterNotFound { index: ConstParameterIndex<u64> },
-    #[error("Multi-parameter not found: {index}, key: {key}")]
-    MultiParameterNotFound {
-        index: ConstParameterIndex<MultiValue>,
-        key: String,
-    },
+    #[error("Simple parameter value error: {0}")]
+    ConstParameterValuesError(#[from] ConstParameterValuesError),
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -815,15 +779,8 @@ pub enum ConstantMetricU64 {
 impl ConstantMetricU64 {
     pub fn get_value(&self, values: &ConstParameterValues) -> Result<u64, ConstantMetricU64Error> {
         match self {
-            ConstantMetricU64::IndexParameterValue(idx) => values
-                .get_const_parameter_u64(*idx)
-                .ok_or(ConstantMetricU64Error::IndexParameterNotFound { index: *idx }),
-            ConstantMetricU64::MultiParameterValue { index, key } => values
-                .get_const_multi_parameter_u64(*index, key)
-                .ok_or_else(|| ConstantMetricU64Error::MultiParameterNotFound {
-                    index: *index,
-                    key: key.clone(),
-                }),
+            ConstantMetricU64::IndexParameterValue(idx) => Ok(values.get_u64(*idx)?),
+            ConstantMetricU64::MultiParameterValue { index, key } => Ok(values.get_multi_u64(*index, key)?),
             ConstantMetricU64::Constant(v) => Ok(*v),
         }
     }
@@ -831,13 +788,8 @@ impl ConstantMetricU64 {
 
 #[derive(Debug, Error)]
 pub enum SimpleMetricU64Error {
-    #[error("Index parameter not found: {index}")]
-    IndexParameterNotFound { index: SimpleParameterIndex<u64> },
-    #[error("Multi-parameter not found: {index}, key: {key}")]
-    MultiParameterNotFound {
-        index: SimpleParameterIndex<MultiValue>,
-        key: String,
-    },
+    #[error("Simple parameter value error: {0}")]
+    SimpleParameterValuesError(#[from] SimpleParameterValuesError),
     #[error("Constant metric error: {0}")]
     ConstantMetricError(#[from] ConstantMetricU64Error),
     #[error("Cannot simplify metric to a constant metric")]
@@ -846,10 +798,14 @@ pub enum SimpleMetricU64Error {
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum SimpleMetricU64 {
-    IndexParameterValue(SimpleParameterIndex<u64>),
+    IndexParameterValue {
+        index: SimpleParameterIndex<u64>,
+        return_value: ParameterReturnValue,
+    },
     MultiParameterValue {
         index: SimpleParameterIndex<MultiValue>,
         key: String,
+        return_value: ParameterReturnValue,
     },
     Constant(ConstantMetricU64),
 }
@@ -857,15 +813,12 @@ pub enum SimpleMetricU64 {
 impl SimpleMetricU64 {
     pub fn get_value(&self, values: &SimpleParameterValues) -> Result<u64, SimpleMetricU64Error> {
         match self {
-            SimpleMetricU64::IndexParameterValue(idx) => values
-                .get_simple_parameter_u64(*idx)
-                .ok_or(SimpleMetricU64Error::IndexParameterNotFound { index: *idx }),
-            SimpleMetricU64::MultiParameterValue { index, key } => values
-                .get_simple_multi_parameter_u64(*index, key)
-                .ok_or_else(|| SimpleMetricU64Error::MultiParameterNotFound {
-                    index: *index,
-                    key: key.clone(),
-                }),
+            SimpleMetricU64::IndexParameterValue { index, return_value } => Ok(values.get_u64(*index, *return_value)?),
+            SimpleMetricU64::MultiParameterValue {
+                index,
+                key,
+                return_value,
+            } => Ok(values.get_multi_u64(*index, key, *return_value)?),
             SimpleMetricU64::Constant(m) => Ok(m.get_value(values.get_constant_values())?),
         }
     }

--- a/pywr-core/src/network.rs
+++ b/pywr-core/src/network.rs
@@ -1004,7 +1004,7 @@ impl Network {
 
         // First we update the simple parameters
         self.parameters
-            .before_simple(timestep, scenario_index, state, internal_states)?;
+            .compute_simple(timestep, scenario_index, state, internal_states)?;
 
         // Next run "before" on nodes and virtual nodes
         for n in &self.nodes {
@@ -1050,9 +1050,6 @@ impl Network {
         timings: Option<&mut ComponentTimings>,
     ) -> Result<(), NetworkStepError> {
         // TODO reset parameter state to zero
-
-        self.parameters
-            .after_simple(timestep, scenario_index, state, internal_states)?;
 
         // No "after" on nodes and virtual nodes
 

--- a/pywr-core/src/network.rs
+++ b/pywr-core/src/network.rs
@@ -1004,7 +1004,7 @@ impl Network {
 
         // First we update the simple parameters
         self.parameters
-            .compute_simple(timestep, scenario_index, state, internal_states)?;
+            .before_simple(timestep, scenario_index, state, internal_states)?;
 
         // Next run "before" on nodes and virtual nodes
         for n in &self.nodes {
@@ -1027,7 +1027,7 @@ impl Network {
 
         // Now we can compute the general parameters that may depend on node state.
         self.parameters
-            .compute_general(timestep, scenario_index, self, state, internal_states, p_timings)
+            .before_general(timestep, scenario_index, self, state, internal_states, p_timings)
             .map_err(|source| NetworkStepError::GeneralParameterCalculationError(Box::new(source)))?;
 
         Ok(())

--- a/pywr-core/src/parameters/aggregated.rs
+++ b/pywr-core/src/parameters/aggregated.rs
@@ -1,8 +1,7 @@
 use super::{
     BuiltParameter, ConstParameter, GeneralAfterParameter, GeneralBeforeParameter, GeneralParameterContext,
     GeneralParameterEntry, MaybeBuiltParameter, Parameter, ParameterBuildError, ParameterBuilder, ParameterName,
-    ParameterState, SimpleAfterParameter, SimpleBeforeParameter, SimpleParameter, SimpleParameterContext,
-    SimpleParameterEntry,
+    ParameterState, SimpleParameter, SimpleParameterContext,
 };
 use crate::agg_funcs::AggFuncF64;
 use crate::metric::{
@@ -74,47 +73,25 @@ impl GeneralAfterParameter<f64> for AggregatedParameter<MetricF64> {
     }
 }
 
-impl<M> SimpleParameter for AggregatedParameter<M>
-where
-    M: Send + Sync + Debug,
-{
+impl SimpleParameter<f64> for AggregatedParameter<SimpleMetricF64> {
+    fn compute(
+        &self,
+        ctx: SimpleParameterContext<'_>,
+        _internal_state: &mut Option<Box<dyn ParameterState>>,
+    ) -> Result<f64, SimpleCalculationError> {
+        let values = self
+            .metrics
+            .iter()
+            .map(|p| p.get_value(ctx.values))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(self.agg_func.calc_iter_f64(&values)?)
+    }
     fn as_parameter(&self) -> &dyn Parameter
     where
         Self: Sized,
     {
         self
-    }
-}
-
-impl SimpleBeforeParameter<f64> for AggregatedParameter<SimpleMetricF64> {
-    fn before(
-        &self,
-        ctx: SimpleParameterContext<'_>,
-        _internal_state: &mut Option<Box<dyn ParameterState>>,
-    ) -> Result<f64, SimpleCalculationError> {
-        let values = self
-            .metrics
-            .iter()
-            .map(|p| p.get_value(ctx.values))
-            .collect::<Result<Vec<_>, _>>()?;
-
-        Ok(self.agg_func.calc_iter_f64(&values)?)
-    }
-}
-
-impl SimpleAfterParameter<f64> for AggregatedParameter<SimpleMetricF64> {
-    fn after(
-        &self,
-        ctx: SimpleParameterContext<'_>,
-        _internal_state: &mut Option<Box<dyn ParameterState>>,
-    ) -> Result<f64, SimpleCalculationError> {
-        let values = self
-            .metrics
-            .iter()
-            .map(|p| p.get_value(ctx.values))
-            .collect::<Result<Vec<_>, _>>()?;
-
-        Ok(self.agg_func.calc_iter_f64(&values)?)
     }
 }
 
@@ -191,14 +168,12 @@ impl ParameterBuilder<f64> for AggregatedParameterBuilder {
         }
 
         if let Some(metrics) = try_into_simple_metrics_f64(&metrics) {
-            return Ok(
-                BuiltParameter::Simple(SimpleParameterEntry::both(AggregatedParameter::<SimpleMetricF64> {
-                    meta,
-                    metrics,
-                    agg_func,
-                }))
-                .into(),
-            );
+            return Ok(BuiltParameter::Simple(Box::new(AggregatedParameter::<SimpleMetricF64> {
+                meta,
+                metrics,
+                agg_func,
+            }))
+            .into());
         }
 
         Ok(

--- a/pywr-core/src/parameters/aggregated.rs
+++ b/pywr-core/src/parameters/aggregated.rs
@@ -1,9 +1,14 @@
 use super::{
-    BuiltParameter, ConstParameter, GeneralParameterContext, MaybeBuiltParameter, Parameter, ParameterBuildError,
-    ParameterBuilder, ParameterName, ParameterState, SimpleParameter, SimpleParameterContext,
+    BuiltParameter, ConstParameter, GeneralAfterParameter, GeneralBeforeParameter, GeneralParameterContext,
+    GeneralParameterEntry, MaybeBuiltParameter, Parameter, ParameterBuildError, ParameterBuilder, ParameterName,
+    ParameterState, SimpleAfterParameter, SimpleBeforeParameter, SimpleParameter, SimpleParameterContext,
+    SimpleParameterEntry,
 };
 use crate::agg_funcs::AggFuncF64;
-use crate::metric::{ConstantMetricF64, MetricF64, SimpleMetricF64, UnresolvedMetricF64};
+use crate::metric::{
+    ConstantMetricF64, MetricF64, SimpleMetricF64, UnresolvedMetricF64, try_into_constant_metrics_f64,
+    try_into_simple_metrics_f64,
+};
 use crate::network::ResolutionMaps;
 use crate::parameters::errors::{ConstCalculationError, GeneralCalculationError, SimpleCalculationError};
 use crate::parameters::{GeneralParameter, ParameterMeta};
@@ -28,37 +33,7 @@ where
     }
 }
 
-impl GeneralParameter<f64> for AggregatedParameter<MetricF64> {
-    fn before(
-        &self,
-        ctx: GeneralParameterContext<'_>,
-        _internal_state: &mut Option<Box<dyn ParameterState>>,
-    ) -> Result<Option<f64>, GeneralCalculationError> {
-        let values = self
-            .metrics
-            .iter()
-            .map(|p| p.get_value(ctx.network, ctx.state))
-            .collect::<Result<Vec<_>, _>>()?;
-
-        Ok(Some(self.agg_func.calc_iter_f64(&values)?))
-    }
-
-    fn try_into_simple(&self) -> Option<Box<dyn SimpleParameter<f64>>> {
-        // We can make a simple version if all metrics can be simplified
-        let metrics: Vec<SimpleMetricF64> = self
-            .metrics
-            .clone()
-            .into_iter()
-            .map(|m| m.try_into().ok())
-            .collect::<Option<Vec<_>>>()?;
-
-        Some(Box::new(AggregatedParameter::<SimpleMetricF64> {
-            meta: self.meta.clone(),
-            metrics,
-            agg_func: self.agg_func.clone(),
-        }))
-    }
-
+impl GeneralParameter for AggregatedParameter<MetricF64> {
     fn as_parameter(&self) -> &dyn Parameter
     where
         Self: Sized,
@@ -67,42 +42,79 @@ impl GeneralParameter<f64> for AggregatedParameter<MetricF64> {
     }
 }
 
-impl SimpleParameter<f64> for AggregatedParameter<SimpleMetricF64> {
+impl GeneralBeforeParameter<f64> for AggregatedParameter<MetricF64> {
     fn before(
         &self,
-        ctx: SimpleParameterContext<'_>,
+        ctx: GeneralParameterContext<'_>,
         _internal_state: &mut Option<Box<dyn ParameterState>>,
-    ) -> Result<Option<f64>, SimpleCalculationError> {
+    ) -> Result<f64, GeneralCalculationError> {
         let values = self
             .metrics
             .iter()
-            .map(|p| p.get_value(ctx.values))
+            .map(|p| p.get_value(ctx.network, ctx.state))
             .collect::<Result<Vec<_>, _>>()?;
 
-        Ok(Some(self.agg_func.calc_iter_f64(&values)?))
+        Ok(self.agg_func.calc_iter_f64(&values)?)
     }
+}
 
+impl GeneralAfterParameter<f64> for AggregatedParameter<MetricF64> {
+    fn after(
+        &self,
+        ctx: GeneralParameterContext<'_>,
+        _internal_state: &mut Option<Box<dyn ParameterState>>,
+    ) -> Result<f64, GeneralCalculationError> {
+        let values = self
+            .metrics
+            .iter()
+            .map(|p| p.get_value(ctx.network, ctx.state))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(self.agg_func.calc_iter_f64(&values)?)
+    }
+}
+
+impl<M> SimpleParameter for AggregatedParameter<M>
+where
+    M: Send + Sync + Debug,
+{
     fn as_parameter(&self) -> &dyn Parameter
     where
         Self: Sized,
     {
         self
     }
+}
 
-    fn try_into_const(&self) -> Option<Box<dyn ConstParameter<f64>>> {
-        // We can make a constant version if all metrics can be simplified
-        let metrics: Vec<ConstantMetricF64> = self
+impl SimpleBeforeParameter<f64> for AggregatedParameter<SimpleMetricF64> {
+    fn before(
+        &self,
+        ctx: SimpleParameterContext<'_>,
+        _internal_state: &mut Option<Box<dyn ParameterState>>,
+    ) -> Result<f64, SimpleCalculationError> {
+        let values = self
             .metrics
-            .clone()
-            .into_iter()
-            .map(|m| m.try_into().ok())
-            .collect::<Option<Vec<_>>>()?;
+            .iter()
+            .map(|p| p.get_value(ctx.values))
+            .collect::<Result<Vec<_>, _>>()?;
 
-        Some(Box::new(AggregatedParameter::<ConstantMetricF64> {
-            meta: self.meta.clone(),
-            metrics,
-            agg_func: self.agg_func.clone(),
-        }))
+        Ok(self.agg_func.calc_iter_f64(&values)?)
+    }
+}
+
+impl SimpleAfterParameter<f64> for AggregatedParameter<SimpleMetricF64> {
+    fn after(
+        &self,
+        ctx: SimpleParameterContext<'_>,
+        _internal_state: &mut Option<Box<dyn ParameterState>>,
+    ) -> Result<f64, SimpleCalculationError> {
+        let values = self
+            .metrics
+            .iter()
+            .map(|p| p.get_value(ctx.values))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(self.agg_func.calc_iter_f64(&values)?)
     }
 }
 
@@ -163,13 +175,39 @@ impl ParameterBuilder<f64> for AggregatedParameterBuilder {
     ) -> Result<MaybeBuiltParameter<f64>, ParameterBuildError> {
         let metrics = resolve_metric_f64_vec!(self, &self.metrics, resolution_maps, "metrics");
 
-        let p = AggregatedParameter {
-            meta: self.meta,
-            metrics,
-            agg_func: self.agg_func,
-        };
+        let meta = self.meta;
+        let agg_func = self.agg_func;
 
-        let bp = BuiltParameter::General(Box::new(p));
-        Ok(bp.into())
+        // Try the narrowest dependency class first.
+        if let Some(metrics) = try_into_constant_metrics_f64(&metrics) {
+            return Ok(
+                BuiltParameter::Const(Box::new(AggregatedParameter::<ConstantMetricF64> {
+                    meta,
+                    metrics,
+                    agg_func,
+                }))
+                .into(),
+            );
+        }
+
+        if let Some(metrics) = try_into_simple_metrics_f64(&metrics) {
+            return Ok(
+                BuiltParameter::Simple(SimpleParameterEntry::both(AggregatedParameter::<SimpleMetricF64> {
+                    meta,
+                    metrics,
+                    agg_func,
+                }))
+                .into(),
+            );
+        }
+
+        Ok(
+            BuiltParameter::General(GeneralParameterEntry::both(AggregatedParameter::<MetricF64> {
+                meta,
+                metrics,
+                agg_func,
+            }))
+            .into(),
+        )
     }
 }

--- a/pywr-core/src/parameters/aggregated.rs
+++ b/pywr-core/src/parameters/aggregated.rs
@@ -1,15 +1,15 @@
 use super::{
-    BuiltParameter, ConstParameter, MaybeBuiltParameter, Parameter, ParameterBuildError, ParameterBuilder,
-    ParameterName, ParameterState, SimpleParameter,
+    BuiltParameter, ConstParameter, GeneralParameterContext, MaybeBuiltParameter, Parameter, ParameterBuildError,
+    ParameterBuilder, ParameterName, ParameterState, SimpleParameter,
 };
 use crate::agg_funcs::AggFuncF64;
 use crate::metric::{ConstantMetricF64, MetricF64, SimpleMetricF64, UnresolvedMetricF64};
-use crate::network::{Network, ResolutionMaps};
+use crate::network::ResolutionMaps;
 use crate::parameters::errors::{ConstCalculationError, GeneralCalculationError, SimpleCalculationError};
 use crate::parameters::{GeneralParameter, ParameterMeta};
 use crate::resolve_metric_f64_vec;
 use crate::scenario::ScenarioIndex;
-use crate::state::{ConstParameterValues, SimpleParameterValues, State};
+use crate::state::{ConstParameterValues, SimpleParameterValues};
 use crate::timestep::Timestep;
 use std::fmt::Debug;
 
@@ -32,16 +32,13 @@ where
 impl GeneralParameter<f64> for AggregatedParameter<MetricF64> {
     fn before(
         &self,
-        _timestep: &Timestep,
-        _scenario_index: &ScenarioIndex,
-        model: &Network,
-        state: &State,
+        ctx: GeneralParameterContext<'_>,
         _internal_state: &mut Option<Box<dyn ParameterState>>,
     ) -> Result<Option<f64>, GeneralCalculationError> {
         let values = self
             .metrics
             .iter()
-            .map(|p| p.get_value(model, state))
+            .map(|p| p.get_value(ctx.network, ctx.state))
             .collect::<Result<Vec<_>, _>>()?;
 
         Ok(Some(self.agg_func.calc_iter_f64(&values)?))

--- a/pywr-core/src/parameters/aggregated.rs
+++ b/pywr-core/src/parameters/aggregated.rs
@@ -1,6 +1,6 @@
 use super::{
     BuiltParameter, ConstParameter, GeneralParameterContext, MaybeBuiltParameter, Parameter, ParameterBuildError,
-    ParameterBuilder, ParameterName, ParameterState, SimpleParameter,
+    ParameterBuilder, ParameterName, ParameterState, SimpleParameter, SimpleParameterContext,
 };
 use crate::agg_funcs::AggFuncF64;
 use crate::metric::{ConstantMetricF64, MetricF64, SimpleMetricF64, UnresolvedMetricF64};
@@ -9,8 +9,7 @@ use crate::parameters::errors::{ConstCalculationError, GeneralCalculationError, 
 use crate::parameters::{GeneralParameter, ParameterMeta};
 use crate::resolve_metric_f64_vec;
 use crate::scenario::ScenarioIndex;
-use crate::state::{ConstParameterValues, SimpleParameterValues};
-use crate::timestep::Timestep;
+use crate::state::ConstParameterValues;
 use std::fmt::Debug;
 
 #[derive(Debug)]
@@ -71,15 +70,13 @@ impl GeneralParameter<f64> for AggregatedParameter<MetricF64> {
 impl SimpleParameter<f64> for AggregatedParameter<SimpleMetricF64> {
     fn before(
         &self,
-        _timestep: &Timestep,
-        _scenario_index: &ScenarioIndex,
-        values: &SimpleParameterValues,
+        ctx: SimpleParameterContext<'_>,
         _internal_state: &mut Option<Box<dyn ParameterState>>,
     ) -> Result<Option<f64>, SimpleCalculationError> {
         let values = self
             .metrics
             .iter()
-            .map(|p| p.get_value(values))
+            .map(|p| p.get_value(ctx.values))
             .collect::<Result<Vec<_>, _>>()?;
 
         Ok(Some(self.agg_func.calc_iter_f64(&values)?))

--- a/pywr-core/src/parameters/aggregated_index.rs
+++ b/pywr-core/src/parameters/aggregated_index.rs
@@ -1,11 +1,16 @@
 /// AggregatedIndexParameter
 ///
 use super::{
-    BuiltParameter, ConstParameter, GeneralParameterContext, MaybeBuiltParameter, Parameter, ParameterBuildError,
-    ParameterBuilder, ParameterName, ParameterState, SimpleParameter, SimpleParameterContext,
+    BuiltParameter, ConstParameter, GeneralAfterParameter, GeneralBeforeParameter, GeneralParameterContext,
+    GeneralParameterEntry, MaybeBuiltParameter, Parameter, ParameterBuildError, ParameterBuilder, ParameterName,
+    ParameterState, SimpleAfterParameter, SimpleBeforeParameter, SimpleParameter, SimpleParameterContext,
+    SimpleParameterEntry,
 };
 use crate::agg_funcs::AggFuncU64;
-use crate::metric::{ConstantMetricU64, MetricU64, SimpleMetricU64, UnresolvedMetricU64};
+use crate::metric::{
+    ConstantMetricU64, MetricU64, SimpleMetricU64, UnresolvedMetricU64, try_into_constant_metrics_u64,
+    try_into_simple_metrics_u64,
+};
 use crate::network::ResolutionMaps;
 use crate::parameters::errors::{ConstCalculationError, GeneralCalculationError, SimpleCalculationError};
 use crate::parameters::{GeneralParameter, ParameterMeta};
@@ -30,81 +35,85 @@ where
     }
 }
 
-impl GeneralParameter<u64> for AggregatedIndexParameter<MetricU64> {
+impl GeneralParameter for AggregatedIndexParameter<MetricU64> {
+    fn as_parameter(&self) -> &dyn Parameter
+    where
+        Self: Sized,
+    {
+        self
+    }
+}
+
+impl GeneralBeforeParameter<u64> for AggregatedIndexParameter<MetricU64> {
     fn before(
         &self,
         ctx: GeneralParameterContext<'_>,
         _internal_state: &mut Option<Box<dyn ParameterState>>,
-    ) -> Result<Option<u64>, GeneralCalculationError> {
+    ) -> Result<u64, GeneralCalculationError> {
         let values = self
             .metrics
             .iter()
             .map(|p| p.get_value(ctx.network, ctx.state))
             .collect::<Result<Vec<_>, _>>()?;
 
-        Ok(Some(self.agg_func.calc_iter_u64(&values)?))
+        Ok(self.agg_func.calc_iter_u64(&values)?)
     }
+}
 
+impl GeneralAfterParameter<u64> for AggregatedIndexParameter<MetricU64> {
+    fn after(
+        &self,
+        ctx: GeneralParameterContext<'_>,
+        _internal_state: &mut Option<Box<dyn ParameterState>>,
+    ) -> Result<u64, GeneralCalculationError> {
+        let values = self
+            .metrics
+            .iter()
+            .map(|p| p.get_value(ctx.network, ctx.state))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(self.agg_func.calc_iter_u64(&values)?)
+    }
+}
+
+impl SimpleParameter for AggregatedIndexParameter<SimpleMetricU64> {
     fn as_parameter(&self) -> &dyn Parameter
     where
         Self: Sized,
     {
         self
     }
-
-    fn try_into_simple(&self) -> Option<Box<dyn SimpleParameter<u64>>> {
-        // We can make a simple version if all metrics can be simplified
-        let metrics: Vec<SimpleMetricU64> = self
-            .metrics
-            .clone()
-            .into_iter()
-            .map(|m| m.try_into().ok())
-            .collect::<Option<Vec<_>>>()?;
-
-        Some(Box::new(AggregatedIndexParameter::<SimpleMetricU64> {
-            meta: self.meta.clone(),
-            metrics,
-            agg_func: self.agg_func.clone(),
-        }))
-    }
 }
 
-impl SimpleParameter<u64> for AggregatedIndexParameter<SimpleMetricU64> {
+impl SimpleBeforeParameter<u64> for AggregatedIndexParameter<SimpleMetricU64> {
     fn before(
         &self,
         ctx: SimpleParameterContext<'_>,
         _internal_state: &mut Option<Box<dyn ParameterState>>,
-    ) -> Result<Option<u64>, SimpleCalculationError> {
+    ) -> Result<u64, SimpleCalculationError> {
         let values = self
             .metrics
             .iter()
             .map(|p| p.get_value(ctx.values))
             .collect::<Result<Vec<_>, _>>()?;
 
-        Ok(Some(self.agg_func.calc_iter_u64(&values)?))
+        Ok(self.agg_func.calc_iter_u64(&values)?)
     }
+}
 
-    fn as_parameter(&self) -> &dyn Parameter
-    where
-        Self: Sized,
-    {
-        self
-    }
-
-    fn try_into_const(&self) -> Option<Box<dyn ConstParameter<u64>>> {
-        // We can make a constant version if all metrics can be simplified to constants
-        let metrics: Vec<ConstantMetricU64> = self
+impl SimpleAfterParameter<u64> for AggregatedIndexParameter<SimpleMetricU64> {
+    fn after(
+        &self,
+        ctx: SimpleParameterContext<'_>,
+        _internal_state: &mut Option<Box<dyn ParameterState>>,
+    ) -> Result<u64, SimpleCalculationError> {
+        let values = self
             .metrics
-            .clone()
-            .into_iter()
-            .map(|m| m.try_into().ok())
-            .collect::<Option<Vec<_>>>()?;
+            .iter()
+            .map(|p| p.get_value(ctx.values))
+            .collect::<Result<Vec<_>, _>>()?;
 
-        Some(Box::new(AggregatedIndexParameter::<ConstantMetricU64> {
-            meta: self.meta.clone(),
-            metrics,
-            agg_func: self.agg_func.clone(),
-        }))
+        Ok(self.agg_func.calc_iter_u64(&values)?)
     }
 }
 
@@ -165,13 +174,39 @@ impl ParameterBuilder<u64> for AggregatedIndexParameterBuilder {
     ) -> Result<MaybeBuiltParameter<u64>, ParameterBuildError> {
         let metrics = resolve_metric_u64_vec!(self, &self.metrics, resolution_maps, "metrics");
 
-        let p = AggregatedIndexParameter {
-            meta: self.meta,
-            metrics,
-            agg_func: self.agg_func,
-        };
+        let meta = self.meta;
+        let agg_func = self.agg_func;
 
-        let bp = BuiltParameter::General(Box::new(p));
-        Ok(bp.into())
+        // Try the narrowest dependency class first.
+        if let Some(metrics) = try_into_constant_metrics_u64(&metrics) {
+            return Ok(
+                BuiltParameter::Const(Box::new(AggregatedIndexParameter::<ConstantMetricU64> {
+                    meta,
+                    metrics,
+                    agg_func,
+                }))
+                .into(),
+            );
+        }
+
+        if let Some(metrics) = try_into_simple_metrics_u64(&metrics) {
+            return Ok(BuiltParameter::Simple(SimpleParameterEntry::both(
+                AggregatedIndexParameter::<SimpleMetricU64> {
+                    meta,
+                    metrics,
+                    agg_func,
+                },
+            ))
+            .into());
+        }
+
+        Ok(
+            BuiltParameter::General(GeneralParameterEntry::both(AggregatedIndexParameter::<MetricU64> {
+                meta,
+                metrics,
+                agg_func,
+            }))
+            .into(),
+        )
     }
 }

--- a/pywr-core/src/parameters/aggregated_index.rs
+++ b/pywr-core/src/parameters/aggregated_index.rs
@@ -3,8 +3,7 @@
 use super::{
     BuiltParameter, ConstParameter, GeneralAfterParameter, GeneralBeforeParameter, GeneralParameterContext,
     GeneralParameterEntry, MaybeBuiltParameter, Parameter, ParameterBuildError, ParameterBuilder, ParameterName,
-    ParameterState, SimpleAfterParameter, SimpleBeforeParameter, SimpleParameter, SimpleParameterContext,
-    SimpleParameterEntry,
+    ParameterState, SimpleParameter, SimpleParameterContext,
 };
 use crate::agg_funcs::AggFuncU64;
 use crate::metric::{
@@ -76,44 +75,25 @@ impl GeneralAfterParameter<u64> for AggregatedIndexParameter<MetricU64> {
     }
 }
 
-impl SimpleParameter for AggregatedIndexParameter<SimpleMetricU64> {
+impl SimpleParameter<u64> for AggregatedIndexParameter<SimpleMetricU64> {
+    fn compute(
+        &self,
+        ctx: SimpleParameterContext<'_>,
+        _internal_state: &mut Option<Box<dyn ParameterState>>,
+    ) -> Result<u64, SimpleCalculationError> {
+        let values = self
+            .metrics
+            .iter()
+            .map(|p| p.get_value(ctx.values))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(self.agg_func.calc_iter_u64(&values)?)
+    }
     fn as_parameter(&self) -> &dyn Parameter
     where
         Self: Sized,
     {
         self
-    }
-}
-
-impl SimpleBeforeParameter<u64> for AggregatedIndexParameter<SimpleMetricU64> {
-    fn before(
-        &self,
-        ctx: SimpleParameterContext<'_>,
-        _internal_state: &mut Option<Box<dyn ParameterState>>,
-    ) -> Result<u64, SimpleCalculationError> {
-        let values = self
-            .metrics
-            .iter()
-            .map(|p| p.get_value(ctx.values))
-            .collect::<Result<Vec<_>, _>>()?;
-
-        Ok(self.agg_func.calc_iter_u64(&values)?)
-    }
-}
-
-impl SimpleAfterParameter<u64> for AggregatedIndexParameter<SimpleMetricU64> {
-    fn after(
-        &self,
-        ctx: SimpleParameterContext<'_>,
-        _internal_state: &mut Option<Box<dyn ParameterState>>,
-    ) -> Result<u64, SimpleCalculationError> {
-        let values = self
-            .metrics
-            .iter()
-            .map(|p| p.get_value(ctx.values))
-            .collect::<Result<Vec<_>, _>>()?;
-
-        Ok(self.agg_func.calc_iter_u64(&values)?)
     }
 }
 
@@ -190,14 +170,14 @@ impl ParameterBuilder<u64> for AggregatedIndexParameterBuilder {
         }
 
         if let Some(metrics) = try_into_simple_metrics_u64(&metrics) {
-            return Ok(BuiltParameter::Simple(SimpleParameterEntry::both(
-                AggregatedIndexParameter::<SimpleMetricU64> {
+            return Ok(
+                BuiltParameter::Simple(Box::new(AggregatedIndexParameter::<SimpleMetricU64> {
                     meta,
                     metrics,
                     agg_func,
-                },
-            ))
-            .into());
+                }))
+                .into(),
+            );
         }
 
         Ok(

--- a/pywr-core/src/parameters/aggregated_index.rs
+++ b/pywr-core/src/parameters/aggregated_index.rs
@@ -2,7 +2,7 @@
 ///
 use super::{
     BuiltParameter, ConstParameter, GeneralParameterContext, MaybeBuiltParameter, Parameter, ParameterBuildError,
-    ParameterBuilder, ParameterName, ParameterState, SimpleParameter,
+    ParameterBuilder, ParameterName, ParameterState, SimpleParameter, SimpleParameterContext,
 };
 use crate::agg_funcs::AggFuncU64;
 use crate::metric::{ConstantMetricU64, MetricU64, SimpleMetricU64, UnresolvedMetricU64};
@@ -11,8 +11,7 @@ use crate::parameters::errors::{ConstCalculationError, GeneralCalculationError, 
 use crate::parameters::{GeneralParameter, ParameterMeta};
 use crate::resolve_metric_u64_vec;
 use crate::scenario::ScenarioIndex;
-use crate::state::{ConstParameterValues, SimpleParameterValues};
-use crate::timestep::Timestep;
+use crate::state::ConstParameterValues;
 use std::fmt::Debug;
 
 #[derive(Debug)]
@@ -73,15 +72,13 @@ impl GeneralParameter<u64> for AggregatedIndexParameter<MetricU64> {
 impl SimpleParameter<u64> for AggregatedIndexParameter<SimpleMetricU64> {
     fn before(
         &self,
-        _timestep: &Timestep,
-        _scenario_index: &ScenarioIndex,
-        values: &SimpleParameterValues,
+        ctx: SimpleParameterContext<'_>,
         _internal_state: &mut Option<Box<dyn ParameterState>>,
     ) -> Result<Option<u64>, SimpleCalculationError> {
         let values = self
             .metrics
             .iter()
-            .map(|p| p.get_value(values))
+            .map(|p| p.get_value(ctx.values))
             .collect::<Result<Vec<_>, _>>()?;
 
         Ok(Some(self.agg_func.calc_iter_u64(&values)?))

--- a/pywr-core/src/parameters/aggregated_index.rs
+++ b/pywr-core/src/parameters/aggregated_index.rs
@@ -1,17 +1,17 @@
 /// AggregatedIndexParameter
 ///
 use super::{
-    BuiltParameter, ConstParameter, MaybeBuiltParameter, Parameter, ParameterBuildError, ParameterBuilder,
-    ParameterName, ParameterState, SimpleParameter,
+    BuiltParameter, ConstParameter, GeneralParameterContext, MaybeBuiltParameter, Parameter, ParameterBuildError,
+    ParameterBuilder, ParameterName, ParameterState, SimpleParameter,
 };
 use crate::agg_funcs::AggFuncU64;
 use crate::metric::{ConstantMetricU64, MetricU64, SimpleMetricU64, UnresolvedMetricU64};
-use crate::network::{Network, ResolutionMaps};
+use crate::network::ResolutionMaps;
 use crate::parameters::errors::{ConstCalculationError, GeneralCalculationError, SimpleCalculationError};
 use crate::parameters::{GeneralParameter, ParameterMeta};
 use crate::resolve_metric_u64_vec;
 use crate::scenario::ScenarioIndex;
-use crate::state::{ConstParameterValues, SimpleParameterValues, State};
+use crate::state::{ConstParameterValues, SimpleParameterValues};
 use crate::timestep::Timestep;
 use std::fmt::Debug;
 
@@ -34,16 +34,13 @@ where
 impl GeneralParameter<u64> for AggregatedIndexParameter<MetricU64> {
     fn before(
         &self,
-        _timestep: &Timestep,
-        _scenario_index: &ScenarioIndex,
-        network: &Network,
-        state: &State,
+        ctx: GeneralParameterContext<'_>,
         _internal_state: &mut Option<Box<dyn ParameterState>>,
     ) -> Result<Option<u64>, GeneralCalculationError> {
         let values = self
             .metrics
             .iter()
-            .map(|p| p.get_value(network, state))
+            .map(|p| p.get_value(ctx.network, ctx.state))
             .collect::<Result<Vec<_>, _>>()?;
 
         Ok(Some(self.agg_func.calc_iter_u64(&values)?))

--- a/pywr-core/src/parameters/array.rs
+++ b/pywr-core/src/parameters/array.rs
@@ -2,10 +2,8 @@ use crate::network::ResolutionMaps;
 use crate::parameters::errors::SimpleCalculationError;
 use crate::parameters::{
     BuiltParameter, MaybeBuiltParameter, Parameter, ParameterBuildError, ParameterBuilder, ParameterMeta,
-    ParameterName, ParameterState, SimpleParameter,
+    ParameterName, ParameterState, SimpleParameter, SimpleParameterContext,
 };
-use crate::scenario::ScenarioIndex;
-use crate::state::SimpleParameterValues;
 use crate::timestep::{Timestep, TimestepIndex};
 use ndarray::{Array1, Array2, Axis, s};
 use std::fmt::Debug;
@@ -42,12 +40,10 @@ where
 impl SimpleParameter<f64> for Array1Parameter<f64> {
     fn before(
         &self,
-        timestep: &Timestep,
-        _scenario_index: &ScenarioIndex,
-        _values: &SimpleParameterValues,
+        ctx: SimpleParameterContext<'_>,
         _internal_state: &mut Option<Box<dyn ParameterState>>,
     ) -> Result<Option<f64>, SimpleCalculationError> {
-        let idx = self.timestep_index(timestep);
+        let idx = self.timestep_index(ctx.timestep);
 
         let value = self
             .array
@@ -71,12 +67,10 @@ impl SimpleParameter<f64> for Array1Parameter<f64> {
 impl SimpleParameter<u64> for Array1Parameter<u64> {
     fn before(
         &self,
-        timestep: &Timestep,
-        _scenario_index: &ScenarioIndex,
-        _values: &SimpleParameterValues,
+        ctx: SimpleParameterContext<'_>,
         _internal_state: &mut Option<Box<dyn ParameterState>>,
     ) -> Result<Option<u64>, SimpleCalculationError> {
-        let idx = self.timestep_index(timestep);
+        let idx = self.timestep_index(ctx.timestep);
         let value = self
             .array
             .get(idx)
@@ -186,13 +180,11 @@ where
 impl SimpleParameter<f64> for Array2Parameter<f64> {
     fn before(
         &self,
-        timestep: &Timestep,
-        scenario_index: &ScenarioIndex,
-        _values: &SimpleParameterValues,
+        ctx: SimpleParameterContext<'_>,
         _internal_state: &mut Option<Box<dyn ParameterState>>,
     ) -> Result<Option<f64>, SimpleCalculationError> {
-        let t_idx = self.timestep_index(timestep);
-        let s_idx = scenario_index.simulation_index_for_group(self.scenario_group_index);
+        let t_idx = self.timestep_index(ctx.timestep);
+        let s_idx = ctx.scenario_index.simulation_index_for_group(self.scenario_group_index);
 
         let value = self.array.get([t_idx, s_idx]).ok_or_else(|| {
             let shape = self.array.shape();
@@ -229,13 +221,11 @@ impl SimpleParameter<f64> for Array2Parameter<f64> {
 impl SimpleParameter<u64> for Array2Parameter<u64> {
     fn before(
         &self,
-        timestep: &Timestep,
-        scenario_index: &ScenarioIndex,
-        _values: &SimpleParameterValues,
+        ctx: SimpleParameterContext<'_>,
         _internal_state: &mut Option<Box<dyn ParameterState>>,
     ) -> Result<Option<u64>, SimpleCalculationError> {
-        let t_idx = self.timestep_index(timestep);
-        let s_idx = scenario_index.simulation_index_for_group(self.scenario_group_index);
+        let t_idx = self.timestep_index(ctx.timestep);
+        let s_idx = ctx.scenario_index.simulation_index_for_group(self.scenario_group_index);
 
         let value = self.array.get([t_idx, s_idx]).ok_or_else(|| {
             let shape = self.array.shape();
@@ -404,13 +394,12 @@ mod tests {
 
         for ts in domain.time().timesteps().iter() {
             for si in domain.scenarios().indices().iter() {
-                assert_approx_eq!(
-                    f64,
-                    p.before(ts, si, &spv.get_simple_parameter_values(), &mut state)
-                        .unwrap()
-                        .unwrap(),
-                    ts.index as f64
-                );
+                let ctx = SimpleParameterContext {
+                    timestep: ts,
+                    scenario_index: si,
+                    values: &spv.get_simple_parameter_values(),
+                };
+                assert_approx_eq!(f64, p.before(ctx, &mut state).unwrap().unwrap(), ts.index as f64);
             }
         }
     }
@@ -437,13 +426,13 @@ mod tests {
 
         for ts in domain.time().timesteps().iter() {
             for si in domain.scenarios().indices().iter() {
-                assert_approx_eq!(
-                    f64,
-                    p.before(ts, si, &spv.get_simple_parameter_values(), &mut state)
-                        .unwrap()
-                        .unwrap(),
-                    ts.index as f64
-                );
+                let ctx = SimpleParameterContext {
+                    timestep: ts,
+                    scenario_index: si,
+                    values: &spv.get_simple_parameter_values(),
+                };
+
+                assert_approx_eq!(f64, p.before(ctx, &mut state).unwrap().unwrap(), ts.index as f64);
             }
         }
     }
@@ -470,21 +459,18 @@ mod tests {
 
         for ts in domain.time().timesteps().iter() {
             for si in domain.scenarios().indices().iter() {
+                let ctx = SimpleParameterContext {
+                    timestep: ts,
+                    scenario_index: si,
+                    values: &spv.get_simple_parameter_values(),
+                };
+
                 if ts.index >= 5 {
                     // If the time-step index is out of bounds, we should return an error
-                    assert!(
-                        p.before(ts, si, &spv.get_simple_parameter_values(), &mut state)
-                            .is_err()
-                    );
+                    assert!(p.before(ctx, &mut state).is_err());
                 } else {
                     // Otherwise, we should return the value
-                    assert_approx_eq!(
-                        f64,
-                        p.before(ts, si, &spv.get_simple_parameter_values(), &mut state)
-                            .unwrap()
-                            .unwrap(),
-                        ts.index as f64
-                    );
+                    assert_approx_eq!(f64, p.before(ctx, &mut state).unwrap().unwrap(), ts.index as f64);
                 }
             }
         }

--- a/pywr-core/src/parameters/array.rs
+++ b/pywr-core/src/parameters/array.rs
@@ -2,7 +2,8 @@ use crate::network::ResolutionMaps;
 use crate::parameters::errors::SimpleCalculationError;
 use crate::parameters::{
     BuiltParameter, MaybeBuiltParameter, Parameter, ParameterBuildError, ParameterBuilder, ParameterMeta,
-    ParameterName, ParameterState, SimpleParameter, SimpleParameterContext,
+    ParameterName, ParameterState, SimpleBeforeParameter, SimpleParameter, SimpleParameterContext,
+    SimpleParameterEntry,
 };
 use crate::timestep::{Timestep, TimestepIndex};
 use ndarray::{Array1, Array2, Axis, s};
@@ -37,12 +38,21 @@ where
         &self.meta
     }
 }
-impl SimpleParameter<f64> for Array1Parameter<f64> {
+impl SimpleParameter for Array1Parameter<f64> {
+    fn as_parameter(&self) -> &dyn Parameter
+    where
+        Self: Sized,
+    {
+        self
+    }
+}
+
+impl SimpleBeforeParameter<f64> for Array1Parameter<f64> {
     fn before(
         &self,
         ctx: SimpleParameterContext<'_>,
         _internal_state: &mut Option<Box<dyn ParameterState>>,
-    ) -> Result<Option<f64>, SimpleCalculationError> {
+    ) -> Result<f64, SimpleCalculationError> {
         let idx = self.timestep_index(ctx.timestep);
 
         let value = self
@@ -53,9 +63,11 @@ impl SimpleParameter<f64> for Array1Parameter<f64> {
                 length: self.array.len(),
                 axis: 0,
             })?;
-        Ok(Some(*value))
+        Ok(*value)
     }
+}
 
+impl SimpleParameter for Array1Parameter<u64> {
     fn as_parameter(&self) -> &dyn Parameter
     where
         Self: Sized,
@@ -64,12 +76,12 @@ impl SimpleParameter<f64> for Array1Parameter<f64> {
     }
 }
 
-impl SimpleParameter<u64> for Array1Parameter<u64> {
+impl SimpleBeforeParameter<u64> for Array1Parameter<u64> {
     fn before(
         &self,
         ctx: SimpleParameterContext<'_>,
         _internal_state: &mut Option<Box<dyn ParameterState>>,
-    ) -> Result<Option<u64>, SimpleCalculationError> {
+    ) -> Result<u64, SimpleCalculationError> {
         let idx = self.timestep_index(ctx.timestep);
         let value = self
             .array
@@ -79,16 +91,10 @@ impl SimpleParameter<u64> for Array1Parameter<u64> {
                 length: self.array.len(),
                 axis: 0,
             })?;
-        Ok(Some(*value))
-    }
-
-    fn as_parameter(&self) -> &dyn Parameter
-    where
-        Self: Sized,
-    {
-        self
+        Ok(*value)
     }
 }
+
 #[derive(Debug)]
 pub struct Array1ParameterBuilder<T> {
     meta: ParameterMeta,
@@ -124,7 +130,7 @@ impl ParameterBuilder<f64> for Array1ParameterBuilder<f64> {
             array: self.array,
             timestep_offset: self.timestep_offset,
         };
-        Ok(BuiltParameter::Simple(Box::new(p)).into())
+        Ok(BuiltParameter::Simple(SimpleParameterEntry::before(p)).into())
     }
 }
 
@@ -141,7 +147,7 @@ impl ParameterBuilder<u64> for Array1ParameterBuilder<u64> {
             array: self.array,
             timestep_offset: self.timestep_offset,
         };
-        Ok(BuiltParameter::Simple(Box::new(p)).into())
+        Ok(BuiltParameter::Simple(SimpleParameterEntry::before(p)).into())
     }
 }
 
@@ -177,39 +183,7 @@ where
     }
 }
 
-impl SimpleParameter<f64> for Array2Parameter<f64> {
-    fn before(
-        &self,
-        ctx: SimpleParameterContext<'_>,
-        _internal_state: &mut Option<Box<dyn ParameterState>>,
-    ) -> Result<Option<f64>, SimpleCalculationError> {
-        let t_idx = self.timestep_index(ctx.timestep);
-        let s_idx = ctx.scenario_index.simulation_index_for_group(self.scenario_group_index);
-
-        let value = self.array.get([t_idx, s_idx]).ok_or_else(|| {
-            let shape = self.array.shape();
-            if t_idx >= shape[0] {
-                SimpleCalculationError::OutOfBoundsError {
-                    index: t_idx,
-                    length: shape[0],
-                    axis: 0,
-                }
-            } else if s_idx >= shape[1] {
-                SimpleCalculationError::OutOfBoundsError {
-                    index: s_idx,
-                    length: shape[1],
-                    axis: 1,
-                }
-            } else {
-                unreachable!(
-                    "Invalid indices for array: t_idx = {}, s_idx = {}, shape = {:?}",
-                    t_idx, s_idx, shape
-                )
-            }
-        })?;
-        Ok(Some(*value))
-    }
-
+impl SimpleParameter for Array2Parameter<f64> {
     fn as_parameter(&self) -> &dyn Parameter
     where
         Self: Sized,
@@ -218,12 +192,12 @@ impl SimpleParameter<f64> for Array2Parameter<f64> {
     }
 }
 
-impl SimpleParameter<u64> for Array2Parameter<u64> {
+impl SimpleBeforeParameter<f64> for Array2Parameter<f64> {
     fn before(
         &self,
         ctx: SimpleParameterContext<'_>,
         _internal_state: &mut Option<Box<dyn ParameterState>>,
-    ) -> Result<Option<u64>, SimpleCalculationError> {
+    ) -> Result<f64, SimpleCalculationError> {
         let t_idx = self.timestep_index(ctx.timestep);
         let s_idx = ctx.scenario_index.simulation_index_for_group(self.scenario_group_index);
 
@@ -248,14 +222,48 @@ impl SimpleParameter<u64> for Array2Parameter<u64> {
                 )
             }
         })?;
-        Ok(Some(*value))
+        Ok(*value)
     }
-
+}
+impl SimpleParameter for Array2Parameter<u64> {
     fn as_parameter(&self) -> &dyn Parameter
     where
         Self: Sized,
     {
         self
+    }
+}
+impl SimpleBeforeParameter<u64> for Array2Parameter<u64> {
+    fn before(
+        &self,
+        ctx: SimpleParameterContext<'_>,
+        _internal_state: &mut Option<Box<dyn ParameterState>>,
+    ) -> Result<u64, SimpleCalculationError> {
+        let t_idx = self.timestep_index(ctx.timestep);
+        let s_idx = ctx.scenario_index.simulation_index_for_group(self.scenario_group_index);
+
+        let value = self.array.get([t_idx, s_idx]).ok_or_else(|| {
+            let shape = self.array.shape();
+            if t_idx >= shape[0] {
+                SimpleCalculationError::OutOfBoundsError {
+                    index: t_idx,
+                    length: shape[0],
+                    axis: 0,
+                }
+            } else if s_idx >= shape[1] {
+                SimpleCalculationError::OutOfBoundsError {
+                    index: s_idx,
+                    length: shape[1],
+                    axis: 1,
+                }
+            } else {
+                unreachable!(
+                    "Invalid indices for array: t_idx = {}, s_idx = {}, shape = {:?}",
+                    t_idx, s_idx, shape
+                )
+            }
+        })?;
+        Ok(*value)
     }
 }
 
@@ -312,7 +320,7 @@ impl ParameterBuilder<f64> for Array2ParameterBuilder<f64> {
             timestep_offset: self.timestep_offset,
         };
 
-        Ok(BuiltParameter::Simple(Box::new(p)).into())
+        Ok(BuiltParameter::Simple(SimpleParameterEntry::before(p)).into())
     }
 }
 
@@ -344,7 +352,7 @@ impl ParameterBuilder<u64> for Array2ParameterBuilder<u64> {
             scenario_group_index,
             timestep_offset: self.timestep_offset,
         };
-        Ok(BuiltParameter::Simple(Box::new(p)).into())
+        Ok(BuiltParameter::Simple(SimpleParameterEntry::before(p)).into())
     }
 }
 
@@ -399,7 +407,7 @@ mod tests {
                     scenario_index: si,
                     values: &spv.get_simple_parameter_values(),
                 };
-                assert_approx_eq!(f64, p.before(ctx, &mut state).unwrap().unwrap(), ts.index as f64);
+                assert_approx_eq!(f64, p.before(ctx, &mut state).unwrap(), ts.index as f64);
             }
         }
     }
@@ -432,7 +440,7 @@ mod tests {
                     values: &spv.get_simple_parameter_values(),
                 };
 
-                assert_approx_eq!(f64, p.before(ctx, &mut state).unwrap().unwrap(), ts.index as f64);
+                assert_approx_eq!(f64, p.before(ctx, &mut state).unwrap(), ts.index as f64);
             }
         }
     }
@@ -470,7 +478,7 @@ mod tests {
                     assert!(p.before(ctx, &mut state).is_err());
                 } else {
                     // Otherwise, we should return the value
-                    assert_approx_eq!(f64, p.before(ctx, &mut state).unwrap().unwrap(), ts.index as f64);
+                    assert_approx_eq!(f64, p.before(ctx, &mut state).unwrap(), ts.index as f64);
                 }
             }
         }

--- a/pywr-core/src/parameters/array.rs
+++ b/pywr-core/src/parameters/array.rs
@@ -2,8 +2,7 @@ use crate::network::ResolutionMaps;
 use crate::parameters::errors::SimpleCalculationError;
 use crate::parameters::{
     BuiltParameter, MaybeBuiltParameter, Parameter, ParameterBuildError, ParameterBuilder, ParameterMeta,
-    ParameterName, ParameterState, SimpleBeforeParameter, SimpleParameter, SimpleParameterContext,
-    SimpleParameterEntry,
+    ParameterName, ParameterState, SimpleParameter, SimpleParameterContext,
 };
 use crate::timestep::{Timestep, TimestepIndex};
 use ndarray::{Array1, Array2, Axis, s};
@@ -38,17 +37,8 @@ where
         &self.meta
     }
 }
-impl SimpleParameter for Array1Parameter<f64> {
-    fn as_parameter(&self) -> &dyn Parameter
-    where
-        Self: Sized,
-    {
-        self
-    }
-}
-
-impl SimpleBeforeParameter<f64> for Array1Parameter<f64> {
-    fn before(
+impl SimpleParameter<f64> for Array1Parameter<f64> {
+    fn compute(
         &self,
         ctx: SimpleParameterContext<'_>,
         _internal_state: &mut Option<Box<dyn ParameterState>>,
@@ -65,9 +55,6 @@ impl SimpleBeforeParameter<f64> for Array1Parameter<f64> {
             })?;
         Ok(*value)
     }
-}
-
-impl SimpleParameter for Array1Parameter<u64> {
     fn as_parameter(&self) -> &dyn Parameter
     where
         Self: Sized,
@@ -76,8 +63,8 @@ impl SimpleParameter for Array1Parameter<u64> {
     }
 }
 
-impl SimpleBeforeParameter<u64> for Array1Parameter<u64> {
-    fn before(
+impl SimpleParameter<u64> for Array1Parameter<u64> {
+    fn compute(
         &self,
         ctx: SimpleParameterContext<'_>,
         _internal_state: &mut Option<Box<dyn ParameterState>>,
@@ -92,6 +79,12 @@ impl SimpleBeforeParameter<u64> for Array1Parameter<u64> {
                 axis: 0,
             })?;
         Ok(*value)
+    }
+    fn as_parameter(&self) -> &dyn Parameter
+    where
+        Self: Sized,
+    {
+        self
     }
 }
 
@@ -130,7 +123,7 @@ impl ParameterBuilder<f64> for Array1ParameterBuilder<f64> {
             array: self.array,
             timestep_offset: self.timestep_offset,
         };
-        Ok(BuiltParameter::Simple(SimpleParameterEntry::before(p)).into())
+        Ok(BuiltParameter::Simple(Box::new(p)).into())
     }
 }
 
@@ -147,7 +140,7 @@ impl ParameterBuilder<u64> for Array1ParameterBuilder<u64> {
             array: self.array,
             timestep_offset: self.timestep_offset,
         };
-        Ok(BuiltParameter::Simple(SimpleParameterEntry::before(p)).into())
+        Ok(BuiltParameter::Simple(Box::new(p)).into())
     }
 }
 
@@ -183,17 +176,8 @@ where
     }
 }
 
-impl SimpleParameter for Array2Parameter<f64> {
-    fn as_parameter(&self) -> &dyn Parameter
-    where
-        Self: Sized,
-    {
-        self
-    }
-}
-
-impl SimpleBeforeParameter<f64> for Array2Parameter<f64> {
-    fn before(
+impl SimpleParameter<f64> for Array2Parameter<f64> {
+    fn compute(
         &self,
         ctx: SimpleParameterContext<'_>,
         _internal_state: &mut Option<Box<dyn ParameterState>>,
@@ -224,8 +208,6 @@ impl SimpleBeforeParameter<f64> for Array2Parameter<f64> {
         })?;
         Ok(*value)
     }
-}
-impl SimpleParameter for Array2Parameter<u64> {
     fn as_parameter(&self) -> &dyn Parameter
     where
         Self: Sized,
@@ -233,8 +215,9 @@ impl SimpleParameter for Array2Parameter<u64> {
         self
     }
 }
-impl SimpleBeforeParameter<u64> for Array2Parameter<u64> {
-    fn before(
+
+impl SimpleParameter<u64> for Array2Parameter<u64> {
+    fn compute(
         &self,
         ctx: SimpleParameterContext<'_>,
         _internal_state: &mut Option<Box<dyn ParameterState>>,
@@ -264,6 +247,12 @@ impl SimpleBeforeParameter<u64> for Array2Parameter<u64> {
             }
         })?;
         Ok(*value)
+    }
+    fn as_parameter(&self) -> &dyn Parameter
+    where
+        Self: Sized,
+    {
+        self
     }
 }
 
@@ -320,7 +309,7 @@ impl ParameterBuilder<f64> for Array2ParameterBuilder<f64> {
             timestep_offset: self.timestep_offset,
         };
 
-        Ok(BuiltParameter::Simple(SimpleParameterEntry::before(p)).into())
+        Ok(BuiltParameter::Simple(Box::new(p)).into())
     }
 }
 
@@ -352,7 +341,7 @@ impl ParameterBuilder<u64> for Array2ParameterBuilder<u64> {
             scenario_group_index,
             timestep_offset: self.timestep_offset,
         };
-        Ok(BuiltParameter::Simple(SimpleParameterEntry::before(p)).into())
+        Ok(BuiltParameter::Simple(Box::new(p)).into())
     }
 }
 
@@ -407,7 +396,7 @@ mod tests {
                     scenario_index: si,
                     values: &spv.get_simple_parameter_values(),
                 };
-                assert_approx_eq!(f64, p.before(ctx, &mut state).unwrap(), ts.index as f64);
+                assert_approx_eq!(f64, p.compute(ctx, &mut state).unwrap(), ts.index as f64);
             }
         }
     }
@@ -440,7 +429,7 @@ mod tests {
                     values: &spv.get_simple_parameter_values(),
                 };
 
-                assert_approx_eq!(f64, p.before(ctx, &mut state).unwrap(), ts.index as f64);
+                assert_approx_eq!(f64, p.compute(ctx, &mut state).unwrap(), ts.index as f64);
             }
         }
     }
@@ -475,10 +464,10 @@ mod tests {
 
                 if ts.index >= 5 {
                     // If the time-step index is out of bounds, we should return an error
-                    assert!(p.before(ctx, &mut state).is_err());
+                    assert!(p.compute(ctx, &mut state).is_err());
                 } else {
                     // Otherwise, we should return the value
-                    assert_approx_eq!(f64, p.before(ctx, &mut state).unwrap(), ts.index as f64);
+                    assert_approx_eq!(f64, p.compute(ctx, &mut state).unwrap(), ts.index as f64);
                 }
             }
         }

--- a/pywr-core/src/parameters/asymmetric.rs
+++ b/pywr-core/src/parameters/asymmetric.rs
@@ -1,13 +1,12 @@
 use crate::metric::{MetricU64, UnresolvedMetricU64};
-use crate::network::{Network, ResolutionMaps};
+use crate::network::ResolutionMaps;
 use crate::parameters::errors::{GeneralCalculationError, ParameterSetupError};
 use crate::parameters::{
-    BuiltParameter, GeneralParameter, MaybeBuiltParameter, Parameter, ParameterBuildError, ParameterBuilder,
-    ParameterMeta, ParameterName, ParameterState, downcast_internal_state_mut,
+    BuiltParameter, GeneralParameter, GeneralParameterContext, MaybeBuiltParameter, Parameter, ParameterBuildError,
+    ParameterBuilder, ParameterMeta, ParameterName, ParameterState, downcast_internal_state_mut,
 };
 use crate::resolve_metric_u64;
 use crate::scenario::ScenarioIndex;
-use crate::state::State;
 use crate::timestep::Timestep;
 
 #[derive(Debug)]
@@ -33,13 +32,10 @@ impl Parameter for AsymmetricSwitchIndexParameter {
 impl GeneralParameter<u64> for AsymmetricSwitchIndexParameter {
     fn before(
         &self,
-        _timestep: &Timestep,
-        _scenario_index: &ScenarioIndex,
-        network: &Network,
-        state: &State,
+        ctx: GeneralParameterContext<'_>,
         internal_state: &mut Option<Box<dyn ParameterState>>,
     ) -> Result<Option<u64>, GeneralCalculationError> {
-        let on_value = self.on_parameter.get_value(network, state)?;
+        let on_value = self.on_parameter.get_value(ctx.network, ctx.state)?;
 
         // Downcast the internal state to the correct type
         let current_state = downcast_internal_state_mut::<u64>(internal_state);
@@ -48,7 +44,7 @@ impl GeneralParameter<u64> for AsymmetricSwitchIndexParameter {
             if on_value > 0 {
                 // No change
             } else {
-                let off_value = self.off_parameter.get_value(network, state)?;
+                let off_value = self.off_parameter.get_value(ctx.network, ctx.state)?;
 
                 if off_value == 0 {
                     *current_state = 0;

--- a/pywr-core/src/parameters/asymmetric.rs
+++ b/pywr-core/src/parameters/asymmetric.rs
@@ -2,8 +2,9 @@ use crate::metric::{MetricU64, UnresolvedMetricU64};
 use crate::network::ResolutionMaps;
 use crate::parameters::errors::{GeneralCalculationError, ParameterSetupError};
 use crate::parameters::{
-    BuiltParameter, GeneralParameter, GeneralParameterContext, MaybeBuiltParameter, Parameter, ParameterBuildError,
-    ParameterBuilder, ParameterMeta, ParameterName, ParameterState, downcast_internal_state_mut,
+    BuiltParameter, GeneralBeforeParameter, GeneralParameter, GeneralParameterContext, GeneralParameterEntry,
+    MaybeBuiltParameter, Parameter, ParameterBuildError, ParameterBuilder, ParameterMeta, ParameterName,
+    ParameterState, downcast_internal_state_mut,
 };
 use crate::resolve_metric_u64;
 use crate::scenario::ScenarioIndex;
@@ -29,12 +30,20 @@ impl Parameter for AsymmetricSwitchIndexParameter {
     }
 }
 
-impl GeneralParameter<u64> for AsymmetricSwitchIndexParameter {
+impl GeneralParameter for AsymmetricSwitchIndexParameter {
+    fn as_parameter(&self) -> &dyn Parameter
+    where
+        Self: Sized,
+    {
+        self
+    }
+}
+impl GeneralBeforeParameter<u64> for AsymmetricSwitchIndexParameter {
     fn before(
         &self,
         ctx: GeneralParameterContext<'_>,
         internal_state: &mut Option<Box<dyn ParameterState>>,
-    ) -> Result<Option<u64>, GeneralCalculationError> {
+    ) -> Result<u64, GeneralCalculationError> {
         let on_value = self.on_parameter.get_value(ctx.network, ctx.state)?;
 
         // Downcast the internal state to the correct type
@@ -54,17 +63,9 @@ impl GeneralParameter<u64> for AsymmetricSwitchIndexParameter {
             *current_state = 1;
         }
 
-        Ok(Some(*current_state))
-    }
-
-    fn as_parameter(&self) -> &dyn Parameter
-    where
-        Self: Sized,
-    {
-        self
+        Ok(*current_state)
     }
 }
-
 #[derive(Debug)]
 pub struct AsymmetricSwitchIndexParameterBuilder {
     meta: ParameterMeta,
@@ -100,6 +101,6 @@ impl ParameterBuilder<u64> for AsymmetricSwitchIndexParameterBuilder {
             off_parameter,
         };
 
-        Ok(MaybeBuiltParameter::Built(BuiltParameter::General(Box::new(p))))
+        Ok(BuiltParameter::General(GeneralParameterEntry::before(p)).into())
     }
 }

--- a/pywr-core/src/parameters/control_curves/apportion.rs
+++ b/pywr-core/src/parameters/control_curves/apportion.rs
@@ -2,8 +2,9 @@ use crate::metric::{MetricF64, UnresolvedMetricF64};
 use crate::network::ResolutionMaps;
 use crate::parameters::errors::GeneralCalculationError;
 use crate::parameters::{
-    BuiltParameter, GeneralParameter, GeneralParameterContext, MaybeBuiltParameter, Parameter, ParameterBuildError,
-    ParameterBuilder, ParameterMeta, ParameterName, ParameterState,
+    BuiltParameter, GeneralBeforeParameter, GeneralParameter, GeneralParameterContext, GeneralParameterEntry,
+    MaybeBuiltParameter, Parameter, ParameterBuildError, ParameterBuilder, ParameterMeta, ParameterName,
+    ParameterState,
 };
 use crate::resolve_metric_f64;
 use crate::state::MultiValue;
@@ -30,12 +31,21 @@ impl Parameter for ApportionParameter {
     }
 }
 
-impl GeneralParameter<MultiValue> for ApportionParameter {
+impl GeneralParameter for ApportionParameter {
+    fn as_parameter(&self) -> &dyn Parameter
+    where
+        Self: Sized,
+    {
+        self
+    }
+}
+
+impl GeneralBeforeParameter<MultiValue> for ApportionParameter {
     fn before(
         &self,
         ctx: GeneralParameterContext<'_>,
         _internal_state: &mut Option<Box<dyn ParameterState>>,
-    ) -> Result<Option<MultiValue>, GeneralCalculationError> {
+    ) -> Result<MultiValue, GeneralCalculationError> {
         // Current value
         let x = self.metric.get_value(ctx.network, ctx.state)?;
 
@@ -48,13 +58,7 @@ impl GeneralParameter<MultiValue> for ApportionParameter {
         let values = HashMap::from([("upper".to_string(), upper), ("lower".to_string(), lower)]);
 
         let value = MultiValue::new(values, HashMap::new());
-        Ok(Some(value))
-    }
-    fn as_parameter(&self) -> &dyn Parameter
-    where
-        Self: Sized,
-    {
-        self
+        Ok(value)
     }
 }
 
@@ -93,7 +97,7 @@ impl ParameterBuilder<MultiValue> for ApportionParameterBuilder {
             control_curve,
         };
 
-        let bp = BuiltParameter::General(Box::new(p));
+        let bp = BuiltParameter::General(GeneralParameterEntry::before(p));
         Ok(bp.into())
     }
 }

--- a/pywr-core/src/parameters/control_curves/apportion.rs
+++ b/pywr-core/src/parameters/control_curves/apportion.rs
@@ -1,14 +1,12 @@
 use crate::metric::{MetricF64, UnresolvedMetricF64};
-use crate::network::{Network, ResolutionMaps};
+use crate::network::ResolutionMaps;
 use crate::parameters::errors::GeneralCalculationError;
 use crate::parameters::{
-    BuiltParameter, GeneralParameter, MaybeBuiltParameter, Parameter, ParameterBuildError, ParameterBuilder,
-    ParameterMeta, ParameterName, ParameterState,
+    BuiltParameter, GeneralParameter, GeneralParameterContext, MaybeBuiltParameter, Parameter, ParameterBuildError,
+    ParameterBuilder, ParameterMeta, ParameterName, ParameterState,
 };
 use crate::resolve_metric_f64;
-use crate::scenario::ScenarioIndex;
-use crate::state::{MultiValue, State};
-use crate::timestep::Timestep;
+use crate::state::MultiValue;
 use std::collections::HashMap;
 
 /// A parameter which apportions a metric to an upper and lower amount based
@@ -35,17 +33,14 @@ impl Parameter for ApportionParameter {
 impl GeneralParameter<MultiValue> for ApportionParameter {
     fn before(
         &self,
-        _timestep: &Timestep,
-        _scenario_index: &ScenarioIndex,
-        model: &Network,
-        state: &State,
+        ctx: GeneralParameterContext<'_>,
         _internal_state: &mut Option<Box<dyn ParameterState>>,
     ) -> Result<Option<MultiValue>, GeneralCalculationError> {
         // Current value
-        let x = self.metric.get_value(model, state)?;
+        let x = self.metric.get_value(ctx.network, ctx.state)?;
 
         // Get the control curve value and force it
-        let control_curve = self.control_curve.get_value(model, state)?.clamp(0.0, 1.0);
+        let control_curve = self.control_curve.get_value(ctx.network, ctx.state)?.clamp(0.0, 1.0);
 
         let upper = (1.0 - control_curve) * x;
         let lower = control_curve * x;

--- a/pywr-core/src/parameters/control_curves/index.rs
+++ b/pywr-core/src/parameters/control_curves/index.rs
@@ -1,13 +1,10 @@
 use crate::metric::{MetricF64, UnresolvedMetricF64};
-use crate::network::{Network, ResolutionMaps};
+use crate::network::ResolutionMaps;
 use crate::parameters::errors::GeneralCalculationError;
 use crate::parameters::{
-    BuiltParameter, GeneralParameter, MaybeBuiltParameter, Parameter, ParameterBuildError, ParameterBuilder,
-    ParameterMeta, ParameterName, ParameterState,
+    BuiltParameter, GeneralParameter, GeneralParameterContext, MaybeBuiltParameter, Parameter, ParameterBuildError,
+    ParameterBuilder, ParameterMeta, ParameterName, ParameterState,
 };
-use crate::scenario::ScenarioIndex;
-use crate::state::State;
-use crate::timestep::Timestep;
 use crate::{resolve_metric_f64, resolve_metric_f64_vec};
 
 #[derive(Debug)]
@@ -26,17 +23,14 @@ impl Parameter for ControlCurveIndexParameter {
 impl GeneralParameter<u64> for ControlCurveIndexParameter {
     fn before(
         &self,
-        _timestep: &Timestep,
-        _scenario_index: &ScenarioIndex,
-        model: &Network,
-        state: &State,
+        ctx: GeneralParameterContext<'_>,
         _internal_state: &mut Option<Box<dyn ParameterState>>,
     ) -> Result<Option<u64>, GeneralCalculationError> {
         // Current value
-        let x = self.metric.get_value(model, state)?;
+        let x = self.metric.get_value(ctx.network, ctx.state)?;
 
         for (idx, control_curve) in self.control_curves.iter().enumerate() {
-            let cc_value = control_curve.get_value(model, state)?;
+            let cc_value = control_curve.get_value(ctx.network, ctx.state)?;
             if x >= cc_value {
                 return Ok(Some(idx as u64));
             }

--- a/pywr-core/src/parameters/control_curves/index.rs
+++ b/pywr-core/src/parameters/control_curves/index.rs
@@ -2,8 +2,9 @@ use crate::metric::{MetricF64, UnresolvedMetricF64};
 use crate::network::ResolutionMaps;
 use crate::parameters::errors::GeneralCalculationError;
 use crate::parameters::{
-    BuiltParameter, GeneralParameter, GeneralParameterContext, MaybeBuiltParameter, Parameter, ParameterBuildError,
-    ParameterBuilder, ParameterMeta, ParameterName, ParameterState,
+    BuiltParameter, GeneralBeforeParameter, GeneralParameter, GeneralParameterContext, GeneralParameterEntry,
+    MaybeBuiltParameter, Parameter, ParameterBuildError, ParameterBuilder, ParameterMeta, ParameterName,
+    ParameterState,
 };
 use crate::{resolve_metric_f64, resolve_metric_f64_vec};
 
@@ -20,28 +21,31 @@ impl Parameter for ControlCurveIndexParameter {
     }
 }
 
-impl GeneralParameter<u64> for ControlCurveIndexParameter {
+impl GeneralParameter for ControlCurveIndexParameter {
+    fn as_parameter(&self) -> &dyn Parameter
+    where
+        Self: Sized,
+    {
+        self
+    }
+}
+
+impl GeneralBeforeParameter<u64> for ControlCurveIndexParameter {
     fn before(
         &self,
         ctx: GeneralParameterContext<'_>,
         _internal_state: &mut Option<Box<dyn ParameterState>>,
-    ) -> Result<Option<u64>, GeneralCalculationError> {
+    ) -> Result<u64, GeneralCalculationError> {
         // Current value
         let x = self.metric.get_value(ctx.network, ctx.state)?;
 
         for (idx, control_curve) in self.control_curves.iter().enumerate() {
             let cc_value = control_curve.get_value(ctx.network, ctx.state)?;
             if x >= cc_value {
-                return Ok(Some(idx as u64));
+                return Ok(idx as u64);
             }
         }
-        Ok(Some(self.control_curves.len() as u64))
-    }
-    fn as_parameter(&self) -> &dyn Parameter
-    where
-        Self: Sized,
-    {
-        self
+        Ok(self.control_curves.len() as u64)
     }
 }
 
@@ -85,6 +89,6 @@ impl ParameterBuilder<u64> for ControlCurveIndexParameterBuilder {
             control_curves,
         };
 
-        Ok(MaybeBuiltParameter::Built(BuiltParameter::General(Box::new(p))))
+        Ok(BuiltParameter::General(GeneralParameterEntry::before(p)).into())
     }
 }

--- a/pywr-core/src/parameters/control_curves/interpolated.rs
+++ b/pywr-core/src/parameters/control_curves/interpolated.rs
@@ -1,14 +1,11 @@
 use crate::metric::{MetricF64, UnresolvedMetricF64};
-use crate::network::{Network, ResolutionMaps};
+use crate::network::ResolutionMaps;
 use crate::parameters::errors::GeneralCalculationError;
 use crate::parameters::interpolate::interpolate;
 use crate::parameters::{
-    BuiltParameter, GeneralParameter, MaybeBuiltParameter, Parameter, ParameterBuildError, ParameterBuilder,
-    ParameterMeta, ParameterName, ParameterState,
+    BuiltParameter, GeneralParameter, GeneralParameterContext, MaybeBuiltParameter, Parameter, ParameterBuildError,
+    ParameterBuilder, ParameterMeta, ParameterName, ParameterState,
 };
-use crate::scenario::ScenarioIndex;
-use crate::state::State;
-use crate::timestep::Timestep;
 use crate::{resolve_metric_f64, resolve_metric_f64_vec};
 
 #[derive(Debug)]
@@ -28,22 +25,19 @@ impl Parameter for ControlCurveInterpolatedParameter {
 impl GeneralParameter<f64> for ControlCurveInterpolatedParameter {
     fn before(
         &self,
-        _timestep: &Timestep,
-        _scenario_index: &ScenarioIndex,
-        model: &Network,
-        state: &State,
+        ctx: GeneralParameterContext<'_>,
         _internal_state: &mut Option<Box<dyn ParameterState>>,
     ) -> Result<Option<f64>, GeneralCalculationError> {
         // Current value
-        let x = self.metric.get_value(model, state)?;
+        let x = self.metric.get_value(ctx.network, ctx.state)?;
 
         let mut cc_prev = 1.0;
         for (idx, control_curve) in self.control_curves.iter().enumerate() {
-            let cc_value = control_curve.get_value(model, state)?;
+            let cc_value = control_curve.get_value(ctx.network, ctx.state)?;
 
             if x >= cc_value {
-                let lower_value = self.values[idx + 1].get_value(model, state)?;
-                let upper_value = self.values[idx].get_value(model, state)?;
+                let lower_value = self.values[idx + 1].get_value(ctx.network, ctx.state)?;
+                let upper_value = self.values[idx].get_value(ctx.network, ctx.state)?;
 
                 return Ok(Some(interpolate(x, cc_value, cc_prev, lower_value, upper_value)));
             }
@@ -54,8 +48,8 @@ impl GeneralParameter<f64> for ControlCurveInterpolatedParameter {
         let cc_value = 0.0;
         let n = self.values.len();
 
-        let lower_value = self.values[n - 1].get_value(model, state)?;
-        let upper_value = self.values[n - 2].get_value(model, state)?;
+        let lower_value = self.values[n - 1].get_value(ctx.network, ctx.state)?;
+        let upper_value = self.values[n - 2].get_value(ctx.network, ctx.state)?;
 
         Ok(Some(interpolate(x, cc_value, cc_prev, lower_value, upper_value)))
     }

--- a/pywr-core/src/parameters/control_curves/interpolated.rs
+++ b/pywr-core/src/parameters/control_curves/interpolated.rs
@@ -3,8 +3,9 @@ use crate::network::ResolutionMaps;
 use crate::parameters::errors::GeneralCalculationError;
 use crate::parameters::interpolate::interpolate;
 use crate::parameters::{
-    BuiltParameter, GeneralParameter, GeneralParameterContext, MaybeBuiltParameter, Parameter, ParameterBuildError,
-    ParameterBuilder, ParameterMeta, ParameterName, ParameterState,
+    BuiltParameter, GeneralBeforeParameter, GeneralParameter, GeneralParameterContext, GeneralParameterEntry,
+    MaybeBuiltParameter, Parameter, ParameterBuildError, ParameterBuilder, ParameterMeta, ParameterName,
+    ParameterState,
 };
 use crate::{resolve_metric_f64, resolve_metric_f64_vec};
 
@@ -22,12 +23,21 @@ impl Parameter for ControlCurveInterpolatedParameter {
     }
 }
 
-impl GeneralParameter<f64> for ControlCurveInterpolatedParameter {
+impl GeneralParameter for ControlCurveInterpolatedParameter {
+    fn as_parameter(&self) -> &dyn Parameter
+    where
+        Self: Sized,
+    {
+        self
+    }
+}
+
+impl GeneralBeforeParameter<f64> for ControlCurveInterpolatedParameter {
     fn before(
         &self,
         ctx: GeneralParameterContext<'_>,
         _internal_state: &mut Option<Box<dyn ParameterState>>,
-    ) -> Result<Option<f64>, GeneralCalculationError> {
+    ) -> Result<f64, GeneralCalculationError> {
         // Current value
         let x = self.metric.get_value(ctx.network, ctx.state)?;
 
@@ -39,7 +49,7 @@ impl GeneralParameter<f64> for ControlCurveInterpolatedParameter {
                 let lower_value = self.values[idx + 1].get_value(ctx.network, ctx.state)?;
                 let upper_value = self.values[idx].get_value(ctx.network, ctx.state)?;
 
-                return Ok(Some(interpolate(x, cc_value, cc_prev, lower_value, upper_value)));
+                return Ok(interpolate(x, cc_value, cc_prev, lower_value, upper_value));
             }
 
             cc_prev = cc_value
@@ -51,14 +61,7 @@ impl GeneralParameter<f64> for ControlCurveInterpolatedParameter {
         let lower_value = self.values[n - 1].get_value(ctx.network, ctx.state)?;
         let upper_value = self.values[n - 2].get_value(ctx.network, ctx.state)?;
 
-        Ok(Some(interpolate(x, cc_value, cc_prev, lower_value, upper_value)))
-    }
-
-    fn as_parameter(&self) -> &dyn Parameter
-    where
-        Self: Sized,
-    {
-        self
+        Ok(interpolate(x, cc_value, cc_prev, lower_value, upper_value))
     }
 }
 
@@ -111,7 +114,7 @@ impl ParameterBuilder<f64> for ControlCurveInterpolatedParameterBuilder {
             values,
         };
 
-        let bp = BuiltParameter::General(Box::new(p));
+        let bp = BuiltParameter::General(GeneralParameterEntry::before(p));
         Ok(bp.into())
     }
 }

--- a/pywr-core/src/parameters/control_curves/piecewise.rs
+++ b/pywr-core/src/parameters/control_curves/piecewise.rs
@@ -1,14 +1,11 @@
 use crate::metric::{MetricF64, UnresolvedMetricF64};
-use crate::network::{Network, ResolutionMaps};
+use crate::network::ResolutionMaps;
 use crate::parameters::errors::GeneralCalculationError;
 use crate::parameters::interpolate::interpolate;
 use crate::parameters::{
-    BuiltParameter, GeneralParameter, MaybeBuiltParameter, Parameter, ParameterBuildError, ParameterBuilder,
-    ParameterMeta, ParameterName, ParameterState,
+    BuiltParameter, GeneralParameter, GeneralParameterContext, MaybeBuiltParameter, Parameter, ParameterBuildError,
+    ParameterBuilder, ParameterMeta, ParameterName, ParameterState,
 };
-use crate::scenario::ScenarioIndex;
-use crate::state::State;
-use crate::timestep::Timestep;
 use crate::{resolve_metric_f64, resolve_metric_f64_vec};
 
 #[derive(Debug)]
@@ -29,18 +26,15 @@ impl Parameter for PiecewiseInterpolatedParameter {
 impl GeneralParameter<f64> for PiecewiseInterpolatedParameter {
     fn before(
         &self,
-        _timestep: &Timestep,
-        _scenario_index: &ScenarioIndex,
-        model: &Network,
-        state: &State,
+        ctx: GeneralParameterContext<'_>,
         _internal_state: &mut Option<Box<dyn ParameterState>>,
     ) -> Result<Option<f64>, GeneralCalculationError> {
         // Current value
-        let x = self.metric.get_value(model, state)?;
+        let x = self.metric.get_value(ctx.network, ctx.state)?;
 
         let mut cc_previous_value = self.maximum;
         for (idx, control_curve) in self.control_curves.iter().enumerate() {
-            let cc_value = control_curve.get_value(model, state)?;
+            let cc_value = control_curve.get_value(ctx.network, ctx.state)?;
             if x >= cc_value {
                 let v = self
                     .values

--- a/pywr-core/src/parameters/control_curves/piecewise.rs
+++ b/pywr-core/src/parameters/control_curves/piecewise.rs
@@ -3,8 +3,9 @@ use crate::network::ResolutionMaps;
 use crate::parameters::errors::GeneralCalculationError;
 use crate::parameters::interpolate::interpolate;
 use crate::parameters::{
-    BuiltParameter, GeneralParameter, GeneralParameterContext, MaybeBuiltParameter, Parameter, ParameterBuildError,
-    ParameterBuilder, ParameterMeta, ParameterName, ParameterState,
+    BuiltParameter, GeneralBeforeParameter, GeneralParameter, GeneralParameterContext, GeneralParameterEntry,
+    MaybeBuiltParameter, Parameter, ParameterBuildError, ParameterBuilder, ParameterMeta, ParameterName,
+    ParameterState,
 };
 use crate::{resolve_metric_f64, resolve_metric_f64_vec};
 
@@ -23,12 +24,21 @@ impl Parameter for PiecewiseInterpolatedParameter {
         &self.meta
     }
 }
-impl GeneralParameter<f64> for PiecewiseInterpolatedParameter {
+impl GeneralParameter for PiecewiseInterpolatedParameter {
+    fn as_parameter(&self) -> &dyn Parameter
+    where
+        Self: Sized,
+    {
+        self
+    }
+}
+
+impl GeneralBeforeParameter<f64> for PiecewiseInterpolatedParameter {
     fn before(
         &self,
         ctx: GeneralParameterContext<'_>,
         _internal_state: &mut Option<Box<dyn ParameterState>>,
-    ) -> Result<Option<f64>, GeneralCalculationError> {
+    ) -> Result<f64, GeneralCalculationError> {
         // Current value
         let x = self.metric.get_value(ctx.network, ctx.state)?;
 
@@ -44,7 +54,7 @@ impl GeneralParameter<f64> for PiecewiseInterpolatedParameter {
                         index: idx,
                         length: self.values.len(),
                     })?;
-                return Ok(Some(interpolate(x, cc_value, cc_previous_value, v[1], v[0])));
+                return Ok(interpolate(x, cc_value, cc_previous_value, v[1], v[0]));
             }
             cc_previous_value = cc_value;
         }
@@ -56,14 +66,7 @@ impl GeneralParameter<f64> for PiecewiseInterpolatedParameter {
                 index: 0,
                 length: self.values.len(),
             })?;
-        Ok(Some(interpolate(x, self.minimum, cc_previous_value, v[1], v[0])))
-    }
-
-    fn as_parameter(&self) -> &dyn Parameter
-    where
-        Self: Sized,
-    {
-        self
+        Ok(interpolate(x, self.minimum, cc_previous_value, v[1], v[0]))
     }
 }
 
@@ -124,7 +127,7 @@ impl ParameterBuilder<f64> for PiecewiseInterpolatedParameterBuilder {
             minimum: self.minimum,
         };
 
-        let bp = BuiltParameter::General(Box::new(p));
+        let bp = BuiltParameter::General(GeneralParameterEntry::before(p));
         Ok(bp.into())
     }
 }

--- a/pywr-core/src/parameters/control_curves/simple.rs
+++ b/pywr-core/src/parameters/control_curves/simple.rs
@@ -2,8 +2,9 @@ use crate::metric::{MetricF64, UnresolvedMetricF64};
 use crate::network::ResolutionMaps;
 use crate::parameters::errors::GeneralCalculationError;
 use crate::parameters::{
-    BuiltParameter, GeneralParameter, GeneralParameterContext, MaybeBuiltParameter, Parameter, ParameterBuildError,
-    ParameterBuilder, ParameterMeta, ParameterName, ParameterState,
+    BuiltParameter, GeneralBeforeParameter, GeneralParameter, GeneralParameterContext, GeneralParameterEntry,
+    MaybeBuiltParameter, Parameter, ParameterBuildError, ParameterBuilder, ParameterMeta, ParameterName,
+    ParameterState,
 };
 use crate::{resolve_metric_f64, resolve_metric_f64_vec};
 
@@ -21,12 +22,21 @@ impl Parameter for ControlCurveParameter {
     }
 }
 
-impl GeneralParameter<f64> for ControlCurveParameter {
+impl GeneralParameter for ControlCurveParameter {
+    fn as_parameter(&self) -> &dyn Parameter
+    where
+        Self: Sized,
+    {
+        self
+    }
+}
+
+impl GeneralBeforeParameter<f64> for ControlCurveParameter {
     fn before(
         &self,
         ctx: GeneralParameterContext<'_>,
         _internal_state: &mut Option<Box<dyn ParameterState>>,
-    ) -> Result<Option<f64>, GeneralCalculationError> {
+    ) -> Result<f64, GeneralCalculationError> {
         // Current value
         let x = self.metric.get_value(ctx.network, ctx.state)?;
 
@@ -41,7 +51,7 @@ impl GeneralParameter<f64> for ControlCurveParameter {
                         index: idx,
                         length: self.values.len(),
                     })?;
-                return Ok(Some(value.get_value(ctx.network, ctx.state)?));
+                return Ok(value.get_value(ctx.network, ctx.state)?);
             }
         }
 
@@ -54,14 +64,7 @@ impl GeneralParameter<f64> for ControlCurveParameter {
                 length: self.values.len(),
             })?;
 
-        Ok(Some(value.get_value(ctx.network, ctx.state)?))
-    }
-
-    fn as_parameter(&self) -> &dyn Parameter
-    where
-        Self: Sized,
-    {
-        self
+        Ok(value.get_value(ctx.network, ctx.state)?)
     }
 }
 
@@ -116,6 +119,6 @@ impl ParameterBuilder<f64> for ControlCurveParameterBuilder {
             values,
         };
 
-        Ok(MaybeBuiltParameter::Built(BuiltParameter::General(Box::new(p))))
+        Ok(BuiltParameter::General(GeneralParameterEntry::before(p)).into())
     }
 }

--- a/pywr-core/src/parameters/control_curves/simple.rs
+++ b/pywr-core/src/parameters/control_curves/simple.rs
@@ -1,13 +1,10 @@
 use crate::metric::{MetricF64, UnresolvedMetricF64};
-use crate::network::{Network, ResolutionMaps};
+use crate::network::ResolutionMaps;
 use crate::parameters::errors::GeneralCalculationError;
 use crate::parameters::{
-    BuiltParameter, GeneralParameter, MaybeBuiltParameter, Parameter, ParameterBuildError, ParameterBuilder,
-    ParameterMeta, ParameterName, ParameterState,
+    BuiltParameter, GeneralParameter, GeneralParameterContext, MaybeBuiltParameter, Parameter, ParameterBuildError,
+    ParameterBuilder, ParameterMeta, ParameterName, ParameterState,
 };
-use crate::scenario::ScenarioIndex;
-use crate::state::State;
-use crate::timestep::Timestep;
 use crate::{resolve_metric_f64, resolve_metric_f64_vec};
 
 #[derive(Debug)]
@@ -27,17 +24,14 @@ impl Parameter for ControlCurveParameter {
 impl GeneralParameter<f64> for ControlCurveParameter {
     fn before(
         &self,
-        _timestep: &Timestep,
-        _scenario_index: &ScenarioIndex,
-        model: &Network,
-        state: &State,
+        ctx: GeneralParameterContext<'_>,
         _internal_state: &mut Option<Box<dyn ParameterState>>,
     ) -> Result<Option<f64>, GeneralCalculationError> {
         // Current value
-        let x = self.metric.get_value(model, state)?;
+        let x = self.metric.get_value(ctx.network, ctx.state)?;
 
         for (idx, control_curve) in self.control_curves.iter().enumerate() {
-            let cc_value = control_curve.get_value(model, state)?;
+            let cc_value = control_curve.get_value(ctx.network, ctx.state)?;
             if x >= cc_value {
                 let value = self
                     .values
@@ -47,7 +41,7 @@ impl GeneralParameter<f64> for ControlCurveParameter {
                         index: idx,
                         length: self.values.len(),
                     })?;
-                return Ok(Some(value.get_value(model, state)?));
+                return Ok(Some(value.get_value(ctx.network, ctx.state)?));
             }
         }
 
@@ -60,7 +54,7 @@ impl GeneralParameter<f64> for ControlCurveParameter {
                 length: self.values.len(),
             })?;
 
-        Ok(Some(value.get_value(model, state)?))
+        Ok(Some(value.get_value(ctx.network, ctx.state)?))
     }
 
     fn as_parameter(&self) -> &dyn Parameter

--- a/pywr-core/src/parameters/control_curves/volume_between.rs
+++ b/pywr-core/src/parameters/control_curves/volume_between.rs
@@ -3,12 +3,9 @@ use crate::network::ResolutionMaps;
 use crate::parameters::errors::SimpleCalculationError;
 use crate::parameters::{
     BuiltParameter, MaybeBuiltParameter, Parameter, ParameterBuildError, ParameterBuilder, ParameterMeta,
-    ParameterName, ParameterState, SimpleParameter,
+    ParameterName, ParameterState, SimpleParameter, SimpleParameterContext,
 };
 use crate::resolve_metric_f64;
-use crate::scenario::ScenarioIndex;
-use crate::state::SimpleParameterValues;
-use crate::timestep::Timestep;
 use std::fmt::Debug;
 
 /// A parameter that returns the volume that is the proportion between two control curves
@@ -32,15 +29,19 @@ where
 impl SimpleParameter<f64> for VolumeBetweenControlCurvesParameter<SimpleMetricF64> {
     fn before(
         &self,
-        _timestep: &Timestep,
-        _scenario_index: &ScenarioIndex,
-        values: &SimpleParameterValues,
+        ctx: SimpleParameterContext<'_>,
         _internal_state: &mut Option<Box<dyn ParameterState>>,
     ) -> Result<Option<f64>, SimpleCalculationError> {
-        let total = self.total.get_value(values)?;
+        let total = self.total.get_value(ctx.values)?;
 
-        let lower = self.lower.as_ref().map_or(Ok(0.0), |metric| metric.get_value(values))?;
-        let upper = self.upper.as_ref().map_or(Ok(1.0), |metric| metric.get_value(values))?;
+        let lower = self
+            .lower
+            .as_ref()
+            .map_or(Ok(0.0), |metric| metric.get_value(ctx.values))?;
+        let upper = self
+            .upper
+            .as_ref()
+            .map_or(Ok(1.0), |metric| metric.get_value(ctx.values))?;
 
         Ok(Some(total * (upper - lower)))
     }

--- a/pywr-core/src/parameters/control_curves/volume_between.rs
+++ b/pywr-core/src/parameters/control_curves/volume_between.rs
@@ -3,7 +3,8 @@ use crate::network::ResolutionMaps;
 use crate::parameters::errors::SimpleCalculationError;
 use crate::parameters::{
     BuiltParameter, MaybeBuiltParameter, Parameter, ParameterBuildError, ParameterBuilder, ParameterMeta,
-    ParameterName, ParameterState, SimpleParameter, SimpleParameterContext,
+    ParameterName, ParameterState, SimpleBeforeParameter, SimpleParameter, SimpleParameterContext,
+    SimpleParameterEntry,
 };
 use crate::resolve_metric_f64;
 use std::fmt::Debug;
@@ -26,12 +27,21 @@ where
     }
 }
 
-impl SimpleParameter<f64> for VolumeBetweenControlCurvesParameter<SimpleMetricF64> {
+impl SimpleParameter for VolumeBetweenControlCurvesParameter<SimpleMetricF64> {
+    fn as_parameter(&self) -> &dyn Parameter
+    where
+        Self: Sized,
+    {
+        self
+    }
+}
+
+impl SimpleBeforeParameter<f64> for VolumeBetweenControlCurvesParameter<SimpleMetricF64> {
     fn before(
         &self,
         ctx: SimpleParameterContext<'_>,
         _internal_state: &mut Option<Box<dyn ParameterState>>,
-    ) -> Result<Option<f64>, SimpleCalculationError> {
+    ) -> Result<f64, SimpleCalculationError> {
         let total = self.total.get_value(ctx.values)?;
 
         let lower = self
@@ -43,14 +53,7 @@ impl SimpleParameter<f64> for VolumeBetweenControlCurvesParameter<SimpleMetricF6
             .as_ref()
             .map_or(Ok(1.0), |metric| metric.get_value(ctx.values))?;
 
-        Ok(Some(total * (upper - lower)))
-    }
-
-    fn as_parameter(&self) -> &dyn Parameter
-    where
-        Self: Sized,
-    {
-        self
+        Ok(total * (upper - lower))
     }
 }
 
@@ -138,6 +141,6 @@ impl ParameterBuilder<f64> for VolumeBetweenControlCurvesParameterBuilder<Unreso
             lower,
         };
 
-        Ok(MaybeBuiltParameter::Built(BuiltParameter::Simple(Box::new(p))))
+        Ok(BuiltParameter::Simple(SimpleParameterEntry::before(p)).into())
     }
 }

--- a/pywr-core/src/parameters/control_curves/volume_between.rs
+++ b/pywr-core/src/parameters/control_curves/volume_between.rs
@@ -3,8 +3,7 @@ use crate::network::ResolutionMaps;
 use crate::parameters::errors::SimpleCalculationError;
 use crate::parameters::{
     BuiltParameter, MaybeBuiltParameter, Parameter, ParameterBuildError, ParameterBuilder, ParameterMeta,
-    ParameterName, ParameterState, SimpleBeforeParameter, SimpleParameter, SimpleParameterContext,
-    SimpleParameterEntry,
+    ParameterName, ParameterState, SimpleParameter, SimpleParameterContext,
 };
 use crate::resolve_metric_f64;
 use std::fmt::Debug;
@@ -27,17 +26,8 @@ where
     }
 }
 
-impl SimpleParameter for VolumeBetweenControlCurvesParameter<SimpleMetricF64> {
-    fn as_parameter(&self) -> &dyn Parameter
-    where
-        Self: Sized,
-    {
-        self
-    }
-}
-
-impl SimpleBeforeParameter<f64> for VolumeBetweenControlCurvesParameter<SimpleMetricF64> {
-    fn before(
+impl SimpleParameter<f64> for VolumeBetweenControlCurvesParameter<SimpleMetricF64> {
+    fn compute(
         &self,
         ctx: SimpleParameterContext<'_>,
         _internal_state: &mut Option<Box<dyn ParameterState>>,
@@ -54,6 +44,12 @@ impl SimpleBeforeParameter<f64> for VolumeBetweenControlCurvesParameter<SimpleMe
             .map_or(Ok(1.0), |metric| metric.get_value(ctx.values))?;
 
         Ok(total * (upper - lower))
+    }
+    fn as_parameter(&self) -> &dyn Parameter
+    where
+        Self: Sized,
+    {
+        self
     }
 }
 
@@ -141,6 +137,6 @@ impl ParameterBuilder<f64> for VolumeBetweenControlCurvesParameterBuilder<Unreso
             lower,
         };
 
-        Ok(BuiltParameter::Simple(SimpleParameterEntry::before(p)).into())
+        Ok(BuiltParameter::Simple(Box::new(p)).into())
     }
 }

--- a/pywr-core/src/parameters/deficit.rs
+++ b/pywr-core/src/parameters/deficit.rs
@@ -1,8 +1,9 @@
 use crate::metric::{MetricF64, UnresolvedMetricF64};
 use crate::network::ResolutionMaps;
 use crate::parameters::{
-    BuiltParameter, GeneralCalculationError, GeneralParameter, GeneralParameterContext, MaybeBuiltParameter, Parameter,
-    ParameterBuildError, ParameterBuilder, ParameterMeta, ParameterName, ParameterState,
+    BuiltParameter, GeneralAfterParameter, GeneralCalculationError, GeneralParameter, GeneralParameterContext,
+    GeneralParameterEntry, MaybeBuiltParameter, Parameter, ParameterBuildError, ParameterBuilder, ParameterMeta,
+    ParameterName, ParameterState,
 };
 use crate::resolve_metric_f64;
 
@@ -23,24 +24,26 @@ impl Parameter for DeficitParameter {
     }
 }
 
-impl GeneralParameter<f64> for DeficitParameter {
-    fn after(
-        &self,
-        ctx: GeneralParameterContext<'_>,
-        _internal_state: &mut Option<Box<dyn ParameterState>>,
-    ) -> Result<Option<f64>, GeneralCalculationError> {
-        let actual_flow = self.flow.get_value(ctx.network, ctx.state)?;
-        let max_flow = self.max_flow.get_value(ctx.network, ctx.state)?;
-
-        let deficit = (max_flow - actual_flow).max(0.0);
-        Ok(Some(deficit))
-    }
-
+impl GeneralParameter for DeficitParameter {
     fn as_parameter(&self) -> &dyn Parameter
     where
         Self: Sized,
     {
         self
+    }
+}
+
+impl GeneralAfterParameter<f64> for DeficitParameter {
+    fn after(
+        &self,
+        ctx: GeneralParameterContext<'_>,
+        _internal_state: &mut Option<Box<dyn ParameterState>>,
+    ) -> Result<f64, GeneralCalculationError> {
+        let actual_flow = self.flow.get_value(ctx.network, ctx.state)?;
+        let max_flow = self.max_flow.get_value(ctx.network, ctx.state)?;
+
+        let deficit = (max_flow - actual_flow).max(0.0);
+        Ok(deficit)
     }
 }
 
@@ -79,6 +82,6 @@ impl ParameterBuilder<f64> for DeficitParameterBuilder {
             max_flow,
         };
 
-        Ok(MaybeBuiltParameter::Built(BuiltParameter::General(Box::new(p))))
+        Ok(BuiltParameter::General(GeneralParameterEntry::after(p)).into())
     }
 }

--- a/pywr-core/src/parameters/deficit.rs
+++ b/pywr-core/src/parameters/deficit.rs
@@ -1,13 +1,10 @@
 use crate::metric::{MetricF64, UnresolvedMetricF64};
-use crate::network::{Network, ResolutionMaps};
+use crate::network::ResolutionMaps;
 use crate::parameters::{
-    BuiltParameter, GeneralCalculationError, GeneralParameter, MaybeBuiltParameter, Parameter, ParameterBuildError,
-    ParameterBuilder, ParameterMeta, ParameterName, ParameterState,
+    BuiltParameter, GeneralCalculationError, GeneralParameter, GeneralParameterContext, MaybeBuiltParameter, Parameter,
+    ParameterBuildError, ParameterBuilder, ParameterMeta, ParameterName, ParameterState,
 };
 use crate::resolve_metric_f64;
-use crate::scenario::ScenarioIndex;
-use crate::state::State;
-use crate::timestep::Timestep;
 
 /// A parameter representing the deficit between a flow metric and a max metric.
 ///
@@ -29,14 +26,11 @@ impl Parameter for DeficitParameter {
 impl GeneralParameter<f64> for DeficitParameter {
     fn after(
         &self,
-        _timestep: &Timestep,
-        _scenario_index: &ScenarioIndex,
-        model: &Network,
-        state: &State,
+        ctx: GeneralParameterContext<'_>,
         _internal_state: &mut Option<Box<dyn ParameterState>>,
     ) -> Result<Option<f64>, GeneralCalculationError> {
-        let actual_flow = self.flow.get_value(model, state)?;
-        let max_flow = self.max_flow.get_value(model, state)?;
+        let actual_flow = self.flow.get_value(ctx.network, ctx.state)?;
+        let max_flow = self.max_flow.get_value(ctx.network, ctx.state)?;
 
         let deficit = (max_flow - actual_flow).max(0.0);
         Ok(Some(deficit))

--- a/pywr-core/src/parameters/delay.rs
+++ b/pywr-core/src/parameters/delay.rs
@@ -2,14 +2,14 @@ use crate::metric::{
     MetricF64, MetricF64Error, MetricU64, MetricU64Error, SimpleMetricF64, SimpleMetricU64, UnresolvedMetricF64,
     UnresolvedMetricU64,
 };
-use crate::network::{Network, ResolutionMaps};
+use crate::network::ResolutionMaps;
 use crate::parameters::errors::{GeneralCalculationError, ParameterSetupError, SimpleCalculationError};
 use crate::parameters::{
-    BuiltParameter, GeneralParameter, MaybeBuiltParameter, Parameter, ParameterBuildError, ParameterBuilder,
-    ParameterMeta, ParameterName, ParameterState, SimpleParameter, downcast_internal_state_mut,
+    BuiltParameter, GeneralParameter, GeneralParameterContext, MaybeBuiltParameter, Parameter, ParameterBuildError,
+    ParameterBuilder, ParameterMeta, ParameterName, ParameterState, SimpleParameter, downcast_internal_state_mut,
 };
 use crate::scenario::ScenarioIndex;
-use crate::state::{SimpleParameterValues, State};
+use crate::state::SimpleParameterValues;
 use crate::timestep::Timestep;
 use crate::{resolve_metric_f64, resolve_metric_u64};
 use std::collections::VecDeque;
@@ -78,10 +78,7 @@ where
 impl GeneralParameter<f64> for DelayParameter<MetricF64, f64> {
     fn before(
         &self,
-        _timestep: &Timestep,
-        _scenario_index: &ScenarioIndex,
-        _model: &Network,
-        _state: &State,
+        _ctx: GeneralParameterContext<'_>,
         internal_state: &mut Option<Box<dyn ParameterState>>,
     ) -> Result<Option<f64>, GeneralCalculationError> {
         // Downcast the internal state to the correct type
@@ -99,17 +96,14 @@ impl GeneralParameter<f64> for DelayParameter<MetricF64, f64> {
 
     fn after(
         &self,
-        _timestep: &Timestep,
-        _scenario_index: &ScenarioIndex,
-        model: &Network,
-        state: &State,
+        ctx: GeneralParameterContext<'_>,
         internal_state: &mut Option<Box<dyn ParameterState>>,
     ) -> Result<Option<f64>, GeneralCalculationError> {
         // Downcast the internal state to the correct type
         let memory = downcast_internal_state_mut::<VecDeque<f64>>(internal_state);
 
         // Get today's value from the metric
-        let value = self.metric.get_value(model, state)?;
+        let value = self.metric.get_value(ctx.network, ctx.state)?;
         memory.push_back(value);
 
         Ok(None)
@@ -181,10 +175,7 @@ impl SimpleParameter<f64> for DelayParameter<SimpleMetricF64, f64> {
 impl GeneralParameter<u64> for DelayParameter<MetricU64, u64> {
     fn before(
         &self,
-        _timestep: &Timestep,
-        _scenario_index: &ScenarioIndex,
-        _model: &Network,
-        _state: &State,
+        _ctx: GeneralParameterContext<'_>,
         internal_state: &mut Option<Box<dyn ParameterState>>,
     ) -> Result<Option<u64>, GeneralCalculationError> {
         // Downcast the internal state to the correct type
@@ -202,17 +193,14 @@ impl GeneralParameter<u64> for DelayParameter<MetricU64, u64> {
 
     fn after(
         &self,
-        _timestep: &Timestep,
-        _scenario_index: &ScenarioIndex,
-        model: &Network,
-        state: &State,
+        ctx: GeneralParameterContext<'_>,
         internal_state: &mut Option<Box<dyn ParameterState>>,
     ) -> Result<Option<u64>, GeneralCalculationError> {
         // Downcast the internal state to the correct type
         let memory = downcast_internal_state_mut::<VecDeque<u64>>(internal_state);
 
         // Get today's value from the metric
-        let value = self.metric.get_value(model, state)?;
+        let value = self.metric.get_value(ctx.network, ctx.state)?;
         memory.push_back(value);
 
         Ok(None)

--- a/pywr-core/src/parameters/delay.rs
+++ b/pywr-core/src/parameters/delay.rs
@@ -5,9 +5,10 @@ use crate::metric::{
 use crate::network::ResolutionMaps;
 use crate::parameters::errors::{GeneralCalculationError, ParameterSetupError, SimpleCalculationError};
 use crate::parameters::{
-    BuiltParameter, GeneralParameter, GeneralParameterContext, MaybeBuiltParameter, Parameter, ParameterBuildError,
-    ParameterBuilder, ParameterMeta, ParameterName, ParameterState, SimpleParameter, SimpleParameterContext,
-    downcast_internal_state_mut,
+    BuiltParameter, GeneralAfterParameterHook, GeneralBeforeParameter, GeneralParameter, GeneralParameterContext,
+    GeneralParameterEntry, MaybeBuiltParameter, Parameter, ParameterBuildError, ParameterBuilder, ParameterMeta,
+    ParameterName, ParameterState, SimpleAfterParameterHook, SimpleBeforeParameter, SimpleParameter,
+    SimpleParameterContext, SimpleParameterEntry, downcast_internal_state_mut,
 };
 use crate::scenario::ScenarioIndex;
 use crate::timestep::Timestep;
@@ -75,12 +76,21 @@ where
     }
 }
 
-impl GeneralParameter<f64> for DelayParameter<MetricF64, f64> {
+impl GeneralParameter for DelayParameter<MetricF64, f64> {
+    fn as_parameter(&self) -> &dyn Parameter
+    where
+        Self: Sized,
+    {
+        self
+    }
+}
+
+impl GeneralBeforeParameter<f64> for DelayParameter<MetricF64, f64> {
     fn before(
         &self,
         _ctx: GeneralParameterContext<'_>,
         internal_state: &mut Option<Box<dyn ParameterState>>,
-    ) -> Result<Option<f64>, GeneralCalculationError> {
+    ) -> Result<f64, GeneralCalculationError> {
         // Downcast the internal state to the correct type
         let memory = downcast_internal_state_mut::<VecDeque<f64>>(internal_state);
 
@@ -91,14 +101,15 @@ impl GeneralParameter<f64> for DelayParameter<MetricF64, f64> {
                 .into(),
         })?;
 
-        Ok(Some(value))
+        Ok(value)
     }
-
+}
+impl GeneralAfterParameterHook<f64> for DelayParameter<MetricF64, f64> {
     fn after(
         &self,
         ctx: GeneralParameterContext<'_>,
         internal_state: &mut Option<Box<dyn ParameterState>>,
-    ) -> Result<Option<f64>, GeneralCalculationError> {
+    ) -> Result<(), GeneralCalculationError> {
         // Downcast the internal state to the correct type
         let memory = downcast_internal_state_mut::<VecDeque<f64>>(internal_state);
 
@@ -106,18 +117,11 @@ impl GeneralParameter<f64> for DelayParameter<MetricF64, f64> {
         let value = self.metric.get_value(ctx.network, ctx.state)?;
         memory.push_back(value);
 
-        Ok(None)
+        Ok(())
     }
+}
 
-    fn try_into_simple(&self) -> Option<Box<dyn SimpleParameter<f64>>>
-    where
-        Self: Sized,
-    {
-        self.try_into()
-            .ok()
-            .map(|p: DelayParameter<SimpleMetricF64, f64>| Box::new(p) as Box<dyn SimpleParameter<f64>>)
-    }
-
+impl SimpleParameter for DelayParameter<SimpleMetricF64, f64> {
     fn as_parameter(&self) -> &dyn Parameter
     where
         Self: Sized,
@@ -126,12 +130,12 @@ impl GeneralParameter<f64> for DelayParameter<MetricF64, f64> {
     }
 }
 
-impl SimpleParameter<f64> for DelayParameter<SimpleMetricF64, f64> {
+impl SimpleBeforeParameter<f64> for DelayParameter<SimpleMetricF64, f64> {
     fn before(
         &self,
         _ctx: SimpleParameterContext<'_>,
         internal_state: &mut Option<Box<dyn ParameterState>>,
-    ) -> Result<Option<f64>, SimpleCalculationError> {
+    ) -> Result<f64, SimpleCalculationError> {
         // Downcast the internal state to the correct type
         let memory = downcast_internal_state_mut::<VecDeque<f64>>(internal_state);
 
@@ -142,14 +146,15 @@ impl SimpleParameter<f64> for DelayParameter<SimpleMetricF64, f64> {
                 .into(),
         })?;
 
-        Ok(Some(value))
+        Ok(value)
     }
-
+}
+impl SimpleAfterParameterHook<f64> for DelayParameter<SimpleMetricF64, f64> {
     fn after(
         &self,
         ctx: SimpleParameterContext<'_>,
         internal_state: &mut Option<Box<dyn ParameterState>>,
-    ) -> Result<Option<f64>, SimpleCalculationError> {
+    ) -> Result<(), SimpleCalculationError> {
         // Downcast the internal state to the correct type
         let memory = downcast_internal_state_mut::<VecDeque<f64>>(internal_state);
 
@@ -157,9 +162,11 @@ impl SimpleParameter<f64> for DelayParameter<SimpleMetricF64, f64> {
         let value = self.metric.get_value(ctx.values)?;
         memory.push_back(value);
 
-        Ok(None)
+        Ok(())
     }
+}
 
+impl GeneralParameter for DelayParameter<MetricU64, u64> {
     fn as_parameter(&self) -> &dyn Parameter
     where
         Self: Sized,
@@ -168,12 +175,12 @@ impl SimpleParameter<f64> for DelayParameter<SimpleMetricF64, f64> {
     }
 }
 
-impl GeneralParameter<u64> for DelayParameter<MetricU64, u64> {
+impl GeneralBeforeParameter<u64> for DelayParameter<MetricU64, u64> {
     fn before(
         &self,
         _ctx: GeneralParameterContext<'_>,
         internal_state: &mut Option<Box<dyn ParameterState>>,
-    ) -> Result<Option<u64>, GeneralCalculationError> {
+    ) -> Result<u64, GeneralCalculationError> {
         // Downcast the internal state to the correct type
         let memory = downcast_internal_state_mut::<VecDeque<u64>>(internal_state);
 
@@ -184,14 +191,15 @@ impl GeneralParameter<u64> for DelayParameter<MetricU64, u64> {
                 .into(),
         })?;
 
-        Ok(Some(value))
+        Ok(value)
     }
-
+}
+impl GeneralAfterParameterHook<u64> for DelayParameter<MetricU64, u64> {
     fn after(
         &self,
         ctx: GeneralParameterContext<'_>,
         internal_state: &mut Option<Box<dyn ParameterState>>,
-    ) -> Result<Option<u64>, GeneralCalculationError> {
+    ) -> Result<(), GeneralCalculationError> {
         // Downcast the internal state to the correct type
         let memory = downcast_internal_state_mut::<VecDeque<u64>>(internal_state);
 
@@ -199,18 +207,11 @@ impl GeneralParameter<u64> for DelayParameter<MetricU64, u64> {
         let value = self.metric.get_value(ctx.network, ctx.state)?;
         memory.push_back(value);
 
-        Ok(None)
+        Ok(())
     }
+}
 
-    fn try_into_simple(&self) -> Option<Box<dyn SimpleParameter<u64>>>
-    where
-        Self: Sized,
-    {
-        self.try_into()
-            .ok()
-            .map(|p: DelayParameter<SimpleMetricU64, u64>| Box::new(p) as Box<dyn SimpleParameter<u64>>)
-    }
-
+impl SimpleParameter for DelayParameter<SimpleMetricU64, u64> {
     fn as_parameter(&self) -> &dyn Parameter
     where
         Self: Sized,
@@ -219,12 +220,12 @@ impl GeneralParameter<u64> for DelayParameter<MetricU64, u64> {
     }
 }
 
-impl SimpleParameter<u64> for DelayParameter<SimpleMetricU64, u64> {
+impl SimpleBeforeParameter<u64> for DelayParameter<SimpleMetricU64, u64> {
     fn before(
         &self,
         _ctx: SimpleParameterContext<'_>,
         internal_state: &mut Option<Box<dyn ParameterState>>,
-    ) -> Result<Option<u64>, SimpleCalculationError> {
+    ) -> Result<u64, SimpleCalculationError> {
         // Downcast the internal state to the correct type
         let memory = downcast_internal_state_mut::<VecDeque<u64>>(internal_state);
 
@@ -235,14 +236,15 @@ impl SimpleParameter<u64> for DelayParameter<SimpleMetricU64, u64> {
                 .into(),
         })?;
 
-        Ok(Some(value))
+        Ok(value)
     }
-
+}
+impl SimpleAfterParameterHook<u64> for DelayParameter<SimpleMetricU64, u64> {
     fn after(
         &self,
         ctx: SimpleParameterContext<'_>,
         internal_state: &mut Option<Box<dyn ParameterState>>,
-    ) -> Result<Option<u64>, SimpleCalculationError> {
+    ) -> Result<(), SimpleCalculationError> {
         // Downcast the internal state to the correct type
         let memory = downcast_internal_state_mut::<VecDeque<u64>>(internal_state);
 
@@ -250,14 +252,7 @@ impl SimpleParameter<u64> for DelayParameter<SimpleMetricU64, u64> {
         let value = self.metric.get_value(ctx.values)?;
         memory.push_back(value);
 
-        Ok(None)
-    }
-
-    fn as_parameter(&self) -> &dyn Parameter
-    where
-        Self: Sized,
-    {
-        self
+        Ok(())
     }
 }
 
@@ -291,6 +286,19 @@ impl ParameterBuilder<f64> for DelayParameterBuilder<UnresolvedMetricF64, f64> {
     ) -> Result<MaybeBuiltParameter<f64>, ParameterBuildError> {
         let metric = resolve_metric_f64!(self, self.metric, resolution_maps, "metric");
 
+        let simple_metric: Result<SimpleMetricF64, _> = metric.clone().try_into();
+        if let Ok(simple_metric) = simple_metric {
+            let p = DelayParameter {
+                meta: self.meta,
+                metric: simple_metric,
+                delay: self.delay,
+                initial_value: self.initial_value,
+            };
+
+            let bp = BuiltParameter::Simple(SimpleParameterEntry::before_with_after_hook(p));
+            return Ok(bp.into());
+        }
+
         let p = DelayParameter {
             meta: self.meta,
             metric,
@@ -298,7 +306,7 @@ impl ParameterBuilder<f64> for DelayParameterBuilder<UnresolvedMetricF64, f64> {
             initial_value: self.initial_value,
         };
 
-        let bp = BuiltParameter::General(Box::new(p));
+        let bp = BuiltParameter::General(GeneralParameterEntry::before_with_after_hook(p));
         Ok(bp.into())
     }
 }
@@ -314,6 +322,19 @@ impl ParameterBuilder<u64> for DelayParameterBuilder<UnresolvedMetricU64, u64> {
     ) -> Result<MaybeBuiltParameter<u64>, ParameterBuildError> {
         let metric = resolve_metric_u64!(self, self.metric, resolution_maps, "metric");
 
+        let simple_metric: Result<SimpleMetricU64, _> = metric.clone().try_into();
+        if let Ok(simple_metric) = simple_metric {
+            let p = DelayParameter {
+                meta: self.meta,
+                metric: simple_metric,
+                delay: self.delay,
+                initial_value: self.initial_value,
+            };
+
+            let bp = BuiltParameter::Simple(SimpleParameterEntry::before_with_after_hook(p));
+            return Ok(bp.into());
+        }
+
         let p = DelayParameter {
             meta: self.meta,
             metric,
@@ -321,7 +342,7 @@ impl ParameterBuilder<u64> for DelayParameterBuilder<UnresolvedMetricU64, u64> {
             initial_value: self.initial_value,
         };
 
-        let bp = BuiltParameter::General(Box::new(p));
+        let bp = BuiltParameter::General(GeneralParameterEntry::before_with_after_hook(p));
         Ok(bp.into())
     }
 }

--- a/pywr-core/src/parameters/delay.rs
+++ b/pywr-core/src/parameters/delay.rs
@@ -6,10 +6,10 @@ use crate::network::ResolutionMaps;
 use crate::parameters::errors::{GeneralCalculationError, ParameterSetupError, SimpleCalculationError};
 use crate::parameters::{
     BuiltParameter, GeneralParameter, GeneralParameterContext, MaybeBuiltParameter, Parameter, ParameterBuildError,
-    ParameterBuilder, ParameterMeta, ParameterName, ParameterState, SimpleParameter, downcast_internal_state_mut,
+    ParameterBuilder, ParameterMeta, ParameterName, ParameterState, SimpleParameter, SimpleParameterContext,
+    downcast_internal_state_mut,
 };
 use crate::scenario::ScenarioIndex;
-use crate::state::SimpleParameterValues;
 use crate::timestep::Timestep;
 use crate::{resolve_metric_f64, resolve_metric_u64};
 use std::collections::VecDeque;
@@ -129,9 +129,7 @@ impl GeneralParameter<f64> for DelayParameter<MetricF64, f64> {
 impl SimpleParameter<f64> for DelayParameter<SimpleMetricF64, f64> {
     fn before(
         &self,
-        _timestep: &Timestep,
-        _scenario_index: &ScenarioIndex,
-        _values: &SimpleParameterValues,
+        _ctx: SimpleParameterContext<'_>,
         internal_state: &mut Option<Box<dyn ParameterState>>,
     ) -> Result<Option<f64>, SimpleCalculationError> {
         // Downcast the internal state to the correct type
@@ -149,16 +147,14 @@ impl SimpleParameter<f64> for DelayParameter<SimpleMetricF64, f64> {
 
     fn after(
         &self,
-        _timestep: &Timestep,
-        _scenario_index: &ScenarioIndex,
-        values: &SimpleParameterValues,
+        ctx: SimpleParameterContext<'_>,
         internal_state: &mut Option<Box<dyn ParameterState>>,
     ) -> Result<Option<f64>, SimpleCalculationError> {
         // Downcast the internal state to the correct type
         let memory = downcast_internal_state_mut::<VecDeque<f64>>(internal_state);
 
         // Get today's value from the metric
-        let value = self.metric.get_value(values)?;
+        let value = self.metric.get_value(ctx.values)?;
         memory.push_back(value);
 
         Ok(None)
@@ -226,9 +222,7 @@ impl GeneralParameter<u64> for DelayParameter<MetricU64, u64> {
 impl SimpleParameter<u64> for DelayParameter<SimpleMetricU64, u64> {
     fn before(
         &self,
-        _timestep: &Timestep,
-        _scenario_index: &ScenarioIndex,
-        _values: &SimpleParameterValues,
+        _ctx: SimpleParameterContext<'_>,
         internal_state: &mut Option<Box<dyn ParameterState>>,
     ) -> Result<Option<u64>, SimpleCalculationError> {
         // Downcast the internal state to the correct type
@@ -246,16 +240,14 @@ impl SimpleParameter<u64> for DelayParameter<SimpleMetricU64, u64> {
 
     fn after(
         &self,
-        _timestep: &Timestep,
-        _scenario_index: &ScenarioIndex,
-        values: &SimpleParameterValues,
+        ctx: SimpleParameterContext<'_>,
         internal_state: &mut Option<Box<dyn ParameterState>>,
     ) -> Result<Option<u64>, SimpleCalculationError> {
         // Downcast the internal state to the correct type
         let memory = downcast_internal_state_mut::<VecDeque<u64>>(internal_state);
 
         // Get today's value from the metric
-        let value = self.metric.get_value(values)?;
+        let value = self.metric.get_value(ctx.values)?;
         memory.push_back(value);
 
         Ok(None)

--- a/pywr-core/src/parameters/delay.rs
+++ b/pywr-core/src/parameters/delay.rs
@@ -7,8 +7,7 @@ use crate::parameters::errors::{GeneralCalculationError, ParameterSetupError, Si
 use crate::parameters::{
     BuiltParameter, GeneralAfterParameterHook, GeneralBeforeParameter, GeneralParameter, GeneralParameterContext,
     GeneralParameterEntry, MaybeBuiltParameter, Parameter, ParameterBuildError, ParameterBuilder, ParameterMeta,
-    ParameterName, ParameterState, SimpleAfterParameterHook, SimpleBeforeParameter, SimpleParameter,
-    SimpleParameterContext, SimpleParameterEntry, downcast_internal_state_mut,
+    ParameterName, ParameterState, SimpleParameter, SimpleParameterContext, downcast_internal_state_mut,
 };
 use crate::scenario::ScenarioIndex;
 use crate::timestep::Timestep;
@@ -121,23 +120,18 @@ impl GeneralAfterParameterHook<f64> for DelayParameter<MetricF64, f64> {
     }
 }
 
-impl SimpleParameter for DelayParameter<SimpleMetricF64, f64> {
-    fn as_parameter(&self) -> &dyn Parameter
-    where
-        Self: Sized,
-    {
-        self
-    }
-}
-
-impl SimpleBeforeParameter<f64> for DelayParameter<SimpleMetricF64, f64> {
-    fn before(
+impl SimpleParameter<f64> for DelayParameter<SimpleMetricF64, f64> {
+    fn compute(
         &self,
-        _ctx: SimpleParameterContext<'_>,
+        ctx: SimpleParameterContext<'_>,
         internal_state: &mut Option<Box<dyn ParameterState>>,
     ) -> Result<f64, SimpleCalculationError> {
         // Downcast the internal state to the correct type
         let memory = downcast_internal_state_mut::<VecDeque<f64>>(internal_state);
+
+        // Get today's value from the metric
+        let value = self.metric.get_value(ctx.values)?;
+        memory.push_back(value);
 
         // Take the oldest value from the queue
         // It should be guaranteed that the internal memory/queue has self.delay number of values
@@ -148,21 +142,11 @@ impl SimpleBeforeParameter<f64> for DelayParameter<SimpleMetricF64, f64> {
 
         Ok(value)
     }
-}
-impl SimpleAfterParameterHook<f64> for DelayParameter<SimpleMetricF64, f64> {
-    fn after(
-        &self,
-        ctx: SimpleParameterContext<'_>,
-        internal_state: &mut Option<Box<dyn ParameterState>>,
-    ) -> Result<(), SimpleCalculationError> {
-        // Downcast the internal state to the correct type
-        let memory = downcast_internal_state_mut::<VecDeque<f64>>(internal_state);
-
-        // Get today's value from the metric
-        let value = self.metric.get_value(ctx.values)?;
-        memory.push_back(value);
-
-        Ok(())
+    fn as_parameter(&self) -> &dyn Parameter
+    where
+        Self: Sized,
+    {
+        self
     }
 }
 
@@ -211,23 +195,18 @@ impl GeneralAfterParameterHook<u64> for DelayParameter<MetricU64, u64> {
     }
 }
 
-impl SimpleParameter for DelayParameter<SimpleMetricU64, u64> {
-    fn as_parameter(&self) -> &dyn Parameter
-    where
-        Self: Sized,
-    {
-        self
-    }
-}
-
-impl SimpleBeforeParameter<u64> for DelayParameter<SimpleMetricU64, u64> {
-    fn before(
+impl SimpleParameter<u64> for DelayParameter<SimpleMetricU64, u64> {
+    fn compute(
         &self,
-        _ctx: SimpleParameterContext<'_>,
+        ctx: SimpleParameterContext<'_>,
         internal_state: &mut Option<Box<dyn ParameterState>>,
     ) -> Result<u64, SimpleCalculationError> {
         // Downcast the internal state to the correct type
         let memory = downcast_internal_state_mut::<VecDeque<u64>>(internal_state);
+
+        // Get today's value from the metric
+        let value = self.metric.get_value(ctx.values)?;
+        memory.push_back(value);
 
         // Take the oldest value from the queue
         // It should be guaranteed that the internal memory/queue has self.delay number of values
@@ -238,21 +217,11 @@ impl SimpleBeforeParameter<u64> for DelayParameter<SimpleMetricU64, u64> {
 
         Ok(value)
     }
-}
-impl SimpleAfterParameterHook<u64> for DelayParameter<SimpleMetricU64, u64> {
-    fn after(
-        &self,
-        ctx: SimpleParameterContext<'_>,
-        internal_state: &mut Option<Box<dyn ParameterState>>,
-    ) -> Result<(), SimpleCalculationError> {
-        // Downcast the internal state to the correct type
-        let memory = downcast_internal_state_mut::<VecDeque<u64>>(internal_state);
-
-        // Get today's value from the metric
-        let value = self.metric.get_value(ctx.values)?;
-        memory.push_back(value);
-
-        Ok(())
+    fn as_parameter(&self) -> &dyn Parameter
+    where
+        Self: Sized,
+    {
+        self
     }
 }
 
@@ -295,7 +264,7 @@ impl ParameterBuilder<f64> for DelayParameterBuilder<UnresolvedMetricF64, f64> {
                 initial_value: self.initial_value,
             };
 
-            let bp = BuiltParameter::Simple(SimpleParameterEntry::before_with_after_hook(p));
+            let bp = BuiltParameter::Simple(Box::new(p));
             return Ok(bp.into());
         }
 
@@ -331,7 +300,7 @@ impl ParameterBuilder<u64> for DelayParameterBuilder<UnresolvedMetricU64, u64> {
                 initial_value: self.initial_value,
             };
 
-            let bp = BuiltParameter::Simple(SimpleParameterEntry::before_with_after_hook(p));
+            let bp = BuiltParameter::Simple(Box::new(p));
             return Ok(bp.into());
         }
 

--- a/pywr-core/src/parameters/difference.rs
+++ b/pywr-core/src/parameters/difference.rs
@@ -1,6 +1,7 @@
 use super::{
-    BuiltParameter, GeneralParameterContext, MaybeBuiltParameter, Parameter, ParameterBuildError, ParameterBuilder,
-    ParameterName, SimpleParameter, SimpleParameterContext,
+    BuiltParameter, GeneralBeforeParameter, GeneralParameterContext, GeneralParameterEntry, MaybeBuiltParameter,
+    Parameter, ParameterBuildError, ParameterBuilder, ParameterName, SimpleBeforeParameter, SimpleParameter,
+    SimpleParameterContext, SimpleParameterEntry,
 };
 use crate::metric::{MetricF64, SimpleMetricF64, UnresolvedMetricF64};
 use crate::network::ResolutionMaps;
@@ -33,12 +34,21 @@ where
         &self.meta
     }
 }
-impl GeneralParameter<f64> for DifferenceParameter<MetricF64> {
+impl GeneralParameter for DifferenceParameter<MetricF64> {
+    fn as_parameter(&self) -> &dyn Parameter
+    where
+        Self: Sized,
+    {
+        self
+    }
+}
+
+impl GeneralBeforeParameter<f64> for DifferenceParameter<MetricF64> {
     fn before(
         &self,
         ctx: GeneralParameterContext<'_>,
         _internal_state: &mut Option<Box<dyn ParameterState>>,
-    ) -> Result<Option<f64>, GeneralCalculationError> {
+    ) -> Result<f64, GeneralCalculationError> {
         let a = self.a.get_value(ctx.network, ctx.state)?;
         let b = self.b.get_value(ctx.network, ctx.state)?;
         let min = self
@@ -52,52 +62,31 @@ impl GeneralParameter<f64> for DifferenceParameter<MetricF64> {
             .map(|m| m.get_value(ctx.network, ctx.state))
             .transpose()?;
 
-        Ok(Some(difference(a, b, min, max)))
+        Ok(difference(a, b, min, max))
     }
+}
 
+impl SimpleParameter for DifferenceParameter<SimpleMetricF64> {
     fn as_parameter(&self) -> &dyn Parameter
     where
         Self: Sized,
     {
         self
     }
-
-    fn try_into_simple(&self) -> Option<Box<dyn SimpleParameter<f64>>> {
-        // We can make a simple version if all metrics can be simplified
-        let a: SimpleMetricF64 = self.a.clone().try_into().ok()?;
-        let b: SimpleMetricF64 = self.b.clone().try_into().ok()?;
-        let min: Option<SimpleMetricF64> = self.min.as_ref().map(|m| m.clone().try_into()).transpose().ok()?;
-        let max: Option<SimpleMetricF64> = self.max.as_ref().map(|m| m.clone().try_into()).transpose().ok()?;
-
-        Some(Box::new(DifferenceParameter::<SimpleMetricF64> {
-            meta: self.meta.clone(),
-            a,
-            b,
-            min,
-            max,
-        }))
-    }
 }
 
-impl SimpleParameter<f64> for DifferenceParameter<SimpleMetricF64> {
+impl SimpleBeforeParameter<f64> for DifferenceParameter<SimpleMetricF64> {
     fn before(
         &self,
         ctx: SimpleParameterContext<'_>,
         _internal_state: &mut Option<Box<dyn ParameterState>>,
-    ) -> Result<Option<f64>, SimpleCalculationError> {
+    ) -> Result<f64, SimpleCalculationError> {
         let a = self.a.get_value(ctx.values)?;
         let b = self.b.get_value(ctx.values)?;
         let min = self.min.as_ref().map(|m| m.get_value(ctx.values)).transpose()?;
         let max = self.max.as_ref().map(|m| m.get_value(ctx.values)).transpose()?;
 
-        Ok(Some(difference(a, b, min, max)))
-    }
-
-    fn as_parameter(&self) -> &dyn Parameter
-    where
-        Self: Sized,
-    {
-        self
+        Ok(difference(a, b, min, max))
     }
 }
 
@@ -168,6 +157,25 @@ impl ParameterBuilder<f64> for DifferenceParameterBuilder {
             None => None,
         };
 
+        {
+            // We can make a simple version if all metrics can be simplified
+            let a: Result<SimpleMetricF64, _> = a.clone().try_into();
+            let b: Result<SimpleMetricF64, _> = b.clone().try_into();
+            let min: Result<Option<SimpleMetricF64>, _> = min.as_ref().map(|m| m.clone().try_into()).transpose();
+            let max: Result<Option<SimpleMetricF64>, _> = max.as_ref().map(|m| m.clone().try_into()).transpose();
+
+            if let (Ok(a), Ok(b), Ok(min), Ok(max)) = (a, b, min, max) {
+                let p = DifferenceParameter {
+                    meta: self.meta,
+                    a,
+                    b,
+                    min,
+                    max,
+                };
+                return Ok(BuiltParameter::Simple(SimpleParameterEntry::before(p)).into());
+            }
+        }
+
         let p = DifferenceParameter {
             meta: self.meta,
             a,
@@ -176,7 +184,7 @@ impl ParameterBuilder<f64> for DifferenceParameterBuilder {
             max,
         };
 
-        Ok(MaybeBuiltParameter::Built(BuiltParameter::General(Box::new(p))))
+        Ok(BuiltParameter::General(GeneralParameterEntry::before(p)).into())
     }
 }
 

--- a/pywr-core/src/parameters/difference.rs
+++ b/pywr-core/src/parameters/difference.rs
@@ -1,14 +1,14 @@
 use super::{
-    BuiltParameter, MaybeBuiltParameter, Parameter, ParameterBuildError, ParameterBuilder, ParameterName,
-    SimpleParameter,
+    BuiltParameter, GeneralParameterContext, MaybeBuiltParameter, Parameter, ParameterBuildError, ParameterBuilder,
+    ParameterName, SimpleParameter,
 };
 use crate::metric::{MetricF64, SimpleMetricF64, UnresolvedMetricF64};
-use crate::network::{Network, ResolutionMaps};
+use crate::network::ResolutionMaps;
 use crate::parameters::errors::{GeneralCalculationError, SimpleCalculationError};
 use crate::parameters::{GeneralParameter, ParameterMeta, ParameterState};
 use crate::resolve_metric_f64;
 use crate::scenario::ScenarioIndex;
-use crate::state::{SimpleParameterValues, State};
+use crate::state::SimpleParameterValues;
 use crate::timestep::Timestep;
 use std::fmt::Debug;
 
@@ -39,16 +39,21 @@ where
 impl GeneralParameter<f64> for DifferenceParameter<MetricF64> {
     fn before(
         &self,
-        _timestep: &Timestep,
-        _scenario_index: &ScenarioIndex,
-        model: &Network,
-        state: &State,
+        ctx: GeneralParameterContext<'_>,
         _internal_state: &mut Option<Box<dyn ParameterState>>,
     ) -> Result<Option<f64>, GeneralCalculationError> {
-        let a = self.a.get_value(model, state)?;
-        let b = self.b.get_value(model, state)?;
-        let min = self.min.as_ref().map(|m| m.get_value(model, state)).transpose()?;
-        let max = self.max.as_ref().map(|m| m.get_value(model, state)).transpose()?;
+        let a = self.a.get_value(ctx.network, ctx.state)?;
+        let b = self.b.get_value(ctx.network, ctx.state)?;
+        let min = self
+            .min
+            .as_ref()
+            .map(|m| m.get_value(ctx.network, ctx.state))
+            .transpose()?;
+        let max = self
+            .max
+            .as_ref()
+            .map(|m| m.get_value(ctx.network, ctx.state))
+            .transpose()?;
 
         Ok(Some(difference(a, b, min, max)))
     }

--- a/pywr-core/src/parameters/difference.rs
+++ b/pywr-core/src/parameters/difference.rs
@@ -1,7 +1,6 @@
 use super::{
     BuiltParameter, GeneralBeforeParameter, GeneralParameterContext, GeneralParameterEntry, MaybeBuiltParameter,
-    Parameter, ParameterBuildError, ParameterBuilder, ParameterName, SimpleBeforeParameter, SimpleParameter,
-    SimpleParameterContext, SimpleParameterEntry,
+    Parameter, ParameterBuildError, ParameterBuilder, ParameterName, SimpleParameter, SimpleParameterContext,
 };
 use crate::metric::{MetricF64, SimpleMetricF64, UnresolvedMetricF64};
 use crate::network::ResolutionMaps;
@@ -66,17 +65,8 @@ impl GeneralBeforeParameter<f64> for DifferenceParameter<MetricF64> {
     }
 }
 
-impl SimpleParameter for DifferenceParameter<SimpleMetricF64> {
-    fn as_parameter(&self) -> &dyn Parameter
-    where
-        Self: Sized,
-    {
-        self
-    }
-}
-
-impl SimpleBeforeParameter<f64> for DifferenceParameter<SimpleMetricF64> {
-    fn before(
+impl SimpleParameter<f64> for DifferenceParameter<SimpleMetricF64> {
+    fn compute(
         &self,
         ctx: SimpleParameterContext<'_>,
         _internal_state: &mut Option<Box<dyn ParameterState>>,
@@ -87,6 +77,12 @@ impl SimpleBeforeParameter<f64> for DifferenceParameter<SimpleMetricF64> {
         let max = self.max.as_ref().map(|m| m.get_value(ctx.values)).transpose()?;
 
         Ok(difference(a, b, min, max))
+    }
+    fn as_parameter(&self) -> &dyn Parameter
+    where
+        Self: Sized,
+    {
+        self
     }
 }
 
@@ -172,7 +168,7 @@ impl ParameterBuilder<f64> for DifferenceParameterBuilder {
                     min,
                     max,
                 };
-                return Ok(BuiltParameter::Simple(SimpleParameterEntry::before(p)).into());
+                return Ok(BuiltParameter::Simple(Box::new(p)).into());
             }
         }
 

--- a/pywr-core/src/parameters/difference.rs
+++ b/pywr-core/src/parameters/difference.rs
@@ -1,15 +1,12 @@
 use super::{
     BuiltParameter, GeneralParameterContext, MaybeBuiltParameter, Parameter, ParameterBuildError, ParameterBuilder,
-    ParameterName, SimpleParameter,
+    ParameterName, SimpleParameter, SimpleParameterContext,
 };
 use crate::metric::{MetricF64, SimpleMetricF64, UnresolvedMetricF64};
 use crate::network::ResolutionMaps;
 use crate::parameters::errors::{GeneralCalculationError, SimpleCalculationError};
 use crate::parameters::{GeneralParameter, ParameterMeta, ParameterState};
 use crate::resolve_metric_f64;
-use crate::scenario::ScenarioIndex;
-use crate::state::SimpleParameterValues;
-use crate::timestep::Timestep;
 use std::fmt::Debug;
 
 /// A parameter that computes the difference between two metrics, with optional minimum and maximum bounds.
@@ -85,15 +82,13 @@ impl GeneralParameter<f64> for DifferenceParameter<MetricF64> {
 impl SimpleParameter<f64> for DifferenceParameter<SimpleMetricF64> {
     fn before(
         &self,
-        _timestep: &Timestep,
-        _scenario_index: &ScenarioIndex,
-        values: &SimpleParameterValues,
+        ctx: SimpleParameterContext<'_>,
         _internal_state: &mut Option<Box<dyn ParameterState>>,
     ) -> Result<Option<f64>, SimpleCalculationError> {
-        let a = self.a.get_value(values)?;
-        let b = self.b.get_value(values)?;
-        let min = self.min.as_ref().map(|m| m.get_value(values)).transpose()?;
-        let max = self.max.as_ref().map(|m| m.get_value(values)).transpose()?;
+        let a = self.a.get_value(ctx.values)?;
+        let b = self.b.get_value(ctx.values)?;
+        let min = self.min.as_ref().map(|m| m.get_value(ctx.values)).transpose()?;
+        let max = self.max.as_ref().map(|m| m.get_value(ctx.values)).transpose()?;
 
         Ok(Some(difference(a, b, min, max)))
     }

--- a/pywr-core/src/parameters/discount_factor.rs
+++ b/pywr-core/src/parameters/discount_factor.rs
@@ -1,14 +1,11 @@
 use crate::metric::{MetricF64, UnresolvedMetricF64};
-use crate::network::{Network, ResolutionMaps};
+use crate::network::ResolutionMaps;
 use crate::parameters::errors::GeneralCalculationError;
 use crate::parameters::{
-    BuiltParameter, GeneralParameter, MaybeBuiltParameter, Parameter, ParameterBuildError, ParameterBuilder,
-    ParameterMeta, ParameterName, ParameterState,
+    BuiltParameter, GeneralParameter, GeneralParameterContext, MaybeBuiltParameter, Parameter, ParameterBuildError,
+    ParameterBuilder, ParameterMeta, ParameterName, ParameterState,
 };
 use crate::resolve_metric_f64;
-use crate::scenario::ScenarioIndex;
-use crate::state::State;
-use crate::timestep::Timestep;
 use chrono::Datelike;
 
 #[derive(Debug)]
@@ -26,14 +23,11 @@ impl Parameter for DiscountFactorParameter {
 impl GeneralParameter<f64> for DiscountFactorParameter {
     fn before(
         &self,
-        timestep: &Timestep,
-        _scenario_index: &ScenarioIndex,
-        network: &Network,
-        state: &State,
+        ctx: GeneralParameterContext<'_>,
         _internal_state: &mut Option<Box<dyn ParameterState>>,
     ) -> Result<Option<f64>, GeneralCalculationError> {
-        let year = timestep.date.year() - self.base_year;
-        let rate = self.discount_rate.get_value(network, state)?;
+        let year = ctx.timestep.date.year() - self.base_year;
+        let rate = self.discount_rate.get_value(ctx.network, ctx.state)?;
 
         let factor = 1.0 / (1.0 + rate).powi(year);
         Ok(Some(factor))

--- a/pywr-core/src/parameters/discount_factor.rs
+++ b/pywr-core/src/parameters/discount_factor.rs
@@ -2,8 +2,9 @@ use crate::metric::{MetricF64, UnresolvedMetricF64};
 use crate::network::ResolutionMaps;
 use crate::parameters::errors::GeneralCalculationError;
 use crate::parameters::{
-    BuiltParameter, GeneralParameter, GeneralParameterContext, MaybeBuiltParameter, Parameter, ParameterBuildError,
-    ParameterBuilder, ParameterMeta, ParameterName, ParameterState,
+    BuiltParameter, GeneralBeforeParameter, GeneralParameter, GeneralParameterContext, GeneralParameterEntry,
+    MaybeBuiltParameter, Parameter, ParameterBuildError, ParameterBuilder, ParameterMeta, ParameterName,
+    ParameterState,
 };
 use crate::resolve_metric_f64;
 use chrono::Datelike;
@@ -20,24 +21,26 @@ impl Parameter for DiscountFactorParameter {
         &self.meta
     }
 }
-impl GeneralParameter<f64> for DiscountFactorParameter {
-    fn before(
-        &self,
-        ctx: GeneralParameterContext<'_>,
-        _internal_state: &mut Option<Box<dyn ParameterState>>,
-    ) -> Result<Option<f64>, GeneralCalculationError> {
-        let year = ctx.timestep.date.year() - self.base_year;
-        let rate = self.discount_rate.get_value(ctx.network, ctx.state)?;
-
-        let factor = 1.0 / (1.0 + rate).powi(year);
-        Ok(Some(factor))
-    }
-
+impl GeneralParameter for DiscountFactorParameter {
     fn as_parameter(&self) -> &dyn Parameter
     where
         Self: Sized,
     {
         self
+    }
+}
+
+impl GeneralBeforeParameter<f64> for DiscountFactorParameter {
+    fn before(
+        &self,
+        ctx: GeneralParameterContext<'_>,
+        _internal_state: &mut Option<Box<dyn ParameterState>>,
+    ) -> Result<f64, GeneralCalculationError> {
+        let year = ctx.timestep.date.year() - self.base_year;
+        let rate = self.discount_rate.get_value(ctx.network, ctx.state)?;
+
+        let factor = 1.0 / (1.0 + rate).powi(year);
+        Ok(factor)
     }
 }
 
@@ -74,8 +77,8 @@ impl ParameterBuilder<f64> for DiscountFactorParameterBuilder {
             base_year: self.base_year,
         };
 
-        let bp = BuiltParameter::General(Box::new(p));
-        Ok(MaybeBuiltParameter::Built(bp))
+        let bp = BuiltParameter::General(GeneralParameterEntry::before(p));
+        Ok(bp.into())
     }
 }
 

--- a/pywr-core/src/parameters/division.rs
+++ b/pywr-core/src/parameters/division.rs
@@ -1,12 +1,12 @@
-use super::{BuiltParameter, MaybeBuiltParameter, Parameter, ParameterBuildError, ParameterBuilder, ParameterName};
+use super::{
+    BuiltParameter, GeneralParameterContext, MaybeBuiltParameter, Parameter, ParameterBuildError, ParameterBuilder,
+    ParameterName,
+};
 use crate::metric::{MetricF64, UnresolvedMetricF64};
-use crate::network::{Network, ResolutionMaps};
+use crate::network::ResolutionMaps;
 use crate::parameters::errors::GeneralCalculationError;
 use crate::parameters::{GeneralParameter, ParameterMeta, ParameterState};
 use crate::resolve_metric_f64;
-use crate::scenario::ScenarioIndex;
-use crate::state::State;
-use crate::timestep::Timestep;
 
 #[derive(Debug)]
 pub struct DivisionParameter {
@@ -23,19 +23,16 @@ impl Parameter for DivisionParameter {
 impl GeneralParameter<f64> for DivisionParameter {
     fn before(
         &self,
-        _timestep: &Timestep,
-        _scenario_index: &ScenarioIndex,
-        model: &Network,
-        state: &State,
+        ctx: GeneralParameterContext<'_>,
         _internal_state: &mut Option<Box<dyn ParameterState>>,
     ) -> Result<Option<f64>, GeneralCalculationError> {
-        let denominator = self.denominator.get_value(model, state)?;
+        let denominator = self.denominator.get_value(ctx.network, ctx.state)?;
 
         if denominator == 0.0 {
             return Err(GeneralCalculationError::DivisionByZeroError);
         }
 
-        let numerator = self.numerator.get_value(model, state)?;
+        let numerator = self.numerator.get_value(ctx.network, ctx.state)?;
         Ok(Some(numerator / denominator))
     }
 

--- a/pywr-core/src/parameters/division.rs
+++ b/pywr-core/src/parameters/division.rs
@@ -1,6 +1,6 @@
 use super::{
-    BuiltParameter, GeneralParameterContext, MaybeBuiltParameter, Parameter, ParameterBuildError, ParameterBuilder,
-    ParameterName,
+    BuiltParameter, GeneralBeforeParameter, GeneralParameterContext, GeneralParameterEntry, MaybeBuiltParameter,
+    Parameter, ParameterBuildError, ParameterBuilder, ParameterName,
 };
 use crate::metric::{MetricF64, UnresolvedMetricF64};
 use crate::network::ResolutionMaps;
@@ -20,12 +20,21 @@ impl Parameter for DivisionParameter {
         &self.meta
     }
 }
-impl GeneralParameter<f64> for DivisionParameter {
+impl GeneralParameter for DivisionParameter {
+    fn as_parameter(&self) -> &dyn Parameter
+    where
+        Self: Sized,
+    {
+        self
+    }
+}
+
+impl GeneralBeforeParameter<f64> for DivisionParameter {
     fn before(
         &self,
         ctx: GeneralParameterContext<'_>,
         _internal_state: &mut Option<Box<dyn ParameterState>>,
-    ) -> Result<Option<f64>, GeneralCalculationError> {
+    ) -> Result<f64, GeneralCalculationError> {
         let denominator = self.denominator.get_value(ctx.network, ctx.state)?;
 
         if denominator == 0.0 {
@@ -33,14 +42,7 @@ impl GeneralParameter<f64> for DivisionParameter {
         }
 
         let numerator = self.numerator.get_value(ctx.network, ctx.state)?;
-        Ok(Some(numerator / denominator))
-    }
-
-    fn as_parameter(&self) -> &dyn Parameter
-    where
-        Self: Sized,
-    {
-        self
+        Ok(numerator / denominator)
     }
 }
 
@@ -79,6 +81,6 @@ impl ParameterBuilder<f64> for DivisionParameterBuilder {
             denominator,
         };
 
-        Ok(MaybeBuiltParameter::Built(BuiltParameter::General(Box::new(p))))
+        Ok(BuiltParameter::General(GeneralParameterEntry::before(p)).into())
     }
 }

--- a/pywr-core/src/parameters/errors.rs
+++ b/pywr-core/src/parameters/errors.rs
@@ -44,6 +44,10 @@ pub enum GeneralCalculationError {
     },
     #[error("Aggregation error: {0}")]
     AggFuncError(#[from] AggFuncError),
+    #[error(
+        "Calculation phase not enabled for parameter. This is a runtime error for parameter type `{ty}` that does support '{phase}', but has failed to calculate for the following reason: {message}"
+    )]
+    PhaseNotEnabled { ty: String, phase: String, message: String },
 }
 
 #[derive(Error, Debug)]

--- a/pywr-core/src/parameters/hydropower.rs
+++ b/pywr-core/src/parameters/hydropower.rs
@@ -2,8 +2,9 @@ use crate::metric::{MetricF64, UnresolvedMetricF64};
 use crate::network::{Network, ResolutionMaps};
 use crate::parameters::errors::GeneralCalculationError;
 use crate::parameters::{
-    BuiltParameter, GeneralParameter, GeneralParameterContext, MaybeBuiltParameter, Parameter, ParameterBuildError,
-    ParameterBuilder, ParameterMeta, ParameterName, ParameterState,
+    BuiltParameter, GeneralAfterParameter, GeneralBeforeParameter, GeneralParameter, GeneralParameterContext,
+    GeneralParameterEntry, MaybeBuiltParameter, Parameter, ParameterBuildError, ParameterBuilder, ParameterMeta,
+    ParameterName, ParameterState,
 };
 use crate::resolve_optional_metric_f64;
 use crate::state::State;
@@ -56,21 +57,29 @@ impl Parameter for HydropowerTargetParameter {
     }
 }
 
-impl GeneralParameter<f64> for HydropowerTargetParameter {
+impl GeneralParameter for HydropowerTargetParameter {
+    fn as_parameter(&self) -> &dyn Parameter
+    where
+        Self: Sized,
+    {
+        self
+    }
+}
+
+impl GeneralBeforeParameter<f64> for HydropowerTargetParameter {
     fn before(
         &self,
         ctx: GeneralParameterContext<'_>,
         _internal_state: &mut Option<Box<dyn ParameterState>>,
-    ) -> Result<Option<f64>, GeneralCalculationError> {
+    ) -> Result<f64, GeneralCalculationError> {
         let head = self.head(ctx.network, ctx.state)?;
-
-        // apply the minimum head threshold
-        if head <= self.turbine_min_head {
-            return Ok(Some(0.0));
-        }
 
         // Get the flow from the current node
         if let Some(target) = &self.target {
+            // apply the minimum head threshold
+            if head <= self.turbine_min_head {
+                return Ok(0.0);
+            }
             let power = target.get_value(ctx.network, ctx.state)?;
             let mut q = inverse_hydropower_calculation(
                 power,
@@ -94,18 +103,22 @@ impl GeneralParameter<f64> for HydropowerTargetParameter {
                     message: "The calculated flow is negative".into(),
                 });
             }
-            Ok(Some(q))
+            Ok(q)
         } else {
-            // No target flow therefore can not calculate a flow
-            Ok(None)
+            Err(GeneralCalculationError::PhaseNotEnabled {
+                ty: "HydropowerTargetParameter".into(),
+                phase: "before".into(),
+                message: "HydropowerTargetParameter must have a `target` defined for the before phase.".into(),
+            })
         }
     }
-
+}
+impl GeneralAfterParameter<f64> for HydropowerTargetParameter {
     fn after(
         &self,
         ctx: GeneralParameterContext<'_>,
         _internal_state: &mut Option<Box<dyn ParameterState>>,
-    ) -> Result<Option<f64>, GeneralCalculationError> {
+    ) -> Result<f64, GeneralCalculationError> {
         if let Some(actual_flow) = &self.actual_flow {
             let flow = actual_flow.get_value(ctx.network, ctx.state)?;
             // Calculate the head (the head may be negative)
@@ -113,28 +126,24 @@ impl GeneralParameter<f64> for HydropowerTargetParameter {
 
             // apply the minimum head threshold
             if head <= self.turbine_min_head {
-                return Ok(Some(0.0));
+                return Ok(0.0);
             }
 
-            Ok(Some(hydropower_calculation(
+            Ok(hydropower_calculation(
                 flow,
                 head,
                 self.turbine_efficiency,
                 self.flow_unit_conversion,
                 self.energy_unit_conversion,
                 self.water_density,
-            )))
+            ))
         } else {
-            // No actual flow therefore can not calculate power
-            Ok(None)
+            Err(GeneralCalculationError::PhaseNotEnabled {
+                ty: "HydropowerTargetParameter".into(),
+                phase: "after".into(),
+                message: "HydropowerTargetParameter must have an `actual_flow` defined for the after phase.".into(),
+            })
         }
-    }
-
-    fn as_parameter(&self) -> &dyn Parameter
-    where
-        Self: Sized,
-    {
-        self
     }
 }
 
@@ -204,6 +213,21 @@ impl ParameterBuilder<f64> for HydropowerTargetParameterBuilder {
             energy_unit_conversion: self.energy_unit_conversion,
         };
 
-        Ok(MaybeBuiltParameter::Built(BuiltParameter::General(Box::new(p))))
+        // Determine which calculation phase(s) the parameter will be used in
+        // based on whether the target and actual flow are provided.
+        // If neither is provided, return an error.
+        let entry = match (p.target.is_some(), p.actual_flow.is_some()) {
+            (true, true) => GeneralParameterEntry::both(p),
+            (true, false) => GeneralParameterEntry::before(p),
+            (false, true) => GeneralParameterEntry::after(p),
+            (false, false) => {
+                return Err(ParameterBuildError::NoCalculationPhase {
+                    detail: "HydropowerTargetParameter must have at least one of `target` or `actual_flow` defined."
+                        .into(),
+                });
+            }
+        };
+
+        Ok(BuiltParameter::General(entry).into())
     }
 }

--- a/pywr-core/src/parameters/hydropower.rs
+++ b/pywr-core/src/parameters/hydropower.rs
@@ -2,13 +2,11 @@ use crate::metric::{MetricF64, UnresolvedMetricF64};
 use crate::network::{Network, ResolutionMaps};
 use crate::parameters::errors::GeneralCalculationError;
 use crate::parameters::{
-    BuiltParameter, GeneralParameter, MaybeBuiltParameter, Parameter, ParameterBuildError, ParameterBuilder,
-    ParameterMeta, ParameterName, ParameterState,
+    BuiltParameter, GeneralParameter, GeneralParameterContext, MaybeBuiltParameter, Parameter, ParameterBuildError,
+    ParameterBuilder, ParameterMeta, ParameterName, ParameterState,
 };
 use crate::resolve_optional_metric_f64;
-use crate::scenario::ScenarioIndex;
 use crate::state::State;
-use crate::timestep::Timestep;
 use crate::utils::{hydropower_calculation, inverse_hydropower_calculation};
 
 pub struct HydropowerTargetData {
@@ -61,13 +59,10 @@ impl Parameter for HydropowerTargetParameter {
 impl GeneralParameter<f64> for HydropowerTargetParameter {
     fn before(
         &self,
-        _timestep: &Timestep,
-        _scenario_index: &ScenarioIndex,
-        model: &Network,
-        state: &State,
+        ctx: GeneralParameterContext<'_>,
         _internal_state: &mut Option<Box<dyn ParameterState>>,
     ) -> Result<Option<f64>, GeneralCalculationError> {
-        let head = self.head(model, state)?;
+        let head = self.head(ctx.network, ctx.state)?;
 
         // apply the minimum head threshold
         if head <= self.turbine_min_head {
@@ -76,7 +71,7 @@ impl GeneralParameter<f64> for HydropowerTargetParameter {
 
         // Get the flow from the current node
         if let Some(target) = &self.target {
-            let power = target.get_value(model, state)?;
+            let power = target.get_value(ctx.network, ctx.state)?;
             let mut q = inverse_hydropower_calculation(
                 power,
                 head,
@@ -88,10 +83,10 @@ impl GeneralParameter<f64> for HydropowerTargetParameter {
 
             // Bound the flow if required
             if let Some(max_flow) = &self.max_flow {
-                q = q.min(max_flow.get_value(model, state)?);
+                q = q.min(max_flow.get_value(ctx.network, ctx.state)?);
             }
             if let Some(min_flow) = &self.min_flow {
-                q = q.max(min_flow.get_value(model, state)?);
+                q = q.max(min_flow.get_value(ctx.network, ctx.state)?);
             }
 
             if q < 0.0 {
@@ -108,16 +103,13 @@ impl GeneralParameter<f64> for HydropowerTargetParameter {
 
     fn after(
         &self,
-        _timestep: &Timestep,
-        _scenario_index: &ScenarioIndex,
-        model: &Network,
-        state: &State,
+        ctx: GeneralParameterContext<'_>,
         _internal_state: &mut Option<Box<dyn ParameterState>>,
     ) -> Result<Option<f64>, GeneralCalculationError> {
         if let Some(actual_flow) = &self.actual_flow {
-            let flow = actual_flow.get_value(model, state)?;
+            let flow = actual_flow.get_value(ctx.network, ctx.state)?;
             // Calculate the head (the head may be negative)
-            let head = self.head(model, state)?;
+            let head = self.head(ctx.network, ctx.state)?;
 
             // apply the minimum head threshold
             if head <= self.turbine_min_head {

--- a/pywr-core/src/parameters/indexed_array.rs
+++ b/pywr-core/src/parameters/indexed_array.rs
@@ -1,13 +1,10 @@
 use crate::metric::{MetricF64, MetricU64, UnresolvedMetricF64, UnresolvedMetricU64};
-use crate::network::{Network, ResolutionMaps};
+use crate::network::ResolutionMaps;
 use crate::parameters::errors::GeneralCalculationError;
 use crate::parameters::{
-    BuiltParameter, GeneralParameter, MaybeBuiltParameter, Parameter, ParameterBuildError, ParameterBuilder,
-    ParameterMeta, ParameterName, ParameterState,
+    BuiltParameter, GeneralParameter, GeneralParameterContext, MaybeBuiltParameter, Parameter, ParameterBuildError,
+    ParameterBuilder, ParameterMeta, ParameterName, ParameterState,
 };
-use crate::scenario::ScenarioIndex;
-use crate::state::State;
-use crate::timestep::Timestep;
 use crate::{resolve_metric_f64_vec, resolve_metric_u64};
 
 #[derive(Debug)]
@@ -26,13 +23,10 @@ impl Parameter for IndexedArrayParameter {
 impl GeneralParameter<f64> for IndexedArrayParameter {
     fn before(
         &self,
-        _timestep: &Timestep,
-        _scenario_index: &ScenarioIndex,
-        network: &Network,
-        state: &State,
+        ctx: GeneralParameterContext<'_>,
         _internal_state: &mut Option<Box<dyn ParameterState>>,
     ) -> Result<Option<f64>, GeneralCalculationError> {
-        let index = self.index_parameter.get_value(network, state)? as usize;
+        let index = self.index_parameter.get_value(ctx.network, ctx.state)? as usize;
 
         let metric = self
             .metrics
@@ -43,7 +37,7 @@ impl GeneralParameter<f64> for IndexedArrayParameter {
                 axis: 0,
             })?;
 
-        Ok(Some(metric.get_value(network, state)?))
+        Ok(Some(metric.get_value(ctx.network, ctx.state)?))
     }
 
     fn as_parameter(&self) -> &dyn Parameter

--- a/pywr-core/src/parameters/indexed_array.rs
+++ b/pywr-core/src/parameters/indexed_array.rs
@@ -2,8 +2,9 @@ use crate::metric::{MetricF64, MetricU64, UnresolvedMetricF64, UnresolvedMetricU
 use crate::network::ResolutionMaps;
 use crate::parameters::errors::GeneralCalculationError;
 use crate::parameters::{
-    BuiltParameter, GeneralParameter, GeneralParameterContext, MaybeBuiltParameter, Parameter, ParameterBuildError,
-    ParameterBuilder, ParameterMeta, ParameterName, ParameterState,
+    BuiltParameter, GeneralBeforeParameter, GeneralParameter, GeneralParameterContext, GeneralParameterEntry,
+    MaybeBuiltParameter, Parameter, ParameterBuildError, ParameterBuilder, ParameterMeta, ParameterName,
+    ParameterState,
 };
 use crate::{resolve_metric_f64_vec, resolve_metric_u64};
 
@@ -20,12 +21,21 @@ impl Parameter for IndexedArrayParameter {
     }
 }
 
-impl GeneralParameter<f64> for IndexedArrayParameter {
+impl GeneralParameter for IndexedArrayParameter {
+    fn as_parameter(&self) -> &dyn Parameter
+    where
+        Self: Sized,
+    {
+        self
+    }
+}
+
+impl GeneralBeforeParameter<f64> for IndexedArrayParameter {
     fn before(
         &self,
         ctx: GeneralParameterContext<'_>,
         _internal_state: &mut Option<Box<dyn ParameterState>>,
-    ) -> Result<Option<f64>, GeneralCalculationError> {
+    ) -> Result<f64, GeneralCalculationError> {
         let index = self.index_parameter.get_value(ctx.network, ctx.state)? as usize;
 
         let metric = self
@@ -37,14 +47,7 @@ impl GeneralParameter<f64> for IndexedArrayParameter {
                 axis: 0,
             })?;
 
-        Ok(Some(metric.get_value(ctx.network, ctx.state)?))
-    }
-
-    fn as_parameter(&self) -> &dyn Parameter
-    where
-        Self: Sized,
-    {
-        self
+        Ok(metric.get_value(ctx.network, ctx.state)?)
     }
 }
 
@@ -88,6 +91,6 @@ impl ParameterBuilder<f64> for IndexedArrayParameterBuilder {
             metrics,
         };
 
-        Ok(MaybeBuiltParameter::Built(BuiltParameter::General(Box::new(p))))
+        Ok(BuiltParameter::General(GeneralParameterEntry::before(p)).into())
     }
 }

--- a/pywr-core/src/parameters/interpolated.rs
+++ b/pywr-core/src/parameters/interpolated.rs
@@ -3,8 +3,9 @@ use crate::network::ResolutionMaps;
 use crate::parameters::errors::GeneralCalculationError;
 use crate::parameters::interpolate::linear_interpolation;
 use crate::parameters::{
-    BuiltParameter, GeneralParameter, GeneralParameterContext, MaybeBuiltParameter, Parameter, ParameterBuildError,
-    ParameterBuilder, ParameterMeta, ParameterName, ParameterState,
+    BuiltParameter, GeneralBeforeParameter, GeneralParameter, GeneralParameterContext, GeneralParameterEntry,
+    MaybeBuiltParameter, Parameter, ParameterBuildError, ParameterBuilder, ParameterMeta, ParameterName,
+    ParameterState,
 };
 use crate::resolve_metric_f64;
 
@@ -22,12 +23,21 @@ impl Parameter for InterpolatedParameter {
         &self.meta
     }
 }
-impl GeneralParameter<f64> for InterpolatedParameter {
+impl GeneralParameter for InterpolatedParameter {
+    fn as_parameter(&self) -> &dyn Parameter
+    where
+        Self: Sized,
+    {
+        self
+    }
+}
+
+impl GeneralBeforeParameter<f64> for InterpolatedParameter {
     fn before(
         &self,
         ctx: GeneralParameterContext<'_>,
         _internal_state: &mut Option<Box<dyn ParameterState>>,
-    ) -> Result<Option<f64>, GeneralCalculationError> {
+    ) -> Result<f64, GeneralCalculationError> {
         // Current value
         let x = self.x.get_value(ctx.network, ctx.state)?;
 
@@ -44,14 +54,7 @@ impl GeneralParameter<f64> for InterpolatedParameter {
 
         let f = linear_interpolation(x, &points, self.error_on_bounds)?;
 
-        Ok(Some(f))
-    }
-
-    fn as_parameter(&self) -> &dyn Parameter
-    where
-        Self: Sized,
-    {
-        self
+        Ok(f)
     }
 }
 
@@ -108,6 +111,6 @@ impl ParameterBuilder<f64> for InterpolatedParameterBuilder {
             error_on_bounds: self.error_on_bounds,
         };
 
-        Ok(MaybeBuiltParameter::Built(BuiltParameter::General(Box::new(p))))
+        Ok(BuiltParameter::General(GeneralParameterEntry::before(p)).into())
     }
 }

--- a/pywr-core/src/parameters/interpolated.rs
+++ b/pywr-core/src/parameters/interpolated.rs
@@ -1,15 +1,12 @@
 use crate::metric::{MetricF64, UnresolvedMetricF64};
-use crate::network::{Network, ResolutionMaps};
+use crate::network::ResolutionMaps;
 use crate::parameters::errors::GeneralCalculationError;
 use crate::parameters::interpolate::linear_interpolation;
 use crate::parameters::{
-    BuiltParameter, GeneralParameter, MaybeBuiltParameter, Parameter, ParameterBuildError, ParameterBuilder,
-    ParameterMeta, ParameterName, ParameterState,
+    BuiltParameter, GeneralParameter, GeneralParameterContext, MaybeBuiltParameter, Parameter, ParameterBuildError,
+    ParameterBuilder, ParameterMeta, ParameterName, ParameterState,
 };
 use crate::resolve_metric_f64;
-use crate::scenario::ScenarioIndex;
-use crate::state::State;
-use crate::timestep::Timestep;
 
 /// A parameter that interpolates a value to a function with given discrete data points.
 #[derive(Debug)]
@@ -28,21 +25,18 @@ impl Parameter for InterpolatedParameter {
 impl GeneralParameter<f64> for InterpolatedParameter {
     fn before(
         &self,
-        _timestep: &Timestep,
-        _scenario_index: &ScenarioIndex,
-        network: &Network,
-        state: &State,
+        ctx: GeneralParameterContext<'_>,
         _internal_state: &mut Option<Box<dyn ParameterState>>,
     ) -> Result<Option<f64>, GeneralCalculationError> {
         // Current value
-        let x = self.x.get_value(network, state)?;
+        let x = self.x.get_value(ctx.network, ctx.state)?;
 
         let points = self
             .points
             .iter()
             .map(|(x, f)| {
-                let xp = x.get_value(network, state)?;
-                let fp = f.get_value(network, state)?;
+                let xp = x.get_value(ctx.network, ctx.state)?;
+                let fp = f.get_value(ctx.network, ctx.state)?;
 
                 Ok::<(f64, f64), GeneralCalculationError>((xp, fp))
             })

--- a/pywr-core/src/parameters/max.rs
+++ b/pywr-core/src/parameters/max.rs
@@ -1,14 +1,11 @@
 use crate::metric::{MetricF64, UnresolvedMetricF64};
-use crate::network::{Network, ResolutionMaps};
+use crate::network::ResolutionMaps;
 use crate::parameters::errors::GeneralCalculationError;
 use crate::parameters::{
-    BuiltParameter, GeneralParameter, MaybeBuiltParameter, Parameter, ParameterBuildError, ParameterBuilder,
-    ParameterMeta, ParameterName, ParameterState,
+    BuiltParameter, GeneralParameter, GeneralParameterContext, MaybeBuiltParameter, Parameter, ParameterBuildError,
+    ParameterBuilder, ParameterMeta, ParameterName, ParameterState,
 };
 use crate::resolve_metric_f64;
-use crate::scenario::ScenarioIndex;
-use crate::state::State;
-use crate::timestep::Timestep;
 
 #[derive(Debug)]
 pub struct MaxParameter {
@@ -26,14 +23,11 @@ impl Parameter for MaxParameter {
 impl GeneralParameter<f64> for MaxParameter {
     fn before(
         &self,
-        _timestep: &Timestep,
-        _scenario_index: &ScenarioIndex,
-        model: &Network,
-        state: &State,
+        ctx: GeneralParameterContext<'_>,
         _internal_state: &mut Option<Box<dyn ParameterState>>,
     ) -> Result<Option<f64>, GeneralCalculationError> {
         // Current value
-        let x = self.metric.get_value(model, state)?;
+        let x = self.metric.get_value(ctx.network, ctx.state)?;
         Ok(Some(x.max(self.threshold)))
     }
 

--- a/pywr-core/src/parameters/max.rs
+++ b/pywr-core/src/parameters/max.rs
@@ -2,8 +2,9 @@ use crate::metric::{MetricF64, UnresolvedMetricF64};
 use crate::network::ResolutionMaps;
 use crate::parameters::errors::GeneralCalculationError;
 use crate::parameters::{
-    BuiltParameter, GeneralParameter, GeneralParameterContext, MaybeBuiltParameter, Parameter, ParameterBuildError,
-    ParameterBuilder, ParameterMeta, ParameterName, ParameterState,
+    BuiltParameter, GeneralBeforeParameter, GeneralParameter, GeneralParameterContext, GeneralParameterEntry,
+    MaybeBuiltParameter, Parameter, ParameterBuildError, ParameterBuilder, ParameterMeta, ParameterName,
+    ParameterState,
 };
 use crate::resolve_metric_f64;
 
@@ -20,22 +21,24 @@ impl Parameter for MaxParameter {
     }
 }
 
-impl GeneralParameter<f64> for MaxParameter {
-    fn before(
-        &self,
-        ctx: GeneralParameterContext<'_>,
-        _internal_state: &mut Option<Box<dyn ParameterState>>,
-    ) -> Result<Option<f64>, GeneralCalculationError> {
-        // Current value
-        let x = self.metric.get_value(ctx.network, ctx.state)?;
-        Ok(Some(x.max(self.threshold)))
-    }
-
+impl GeneralParameter for MaxParameter {
     fn as_parameter(&self) -> &dyn Parameter
     where
         Self: Sized,
     {
         self
+    }
+}
+
+impl GeneralBeforeParameter<f64> for MaxParameter {
+    fn before(
+        &self,
+        ctx: GeneralParameterContext<'_>,
+        _internal_state: &mut Option<Box<dyn ParameterState>>,
+    ) -> Result<f64, GeneralCalculationError> {
+        // Current value
+        let x = self.metric.get_value(ctx.network, ctx.state)?;
+        Ok(x.max(self.threshold))
     }
 }
 
@@ -73,6 +76,6 @@ impl ParameterBuilder<f64> for MaxParameterBuilder {
             threshold: self.threshold,
         };
 
-        Ok(MaybeBuiltParameter::Built(BuiltParameter::General(Box::new(p))))
+        Ok(BuiltParameter::General(GeneralParameterEntry::before(p)).into())
     }
 }

--- a/pywr-core/src/parameters/min.rs
+++ b/pywr-core/src/parameters/min.rs
@@ -2,8 +2,9 @@ use crate::metric::{MetricF64, UnresolvedMetricF64};
 use crate::network::ResolutionMaps;
 use crate::parameters::errors::GeneralCalculationError;
 use crate::parameters::{
-    BuiltParameter, GeneralParameter, GeneralParameterContext, MaybeBuiltParameter, Parameter, ParameterBuildError,
-    ParameterBuilder, ParameterMeta, ParameterName, ParameterState,
+    BuiltParameter, GeneralBeforeParameter, GeneralParameter, GeneralParameterContext, GeneralParameterEntry,
+    MaybeBuiltParameter, Parameter, ParameterBuildError, ParameterBuilder, ParameterMeta, ParameterName,
+    ParameterState,
 };
 use crate::resolve_metric_f64;
 
@@ -19,21 +20,23 @@ impl Parameter for MinParameter {
         &self.meta
     }
 }
-impl GeneralParameter<f64> for MinParameter {
-    fn before(
-        &self,
-        ctx: GeneralParameterContext<'_>,
-        _internal_state: &mut Option<Box<dyn ParameterState>>,
-    ) -> Result<Option<f64>, GeneralCalculationError> {
-        let x = self.metric.get_value(ctx.network, ctx.state)?;
-        Ok(Some(x.min(self.threshold)))
-    }
-
+impl GeneralParameter for MinParameter {
     fn as_parameter(&self) -> &dyn Parameter
     where
         Self: Sized,
     {
         self
+    }
+}
+
+impl GeneralBeforeParameter<f64> for MinParameter {
+    fn before(
+        &self,
+        ctx: GeneralParameterContext<'_>,
+        _internal_state: &mut Option<Box<dyn ParameterState>>,
+    ) -> Result<f64, GeneralCalculationError> {
+        let x = self.metric.get_value(ctx.network, ctx.state)?;
+        Ok(x.min(self.threshold))
     }
 }
 
@@ -71,6 +74,6 @@ impl ParameterBuilder<f64> for MinParameterBuilder {
             threshold: self.threshold,
         };
 
-        Ok(MaybeBuiltParameter::Built(BuiltParameter::General(Box::new(p))))
+        Ok(BuiltParameter::General(GeneralParameterEntry::before(p)).into())
     }
 }

--- a/pywr-core/src/parameters/min.rs
+++ b/pywr-core/src/parameters/min.rs
@@ -1,14 +1,11 @@
 use crate::metric::{MetricF64, UnresolvedMetricF64};
-use crate::network::{Network, ResolutionMaps};
+use crate::network::ResolutionMaps;
 use crate::parameters::errors::GeneralCalculationError;
 use crate::parameters::{
-    BuiltParameter, GeneralParameter, MaybeBuiltParameter, Parameter, ParameterBuildError, ParameterBuilder,
-    ParameterMeta, ParameterName, ParameterState,
+    BuiltParameter, GeneralParameter, GeneralParameterContext, MaybeBuiltParameter, Parameter, ParameterBuildError,
+    ParameterBuilder, ParameterMeta, ParameterName, ParameterState,
 };
 use crate::resolve_metric_f64;
-use crate::scenario::ScenarioIndex;
-use crate::state::State;
-use crate::timestep::Timestep;
 
 #[derive(Debug)]
 pub struct MinParameter {
@@ -25,13 +22,10 @@ impl Parameter for MinParameter {
 impl GeneralParameter<f64> for MinParameter {
     fn before(
         &self,
-        _timestep: &Timestep,
-        _scenario_index: &ScenarioIndex,
-        model: &Network,
-        state: &State,
+        ctx: GeneralParameterContext<'_>,
         _internal_state: &mut Option<Box<dyn ParameterState>>,
     ) -> Result<Option<f64>, GeneralCalculationError> {
-        let x = self.metric.get_value(model, state)?;
+        let x = self.metric.get_value(ctx.network, ctx.state)?;
         Ok(Some(x.min(self.threshold)))
     }
 

--- a/pywr-core/src/parameters/mod.rs
+++ b/pywr-core/src/parameters/mod.rs
@@ -1063,23 +1063,27 @@ macro_rules! resolve_metric_u64_hashmap {
     }};
 }
 
+/// A context struct that is passed to the `before` and `after` methods of a [`SimpleParameter`].
+#[derive(Clone, Copy)]
+pub struct SimpleParameterContext<'a> {
+    pub timestep: &'a Timestep,
+    pub scenario_index: &'a ScenarioIndex,
+    pub values: &'a SimpleParameterValues<'a>,
+}
+
 /// A trait that defines a component that produces a value each time-step.
 ///
 /// The trait is generic over the type of the value produced.
 pub trait SimpleParameter<T>: Parameter {
     fn before(
         &self,
-        timestep: &Timestep,
-        scenario_index: &ScenarioIndex,
-        values: &SimpleParameterValues,
+        context: SimpleParameterContext<'_>,
         internal_state: &mut Option<Box<dyn ParameterState>>,
     ) -> Result<Option<T>, SimpleCalculationError>;
 
     fn after(
         &self,
-        #[allow(unused_variables)] timestep: &Timestep,
-        #[allow(unused_variables)] scenario_index: &ScenarioIndex,
-        #[allow(unused_variables)] values: &SimpleParameterValues,
+        #[allow(unused_variables)] context: SimpleParameterContext<'_>,
         #[allow(unused_variables)] internal_state: &mut Option<Box<dyn ParameterState>>,
     ) -> Result<Option<T>, SimpleCalculationError> {
         Ok(None)
@@ -2325,17 +2329,18 @@ impl ParameterCollection {
                         .get_simple_mut_f64_state(*idx)
                         .ok_or(ParameterCollectionSimpleCalculationError::F64IndexNotFound(*idx))?;
 
-                    let value = p
-                        .before(
-                            timestep,
-                            scenario_index,
-                            &state.get_simple_parameter_values(),
-                            internal_state,
-                        )
-                        .map_err(|source| ParameterCollectionSimpleCalculationError::CalculationError {
+                    let ctx = SimpleParameterContext {
+                        timestep,
+                        scenario_index,
+                        values: &state.get_simple_parameter_values(),
+                    };
+
+                    let value = p.before(ctx, internal_state).map_err(|source| {
+                        ParameterCollectionSimpleCalculationError::CalculationError {
                             name: p.name().clone(),
                             source,
-                        })?;
+                        }
+                    })?;
 
                     state.set_simple_parameter_value_before(*idx, value).map_err(|source| {
                         ParameterCollectionSimpleCalculationError::F64SetStateError {
@@ -2355,17 +2360,18 @@ impl ParameterCollection {
                         .get_simple_mut_u64_state(*idx)
                         .ok_or(ParameterCollectionSimpleCalculationError::U64IndexNotFound(*idx))?;
 
-                    let value = p
-                        .before(
-                            timestep,
-                            scenario_index,
-                            &state.get_simple_parameter_values(),
-                            internal_state,
-                        )
-                        .map_err(|source| ParameterCollectionSimpleCalculationError::CalculationError {
+                    let ctx = SimpleParameterContext {
+                        timestep,
+                        scenario_index,
+                        values: &state.get_simple_parameter_values(),
+                    };
+
+                    let value = p.before(ctx, internal_state).map_err(|source| {
+                        ParameterCollectionSimpleCalculationError::CalculationError {
                             name: p.name().clone(),
                             source,
-                        })?;
+                        }
+                    })?;
 
                     state.set_simple_parameter_index_before(*idx, value).map_err(|source| {
                         ParameterCollectionSimpleCalculationError::U64SetStateError {
@@ -2385,17 +2391,18 @@ impl ParameterCollection {
                         .get_simple_mut_multi_state(*idx)
                         .ok_or(ParameterCollectionSimpleCalculationError::MultiIndexNotFound(*idx))?;
 
-                    let value = p
-                        .before(
-                            timestep,
-                            scenario_index,
-                            &state.get_simple_parameter_values(),
-                            internal_state,
-                        )
-                        .map_err(|source| ParameterCollectionSimpleCalculationError::CalculationError {
+                    let ctx = SimpleParameterContext {
+                        timestep,
+                        scenario_index,
+                        values: &state.get_simple_parameter_values(),
+                    };
+
+                    let value = p.before(ctx, internal_state).map_err(|source| {
+                        ParameterCollectionSimpleCalculationError::CalculationError {
                             name: p.name().clone(),
                             source,
-                        })?;
+                        }
+                    })?;
 
                     state
                         .set_simple_multi_parameter_value_before(*idx, value)
@@ -2431,13 +2438,13 @@ impl ParameterCollection {
                         .get_simple_mut_f64_state(*idx)
                         .ok_or(ParameterCollectionSimpleCalculationError::F64IndexNotFound(*idx))?;
 
-                    p.after(
+                    let ctx = SimpleParameterContext {
                         timestep,
                         scenario_index,
-                        &state.get_simple_parameter_values(),
-                        internal_state,
-                    )
-                    .map_err(|source| {
+                        values: &state.get_simple_parameter_values(),
+                    };
+
+                    p.after(ctx, internal_state).map_err(|source| {
                         ParameterCollectionSimpleCalculationError::CalculationError {
                             name: p.name().clone(),
                             source,
@@ -2455,13 +2462,13 @@ impl ParameterCollection {
                         .get_simple_mut_u64_state(*idx)
                         .ok_or(ParameterCollectionSimpleCalculationError::U64IndexNotFound(*idx))?;
 
-                    p.after(
+                    let ctx = SimpleParameterContext {
                         timestep,
                         scenario_index,
-                        &state.get_simple_parameter_values(),
-                        internal_state,
-                    )
-                    .map_err(|source| {
+                        values: &state.get_simple_parameter_values(),
+                    };
+
+                    p.after(ctx, internal_state).map_err(|source| {
                         ParameterCollectionSimpleCalculationError::CalculationError {
                             name: p.name().clone(),
                             source,
@@ -2479,13 +2486,13 @@ impl ParameterCollection {
                         .get_simple_mut_multi_state(*idx)
                         .ok_or(ParameterCollectionSimpleCalculationError::MultiIndexNotFound(*idx))?;
 
-                    p.after(
+                    let ctx = SimpleParameterContext {
                         timestep,
                         scenario_index,
-                        &state.get_simple_parameter_values(),
-                        internal_state,
-                    )
-                    .map_err(|source| {
+                        values: &state.get_simple_parameter_values(),
+                    };
+
+                    p.after(ctx, internal_state).map_err(|source| {
                         ParameterCollectionSimpleCalculationError::CalculationError {
                             name: p.name().clone(),
                             source,
@@ -2812,7 +2819,7 @@ mod tests {
     use super::{
         BuiltParameter, ConstParameter, GeneralCalculationError, GeneralParameter, GeneralParameterContext,
         MaybeBuiltParameter, Parameter, ParameterBuildError, ParameterBuilder, ParameterCollectionBuilder,
-        ParameterMeta, ParameterName, ParameterState, SimpleParameter,
+        ParameterMeta, ParameterName, ParameterState, SimpleParameter, SimpleParameterContext,
     };
     use crate::network::ResolutionMaps;
     use crate::parameters::errors::{ConstCalculationError, SimpleCalculationError};
@@ -2918,9 +2925,7 @@ mod tests {
     {
         fn before(
             &self,
-            _timestep: &crate::timestep::Timestep,
-            _scenario_index: &ScenarioIndex,
-            _values: &crate::state::SimpleParameterValues,
+            _ctx: SimpleParameterContext<'_>,
             _internal_state: &mut Option<Box<dyn ParameterState>>,
         ) -> Result<Option<T>, SimpleCalculationError> {
             Ok(Some(T::from(1)))
@@ -2934,9 +2939,7 @@ mod tests {
     impl SimpleParameter<MultiValue> for TestParameter {
         fn before(
             &self,
-            _timestep: &crate::timestep::Timestep,
-            _scenario_index: &ScenarioIndex,
-            _values: &crate::state::SimpleParameterValues,
+            _ctx: SimpleParameterContext<'_>,
             _internal_state: &mut Option<Box<dyn ParameterState>>,
         ) -> Result<Option<MultiValue>, SimpleCalculationError> {
             Ok(Some(MultiValue::default()))

--- a/pywr-core/src/parameters/mod.rs
+++ b/pywr-core/src/parameters/mod.rs
@@ -708,16 +708,22 @@ pub trait Parameter: Send + Sync + Debug {
     }
 }
 
+/// A context struct that is passed to the `before` and `after` methods of a [`GeneralParameter`].
+#[derive(Clone, Copy)]
+pub struct GeneralParameterContext<'a> {
+    pub timestep: &'a Timestep,
+    pub scenario_index: &'a ScenarioIndex,
+    pub network: &'a Network,
+    pub state: &'a State,
+}
+
 /// A trait that defines a component that produces a value each time-step.
 ///
 /// The trait is generic over the type of the value produced.
 pub trait GeneralParameter<T>: Parameter {
     fn before(
         &self,
-        #[allow(unused_variables)] timestep: &Timestep,
-        #[allow(unused_variables)] scenario_index: &ScenarioIndex,
-        #[allow(unused_variables)] model: &Network,
-        #[allow(unused_variables)] state: &State,
+        #[allow(unused_variables)] context: GeneralParameterContext<'_>,
         #[allow(unused_variables)] internal_state: &mut Option<Box<dyn ParameterState>>,
     ) -> Result<Option<T>, GeneralCalculationError> {
         Ok(None)
@@ -725,10 +731,7 @@ pub trait GeneralParameter<T>: Parameter {
 
     fn after(
         &self,
-        #[allow(unused_variables)] timestep: &Timestep,
-        #[allow(unused_variables)] scenario_index: &ScenarioIndex,
-        #[allow(unused_variables)] model: &Network,
-        #[allow(unused_variables)] state: &State,
+        #[allow(unused_variables)] context: GeneralParameterContext<'_>,
         #[allow(unused_variables)] internal_state: &mut Option<Box<dyn ParameterState>>,
     ) -> Result<Option<T>, GeneralCalculationError> {
         Ok(None)
@@ -2050,12 +2053,19 @@ impl ParameterCollection {
                         .get_general_mut_f64_state(*idx)
                         .ok_or(ParameterCollectionGeneralCalculationError::F64IndexNotFound(*idx))?;
 
-                    let value = p
-                        .before(timestep, scenario_index, network, state, internal_state)
-                        .map_err(|source| ParameterCollectionGeneralCalculationError::CalculationError {
+                    let ctx = GeneralParameterContext {
+                        timestep,
+                        scenario_index,
+                        network,
+                        state,
+                    };
+
+                    let value = p.before(ctx, internal_state).map_err(|source| {
+                        ParameterCollectionGeneralCalculationError::CalculationError {
                             name: p.name().clone(),
                             source: Box::new(source),
-                        })?;
+                        }
+                    })?;
 
                     state
                         .set_general_parameter_value_before(*idx, value)
@@ -2081,12 +2091,19 @@ impl ParameterCollection {
                         .get_general_mut_u64_state(*idx)
                         .ok_or(ParameterCollectionGeneralCalculationError::U64IndexNotFound(*idx))?;
 
-                    let value = p
-                        .before(timestep, scenario_index, network, state, internal_state)
-                        .map_err(|source| ParameterCollectionGeneralCalculationError::CalculationError {
+                    let ctx = GeneralParameterContext {
+                        timestep,
+                        scenario_index,
+                        network,
+                        state,
+                    };
+
+                    let value = p.before(ctx, internal_state).map_err(|source| {
+                        ParameterCollectionGeneralCalculationError::CalculationError {
                             name: p.name().clone(),
                             source: Box::new(source),
-                        })?;
+                        }
+                    })?;
 
                     state
                         .set_general_parameter_index_before(*idx, value)
@@ -2112,12 +2129,19 @@ impl ParameterCollection {
                         .get_general_mut_multi_state(*idx)
                         .ok_or(ParameterCollectionGeneralCalculationError::MultiIndexNotFound(*idx))?;
 
-                    let value = p
-                        .before(timestep, scenario_index, network, state, internal_state)
-                        .map_err(|source| ParameterCollectionGeneralCalculationError::CalculationError {
+                    let ctx = GeneralParameterContext {
+                        timestep,
+                        scenario_index,
+                        network,
+                        state,
+                    };
+
+                    let value = p.before(ctx, internal_state).map_err(|source| {
+                        ParameterCollectionGeneralCalculationError::CalculationError {
                             name: p.name().clone(),
                             source: Box::new(source),
-                        })?;
+                        }
+                    })?;
 
                     state
                         .set_general_multi_parameter_value_before(*idx, value)
@@ -2170,12 +2194,19 @@ impl ParameterCollection {
                         .get_general_mut_f64_state(*idx)
                         .ok_or(ParameterCollectionGeneralCalculationError::F64IndexNotFound(*idx))?;
 
-                    let value = p
-                        .after(timestep, scenario_index, network, state, internal_state)
-                        .map_err(|source| ParameterCollectionGeneralCalculationError::CalculationError {
+                    let ctx = GeneralParameterContext {
+                        timestep,
+                        scenario_index,
+                        network,
+                        state,
+                    };
+
+                    let value = p.after(ctx, internal_state).map_err(|source| {
+                        ParameterCollectionGeneralCalculationError::CalculationError {
                             name: p.name().clone(),
                             source: Box::new(source),
-                        })?;
+                        }
+                    })?;
 
                     state.set_general_parameter_value_after(*idx, value).map_err(|source| {
                         ParameterCollectionGeneralCalculationError::F64SetStateError {
@@ -2201,12 +2232,19 @@ impl ParameterCollection {
                         .get_general_mut_u64_state(*idx)
                         .ok_or(ParameterCollectionGeneralCalculationError::U64IndexNotFound(*idx))?;
 
-                    let value = p
-                        .after(timestep, scenario_index, network, state, internal_state)
-                        .map_err(|source| ParameterCollectionGeneralCalculationError::CalculationError {
+                    let ctx = GeneralParameterContext {
+                        timestep,
+                        scenario_index,
+                        network,
+                        state,
+                    };
+
+                    let value = p.after(ctx, internal_state).map_err(|source| {
+                        ParameterCollectionGeneralCalculationError::CalculationError {
                             name: p.name().clone(),
                             source: Box::new(source),
-                        })?;
+                        }
+                    })?;
 
                     state.set_general_parameter_index_after(*idx, value).map_err(|source| {
                         ParameterCollectionGeneralCalculationError::U64SetStateError {
@@ -2232,12 +2270,19 @@ impl ParameterCollection {
                         .get_general_mut_multi_state(*idx)
                         .ok_or(ParameterCollectionGeneralCalculationError::MultiIndexNotFound(*idx))?;
 
-                    let value = p
-                        .after(timestep, scenario_index, network, state, internal_state)
-                        .map_err(|source| ParameterCollectionGeneralCalculationError::CalculationError {
+                    let ctx = GeneralParameterContext {
+                        timestep,
+                        scenario_index,
+                        network,
+                        state,
+                    };
+
+                    let value = p.after(ctx, internal_state).map_err(|source| {
+                        ParameterCollectionGeneralCalculationError::CalculationError {
                             name: p.name().clone(),
                             source: Box::new(source),
-                        })?;
+                        }
+                    })?;
 
                     state
                         .set_general_multi_parameter_value_after(*idx, value)
@@ -2765,9 +2810,9 @@ impl ParameterCollectionBuilder {
 #[cfg(test)]
 mod tests {
     use super::{
-        BuiltParameter, ConstParameter, GeneralCalculationError, GeneralParameter, MaybeBuiltParameter, Parameter,
-        ParameterBuildError, ParameterBuilder, ParameterCollectionBuilder, ParameterMeta, ParameterName,
-        ParameterState, SimpleParameter,
+        BuiltParameter, ConstParameter, GeneralCalculationError, GeneralParameter, GeneralParameterContext,
+        MaybeBuiltParameter, Parameter, ParameterBuildError, ParameterBuilder, ParameterCollectionBuilder,
+        ParameterMeta, ParameterName, ParameterState, SimpleParameter,
     };
     use crate::network::ResolutionMaps;
     use crate::parameters::errors::{ConstCalculationError, SimpleCalculationError};
@@ -2907,10 +2952,7 @@ mod tests {
     {
         fn before(
             &self,
-            _timestep: &crate::timestep::Timestep,
-            _scenario_index: &ScenarioIndex,
-            _model: &crate::network::Network,
-            _state: &crate::state::State,
+            _ctx: GeneralParameterContext<'_>,
             _internal_state: &mut Option<Box<dyn ParameterState>>,
         ) -> Result<Option<T>, GeneralCalculationError> {
             Ok(Some(T::from(1)))
@@ -2924,10 +2966,7 @@ mod tests {
     impl GeneralParameter<MultiValue> for TestParameter {
         fn before(
             &self,
-            _timestep: &crate::timestep::Timestep,
-            _scenario_index: &ScenarioIndex,
-            _model: &crate::network::Network,
-            _state: &crate::state::State,
+            _ctx: GeneralParameterContext<'_>,
             _internal_state: &mut Option<Box<dyn ParameterState>>,
         ) -> Result<Option<MultiValue>, GeneralCalculationError> {
             Ok(Some(MultiValue::default()))

--- a/pywr-core/src/parameters/mod.rs
+++ b/pywr-core/src/parameters/mod.rs
@@ -93,6 +93,7 @@ use std::fmt::{Debug, Display, Formatter};
 use std::hash::{Hash, Hasher};
 use std::marker::PhantomData;
 use std::ops::Deref;
+use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 use thiserror::Error;
@@ -717,31 +718,128 @@ pub struct GeneralParameterContext<'a> {
     pub state: &'a State,
 }
 
-/// A trait that defines a component that produces a value each time-step.
+/// A trait that defines a component that may produce a value each time-step, and may have an
+/// internal state that is updated each time-step.
 ///
-/// The trait is generic over the type of the value produced.
-pub trait GeneralParameter<T>: Parameter {
+/// See [`GeneralBeforeParameter`] and [`GeneralAfterParameter`] for more specific traits that define
+/// the behaviour of parameters that produce values before or after the network is updated.
+pub trait GeneralParameter: Parameter {
+    fn as_parameter(&self) -> &dyn Parameter;
+}
+
+/// A trait that defines a component that produces a value before the network is updated each time-step.
+pub trait GeneralBeforeParameter<T>: GeneralParameter {
     fn before(
         &self,
-        #[allow(unused_variables)] context: GeneralParameterContext<'_>,
-        #[allow(unused_variables)] internal_state: &mut Option<Box<dyn ParameterState>>,
-    ) -> Result<Option<T>, GeneralCalculationError> {
-        Ok(None)
-    }
+        context: GeneralParameterContext<'_>,
+        internal_state: &mut Option<Box<dyn ParameterState>>,
+    ) -> Result<T, GeneralCalculationError>;
+}
 
+/// A trait that defines a component that produces a value after the network is updated each time-step.
+pub trait GeneralAfterParameter<T>: GeneralParameter {
     fn after(
         &self,
-        #[allow(unused_variables)] context: GeneralParameterContext<'_>,
-        #[allow(unused_variables)] internal_state: &mut Option<Box<dyn ParameterState>>,
-    ) -> Result<Option<T>, GeneralCalculationError> {
-        Ok(None)
+        context: GeneralParameterContext<'_>,
+        internal_state: &mut Option<Box<dyn ParameterState>>,
+    ) -> Result<T, GeneralCalculationError>;
+}
+
+/// A trait that defines a component that performs an action after the network is updated each
+/// time-step, but does not produce a value.
+pub trait GeneralAfterParameterHook<T>: GeneralParameter {
+    fn after(
+        &self,
+        context: GeneralParameterContext<'_>,
+        internal_state: &mut Option<Box<dyn ParameterState>>,
+    ) -> Result<(), GeneralCalculationError>;
+}
+
+#[derive(Debug)]
+enum GeneralAfterOperation<T> {
+    Value(Arc<dyn GeneralAfterParameter<T>>),
+    Hook(Arc<dyn GeneralAfterParameterHook<T>>),
+}
+
+#[derive(Debug)]
+pub struct GeneralParameterEntry<T> {
+    parameter: Arc<dyn GeneralParameter>,
+    before: Option<Arc<dyn GeneralBeforeParameter<T>>>,
+    after: Option<GeneralAfterOperation<T>>,
+}
+
+impl<T: 'static> GeneralParameterEntry<T> {
+    pub fn before<P>(parameter: P) -> Self
+    where
+        P: GeneralBeforeParameter<T> + 'static,
+    {
+        let parameter = Arc::new(parameter);
+        Self {
+            parameter: parameter.clone(),
+            before: Some(parameter),
+            after: None,
+        }
     }
 
-    fn try_into_simple(&self) -> Option<Box<dyn SimpleParameter<T>>> {
-        None
+    pub fn after<P>(parameter: P) -> Self
+    where
+        P: GeneralAfterParameter<T> + 'static,
+    {
+        let parameter = Arc::new(parameter);
+        Self {
+            parameter: parameter.clone(),
+            before: None,
+            after: Some(GeneralAfterOperation::Value(parameter)),
+        }
     }
 
-    fn as_parameter(&self) -> &dyn Parameter;
+    pub fn both<P>(parameter: P) -> Self
+    where
+        P: GeneralBeforeParameter<T> + GeneralAfterParameter<T> + 'static,
+    {
+        let parameter = Arc::new(parameter);
+        Self {
+            parameter: parameter.clone(),
+            before: Some(parameter.clone()),
+            after: Some(GeneralAfterOperation::Value(parameter)),
+        }
+    }
+
+    pub fn before_with_after_hook<P>(parameter: P) -> Self
+    where
+        P: GeneralBeforeParameter<T> + GeneralAfterParameterHook<T> + 'static,
+    {
+        let parameter = Arc::new(parameter);
+        Self {
+            parameter: parameter.clone(),
+            before: Some(parameter.clone()),
+            after: Some(GeneralAfterOperation::Hook(parameter)),
+        }
+    }
+
+    fn setup(
+        &self,
+        timesteps: &[Timestep],
+        scenario_index: &ScenarioIndex,
+    ) -> Result<Option<Box<dyn ParameterState>>, ParameterSetupError> {
+        self.parameter.setup(timesteps, scenario_index)
+    }
+
+    pub fn name(&self) -> &ParameterName {
+        self.parameter.name()
+    }
+
+    fn as_parameter(&self) -> &dyn Parameter {
+        self.parameter.as_parameter()
+    }
+
+    fn has_before(&self) -> bool {
+        self.before.is_some()
+    }
+
+    fn has_after(&self) -> bool {
+        self.after.is_some()
+    }
 }
 
 #[derive(Debug, Error)]
@@ -783,11 +881,13 @@ pub enum ParameterBuildError {
     },
     #[error("Could not compute day of the year; invalid date: day: {day}, month: {day}")]
     InvalidDayOfYear { day: u32, month: u32 },
+    #[error("Parameter is configured without a valid calculation phase: {detail}")]
+    NoCalculationPhase { detail: String },
 }
 
 pub enum BuiltParameter<T> {
-    General(Box<dyn GeneralParameter<T>>),
-    Simple(Box<dyn SimpleParameter<T>>),
+    General(GeneralParameterEntry<T>),
+    Simple(SimpleParameterEntry<T>),
     Const(Box<dyn ConstParameter<T>>),
 }
 
@@ -1071,28 +1171,123 @@ pub struct SimpleParameterContext<'a> {
     pub values: &'a SimpleParameterValues<'a>,
 }
 
-/// A trait that defines a component that produces a value each time-step.
+/// A trait that defines a component that may produce a value each time-step, and may have an
+/// internal state that is updated each time-step.
 ///
-/// The trait is generic over the type of the value produced.
-pub trait SimpleParameter<T>: Parameter {
+/// See [`SimpleBeforeParameter`] and [`SimpleAfterParameter`] for more specific traits that define
+/// the behaviour of parameters that produce values before or after the network is updated.
+pub trait SimpleParameter: Parameter {
+    fn as_parameter(&self) -> &dyn Parameter;
+}
+
+pub trait SimpleBeforeParameter<T>: SimpleParameter {
     fn before(
         &self,
         context: SimpleParameterContext<'_>,
         internal_state: &mut Option<Box<dyn ParameterState>>,
-    ) -> Result<Option<T>, SimpleCalculationError>;
+    ) -> Result<T, SimpleCalculationError>;
+}
 
+pub trait SimpleAfterParameter<T>: SimpleParameter {
     fn after(
         &self,
-        #[allow(unused_variables)] context: SimpleParameterContext<'_>,
-        #[allow(unused_variables)] internal_state: &mut Option<Box<dyn ParameterState>>,
-    ) -> Result<Option<T>, SimpleCalculationError> {
-        Ok(None)
+        context: SimpleParameterContext<'_>,
+        internal_state: &mut Option<Box<dyn ParameterState>>,
+    ) -> Result<T, SimpleCalculationError>;
+}
+
+pub trait SimpleAfterParameterHook<T>: SimpleParameter {
+    fn after(
+        &self,
+        context: SimpleParameterContext<'_>,
+        internal_state: &mut Option<Box<dyn ParameterState>>,
+    ) -> Result<(), SimpleCalculationError>;
+}
+
+#[derive(Debug)]
+enum SimpleAfterOperation<T> {
+    Value(Arc<dyn SimpleAfterParameter<T>>),
+    Hook(Arc<dyn SimpleAfterParameterHook<T>>),
+}
+
+#[derive(Debug)]
+pub struct SimpleParameterEntry<T> {
+    parameter: Arc<dyn SimpleParameter>,
+    before: Option<Arc<dyn SimpleBeforeParameter<T>>>,
+    after: Option<SimpleAfterOperation<T>>,
+}
+
+impl<T: 'static> SimpleParameterEntry<T> {
+    pub fn before<P>(parameter: P) -> Self
+    where
+        P: SimpleBeforeParameter<T> + 'static,
+    {
+        let parameter = Arc::new(parameter);
+        Self {
+            parameter: parameter.clone(),
+            before: Some(parameter),
+            after: None,
+        }
     }
 
-    fn as_parameter(&self) -> &dyn Parameter;
+    pub fn after<P>(parameter: P) -> Self
+    where
+        P: SimpleAfterParameter<T> + 'static,
+    {
+        let parameter = Arc::new(parameter);
+        Self {
+            parameter: parameter.clone(),
+            before: None,
+            after: Some(SimpleAfterOperation::Value(parameter)),
+        }
+    }
 
-    fn try_into_const(&self) -> Option<Box<dyn ConstParameter<T>>> {
-        None
+    pub fn both<P>(parameter: P) -> Self
+    where
+        P: SimpleBeforeParameter<T> + SimpleAfterParameter<T> + 'static,
+    {
+        let parameter = Arc::new(parameter);
+        Self {
+            parameter: parameter.clone(),
+            before: Some(parameter.clone()),
+            after: Some(SimpleAfterOperation::Value(parameter)),
+        }
+    }
+
+    pub fn before_with_after_hook<P>(parameter: P) -> Self
+    where
+        P: SimpleBeforeParameter<T> + SimpleAfterParameterHook<T> + 'static,
+    {
+        let parameter = Arc::new(parameter);
+        Self {
+            parameter: parameter.clone(),
+            before: Some(parameter.clone()),
+            after: Some(SimpleAfterOperation::Hook(parameter)),
+        }
+    }
+
+    fn setup(
+        &self,
+        timesteps: &[Timestep],
+        scenario_index: &ScenarioIndex,
+    ) -> Result<Option<Box<dyn ParameterState>>, ParameterSetupError> {
+        self.parameter.setup(timesteps, scenario_index)
+    }
+
+    pub fn name(&self) -> &ParameterName {
+        self.parameter.name()
+    }
+
+    fn as_parameter(&self) -> &dyn Parameter {
+        self.parameter.as_parameter()
+    }
+
+    fn has_before(&self) -> bool {
+        self.before.is_some()
+    }
+
+    fn has_after(&self) -> bool {
+        self.after.is_some()
     }
 }
 
@@ -1345,6 +1540,10 @@ pub enum ParameterCollectionSimpleCalculationError {
         #[source]
         source: SetStateError<SimpleParameterIndex<MultiValue>>,
     },
+    #[error("Before is not implemented for simple parameter '{name}'.")]
+    BeforeNotImplemented { name: ParameterName },
+    #[error("After is not implemented for simple parameter '{name}'.")]
+    AfterNotImplemented { name: ParameterName },
 }
 
 // Unique ID for each parameter collection.
@@ -1526,6 +1725,10 @@ pub enum ParameterCollectionGeneralCalculationError {
     },
     #[error("The timing data was created with from a different parameter collection. ")]
     TimingsFromAnotherCollection,
+    #[error("Before is not implemented for general parameter '{name}'.")]
+    BeforeNotImplemented { name: ParameterName },
+    #[error("After is not implemented for general parameter '{name}'.")]
+    AfterNotImplemented { name: ParameterName },
 }
 
 /// A collection of parameters that return different types.
@@ -1536,15 +1739,17 @@ pub struct ParameterCollection {
     constant_multi: Vec<Box<dyn ConstParameter<MultiValue>>>,
     constant_resolve_order: Vec<ConstParameterType>,
 
-    simple_f64: Vec<Box<dyn SimpleParameter<f64>>>,
-    simple_u64: Vec<Box<dyn SimpleParameter<u64>>>,
-    simple_multi: Vec<Box<dyn SimpleParameter<MultiValue>>>,
-    simple_resolve_order: Vec<SimpleParameterType>,
+    simple_f64: Vec<SimpleParameterEntry<f64>>,
+    simple_u64: Vec<SimpleParameterEntry<u64>>,
+    simple_multi: Vec<SimpleParameterEntry<MultiValue>>,
+    simple_before_order: Vec<SimpleParameterType>,
+    simple_after_order: Vec<SimpleParameterType>,
 
-    general_f64: Vec<Box<dyn GeneralParameter<f64>>>,
-    general_u64: Vec<Box<dyn GeneralParameter<u64>>>,
-    general_multi: Vec<Box<dyn GeneralParameter<MultiValue>>>,
-    general_resolve_order: Vec<GeneralParameterType>,
+    general_f64: Vec<GeneralParameterEntry<f64>>,
+    general_u64: Vec<GeneralParameterEntry<u64>>,
+    general_multi: Vec<GeneralParameterEntry<MultiValue>>,
+    general_before_order: Vec<GeneralParameterType>,
+    general_after_order: Vec<GeneralParameterType>,
     id: u64,
 }
 
@@ -1558,11 +1763,13 @@ impl Default for ParameterCollection {
             simple_f64: Vec::new(),
             simple_u64: Vec::new(),
             simple_multi: Vec::new(),
-            simple_resolve_order: Vec::new(),
+            simple_before_order: Vec::new(),
+            simple_after_order: Vec::new(),
             general_f64: Vec::new(),
             general_u64: Vec::new(),
             general_multi: Vec::new(),
-            general_resolve_order: Vec::new(),
+            general_before_order: Vec::new(),
+            general_after_order: Vec::new(),
             id: PARAMETER_COLLECTION_ID.fetch_add(1, Ordering::Relaxed),
         }
     }
@@ -1591,10 +1798,12 @@ impl ParameterCollection {
         let f64_states = self
             .general_f64
             .iter()
-            .map(|p| {
-                p.setup(timesteps, scenario_index)
+            .map(|entry| {
+                entry
+                    .parameter
+                    .setup(timesteps, scenario_index)
                     .map_err(|source| ParameterCollectionSetupError {
-                        name: Box::new(p.name().clone()),
+                        name: Box::new(entry.name().clone()),
                         source: Box::new(source),
                     })
             })
@@ -1603,10 +1812,11 @@ impl ParameterCollection {
         let usize_states = self
             .general_u64
             .iter()
-            .map(|p| {
-                p.setup(timesteps, scenario_index)
+            .map(|entry| {
+                entry
+                    .setup(timesteps, scenario_index)
                     .map_err(|source| ParameterCollectionSetupError {
-                        name: Box::new(p.name().clone()),
+                        name: Box::new(entry.name().clone()),
                         source: Box::new(source),
                     })
             })
@@ -1751,37 +1961,38 @@ impl ParameterCollection {
     /// The new parameter will be simplified as much as possible.
     ///
     /// SAFETY: This must remain a private function to maintain the indexing guarantees.
-    fn push_general_f64(&mut self, p: Box<dyn GeneralParameter<f64>>) -> ParameterIndex<f64> {
-        match p.try_into_simple() {
-            Some(p) => self.push_simple_f64(p),
-            None => {
-                let index = GeneralParameterIndex::new(self.general_f64.len());
+    fn push_general_f64(&mut self, entry: GeneralParameterEntry<f64>) -> ParameterIndex<f64> {
+        let index = GeneralParameterIndex::new(self.general_f64.len());
 
-                self.general_resolve_order.push(GeneralParameterType::Parameter(index));
-                self.general_f64.push(p);
-
-                ParameterIndex::General(index)
-            }
+        if entry.has_before() {
+            self.general_before_order.push(index.into());
         }
+
+        if entry.has_after() {
+            self.general_after_order.push(index.into());
+        }
+
+        self.general_f64.push(entry);
+
+        ParameterIndex::General(index)
     }
 
     /// Push a new simple parameter to the collection.
     ///
-    /// The new parameter will be simplified as much as possible.
-    ///
     /// SAFETY: This must remain a private function to maintain the indexing guarantees.
-    fn push_simple_f64(&mut self, p: Box<dyn SimpleParameter<f64>>) -> ParameterIndex<f64> {
-        match p.try_into_const() {
-            Some(p) => self.push_const_f64(p),
-            None => {
-                let index = SimpleParameterIndex::new(self.simple_f64.len());
+    fn push_simple_f64(&mut self, entry: SimpleParameterEntry<f64>) -> ParameterIndex<f64> {
+        let index = SimpleParameterIndex::new(self.simple_f64.len());
 
-                self.simple_resolve_order.push(SimpleParameterType::Parameter(index));
-                self.simple_f64.push(p);
-
-                ParameterIndex::Simple(index)
-            }
+        if entry.has_before() {
+            self.simple_before_order.push(index.into());
         }
+
+        if entry.has_after() {
+            self.simple_after_order.push(index.into());
+        }
+        self.simple_f64.push(entry);
+
+        ParameterIndex::Simple(index)
     }
 
     /// Push a new const parameter to the collection.
@@ -1804,8 +2015,8 @@ impl ParameterCollection {
         }
     }
 
-    pub fn get_general_f64(&self, index: GeneralParameterIndex<f64>) -> Option<&dyn GeneralParameter<f64>> {
-        self.general_f64.get(*index.deref()).map(|p| p.as_ref())
+    pub fn get_general_f64(&self, index: GeneralParameterIndex<f64>) -> Option<&GeneralParameterEntry<f64>> {
+        self.general_f64.get(*index.deref())
     }
 
     pub fn get_f64_by_name(&self, name: &ParameterName) -> Option<&dyn Parameter> {
@@ -1841,21 +2052,20 @@ impl ParameterCollection {
 
     /// Push a new general parameter to the collection.
     ///
-    /// The new parameter will be simplified as much as possible.
-    ///
     /// SAFETY: This must remain a private function to maintain the indexing guarantees.
-    fn push_general_u64(&mut self, p: Box<dyn GeneralParameter<u64>>) -> ParameterIndex<u64> {
-        match p.try_into_simple() {
-            Some(p) => self.push_simple_u64(p),
-            None => {
-                let index = GeneralParameterIndex::new(self.general_u64.len());
+    fn push_general_u64(&mut self, entry: GeneralParameterEntry<u64>) -> ParameterIndex<u64> {
+        let index = GeneralParameterIndex::new(self.general_u64.len());
 
-                self.general_resolve_order.push(GeneralParameterType::Index(index));
-                self.general_u64.push(p);
-
-                ParameterIndex::General(index)
-            }
+        if entry.has_before() {
+            self.general_before_order.push(index.into());
         }
+
+        if entry.has_after() {
+            self.general_after_order.push(index.into());
+        }
+        self.general_u64.push(entry);
+
+        ParameterIndex::General(index)
     }
 
     /// Push a new simple parameter to the collection.
@@ -1863,18 +2073,19 @@ impl ParameterCollection {
     /// The new parameter will be simplified as much as possible.
     ///
     /// SAFETY: This must remain a private function to maintain the indexing guarantees.
-    fn push_simple_u64(&mut self, p: Box<dyn SimpleParameter<u64>>) -> ParameterIndex<u64> {
-        match p.try_into_const() {
-            Some(p) => self.push_const_u64(p),
-            None => {
-                let index = SimpleParameterIndex::new(self.simple_u64.len());
+    fn push_simple_u64(&mut self, entry: SimpleParameterEntry<u64>) -> ParameterIndex<u64> {
+        let index = SimpleParameterIndex::new(self.simple_u64.len());
 
-                self.simple_resolve_order.push(SimpleParameterType::Index(index));
-                self.simple_u64.push(p);
-
-                ParameterIndex::Simple(index)
-            }
+        if entry.has_before() {
+            self.simple_before_order.push(index.into());
         }
+
+        if entry.has_after() {
+            self.simple_after_order.push(index.into());
+        }
+        self.simple_u64.push(entry);
+
+        ParameterIndex::Simple(index)
     }
 
     /// Push a new const parameter to the collection.
@@ -1897,8 +2108,8 @@ impl ParameterCollection {
         }
     }
 
-    pub fn get_general_u64(&self, index: GeneralParameterIndex<u64>) -> Option<&dyn GeneralParameter<u64>> {
-        self.general_u64.get(*index.deref()).map(|p| p.as_ref())
+    pub fn get_general_u64(&self, index: GeneralParameterIndex<u64>) -> Option<&GeneralParameterEntry<u64>> {
+        self.general_u64.get(*index.deref())
     }
 
     pub fn get_u64_by_name(&self, name: &ParameterName) -> Option<&dyn Parameter> {
@@ -1937,18 +2148,19 @@ impl ParameterCollection {
     /// The new parameter will be simplified as much as possible.
     ///
     /// SAFETY: This must remain a private function to maintain the indexing guarantees.
-    fn push_general_multi(&mut self, p: Box<dyn GeneralParameter<MultiValue>>) -> ParameterIndex<MultiValue> {
-        match p.try_into_simple() {
-            Some(p) => self.push_simple_multi(p),
-            None => {
-                let index = GeneralParameterIndex::new(self.general_multi.len());
+    fn push_general_multi(&mut self, entry: GeneralParameterEntry<MultiValue>) -> ParameterIndex<MultiValue> {
+        let index = GeneralParameterIndex::new(self.general_multi.len());
 
-                self.general_resolve_order.push(GeneralParameterType::Multi(index));
-                self.general_multi.push(p);
-
-                ParameterIndex::General(index)
-            }
+        if entry.has_before() {
+            self.general_before_order.push(index.into());
         }
+
+        if entry.has_after() {
+            self.general_after_order.push(index.into());
+        }
+        self.general_multi.push(entry);
+
+        ParameterIndex::General(index)
     }
 
     /// Push a new simple parameter to the collection.
@@ -1956,18 +2168,19 @@ impl ParameterCollection {
     /// The new parameter will be simplified as much as possible.
     ///
     /// SAFETY: This must remain a private function to maintain the indexing guarantees.
-    fn push_simple_multi(&mut self, p: Box<dyn SimpleParameter<MultiValue>>) -> ParameterIndex<MultiValue> {
-        match p.try_into_const() {
-            Some(p) => self.push_const_multi(p),
-            None => {
-                let index = SimpleParameterIndex::new(self.simple_multi.len());
+    fn push_simple_multi(&mut self, entry: SimpleParameterEntry<MultiValue>) -> ParameterIndex<MultiValue> {
+        let index = SimpleParameterIndex::new(self.simple_multi.len());
 
-                self.simple_resolve_order.push(SimpleParameterType::Multi(index));
-                self.simple_multi.push(p);
-
-                ParameterIndex::Simple(index)
-            }
+        if entry.has_before() {
+            self.simple_before_order.push(index.into());
         }
+
+        if entry.has_after() {
+            self.simple_after_order.push(index.into());
+        }
+        self.simple_multi.push(entry);
+
+        ParameterIndex::Simple(index)
     }
 
     /// Push a new const parameter to the collection.
@@ -1993,8 +2206,8 @@ impl ParameterCollection {
     pub fn get_general_multi(
         &self,
         index: &GeneralParameterIndex<MultiValue>,
-    ) -> Option<&dyn GeneralParameter<MultiValue>> {
-        self.general_multi.get(*index.deref()).map(|p| p.as_ref())
+    ) -> Option<&GeneralParameterEntry<MultiValue>> {
+        self.general_multi.get(*index.deref())
     }
 
     pub fn get_multi_by_name(&self, name: &ParameterName) -> Option<&dyn Parameter> {
@@ -2028,7 +2241,7 @@ impl ParameterCollection {
         }
     }
 
-    pub fn compute_general(
+    pub fn before_general(
         &self,
         timestep: &Timestep,
         scenario_index: &ScenarioIndex,
@@ -2043,19 +2256,26 @@ impl ParameterCollection {
             }
         }
 
-        for p in &self.general_resolve_order {
+        for p in &self.general_before_order {
             let start = Instant::now();
             match p {
                 GeneralParameterType::Parameter(idx) => {
                     // Find the parameter itself
-                    let p = self
+                    let entry = self
                         .general_f64
                         .get(*idx.deref())
                         .ok_or(ParameterCollectionGeneralCalculationError::F64IndexNotFound(*idx))?;
+
                     // .. and its internal state
                     let internal_state = internal_states
                         .get_general_mut_f64_state(*idx)
                         .ok_or(ParameterCollectionGeneralCalculationError::F64IndexNotFound(*idx))?;
+
+                    let p = entry.before.as_ref().ok_or(
+                        ParameterCollectionGeneralCalculationError::BeforeNotImplemented {
+                            name: entry.name().clone(),
+                        },
+                    )?;
 
                     let ctx = GeneralParameterContext {
                         timestep,
@@ -2066,7 +2286,7 @@ impl ParameterCollection {
 
                     let value = p.before(ctx, internal_state).map_err(|source| {
                         ParameterCollectionGeneralCalculationError::CalculationError {
-                            name: p.name().clone(),
+                            name: entry.name().clone(),
                             source: Box::new(source),
                         }
                     })?;
@@ -2074,7 +2294,7 @@ impl ParameterCollection {
                     state
                         .set_general_parameter_value_before(*idx, value)
                         .map_err(|source| ParameterCollectionGeneralCalculationError::F64SetStateError {
-                            name: p.name().clone(),
+                            name: entry.name().clone(),
                             source,
                         })?;
 
@@ -2086,7 +2306,7 @@ impl ParameterCollection {
                 }
                 GeneralParameterType::Index(idx) => {
                     // Find the parameter itself
-                    let p = self
+                    let entry = self
                         .general_u64
                         .get(*idx.deref())
                         .ok_or(ParameterCollectionGeneralCalculationError::U64IndexNotFound(*idx))?;
@@ -2094,6 +2314,12 @@ impl ParameterCollection {
                     let internal_state = internal_states
                         .get_general_mut_u64_state(*idx)
                         .ok_or(ParameterCollectionGeneralCalculationError::U64IndexNotFound(*idx))?;
+
+                    let p = entry.before.as_ref().ok_or(
+                        ParameterCollectionGeneralCalculationError::BeforeNotImplemented {
+                            name: entry.name().clone(),
+                        },
+                    )?;
 
                     let ctx = GeneralParameterContext {
                         timestep,
@@ -2124,7 +2350,7 @@ impl ParameterCollection {
                 }
                 GeneralParameterType::Multi(idx) => {
                     // Find the parameter itself
-                    let p = self
+                    let entry = self
                         .general_multi
                         .get(*idx.deref())
                         .ok_or(ParameterCollectionGeneralCalculationError::MultiIndexNotFound(*idx))?;
@@ -2132,6 +2358,12 @@ impl ParameterCollection {
                     let internal_state = internal_states
                         .get_general_mut_multi_state(*idx)
                         .ok_or(ParameterCollectionGeneralCalculationError::MultiIndexNotFound(*idx))?;
+
+                    let p = entry.before.as_ref().ok_or(
+                        ParameterCollectionGeneralCalculationError::BeforeNotImplemented {
+                            name: entry.name().clone(),
+                        },
+                    )?;
 
                     let ctx = GeneralParameterContext {
                         timestep,
@@ -2184,12 +2416,12 @@ impl ParameterCollection {
             }
         }
 
-        for p in &self.general_resolve_order {
+        for p in &self.general_after_order {
             let start = Instant::now();
             match p {
                 GeneralParameterType::Parameter(idx) => {
                     // Find the parameter itself
-                    let p = self
+                    let entry = self
                         .general_f64
                         .get(*idx.deref())
                         .ok_or(ParameterCollectionGeneralCalculationError::F64IndexNotFound(*idx))?;
@@ -2198,6 +2430,12 @@ impl ParameterCollection {
                         .get_general_mut_f64_state(*idx)
                         .ok_or(ParameterCollectionGeneralCalculationError::F64IndexNotFound(*idx))?;
 
+                    let op = entry.after.as_ref().ok_or(
+                        ParameterCollectionGeneralCalculationError::AfterNotImplemented {
+                            name: entry.name().clone(),
+                        },
+                    )?;
+
                     let ctx = GeneralParameterContext {
                         timestep,
                         scenario_index,
@@ -2205,19 +2443,31 @@ impl ParameterCollection {
                         state,
                     };
 
-                    let value = p.after(ctx, internal_state).map_err(|source| {
-                        ParameterCollectionGeneralCalculationError::CalculationError {
-                            name: p.name().clone(),
-                            source: Box::new(source),
-                        }
-                    })?;
+                    match op {
+                        GeneralAfterOperation::Value(p) => {
+                            let value = p.after(ctx, internal_state).map_err(|source| {
+                                ParameterCollectionGeneralCalculationError::CalculationError {
+                                    name: entry.name().clone(),
+                                    source: Box::new(source),
+                                }
+                            })?;
 
-                    state.set_general_parameter_value_after(*idx, value).map_err(|source| {
-                        ParameterCollectionGeneralCalculationError::F64SetStateError {
-                            name: p.name().clone(),
-                            source,
+                            state.set_general_parameter_value_after(*idx, value).map_err(|source| {
+                                ParameterCollectionGeneralCalculationError::F64SetStateError {
+                                    name: entry.name().clone(),
+                                    source,
+                                }
+                            })?;
                         }
-                    })?;
+                        GeneralAfterOperation::Hook(p) => {
+                            p.after(ctx, internal_state).map_err(|source| {
+                                ParameterCollectionGeneralCalculationError::CalculationError {
+                                    name: entry.name().clone(),
+                                    source: Box::new(source),
+                                }
+                            })?;
+                        }
+                    }
 
                     if let Some(timings) = timings.as_deref_mut() {
                         unsafe {
@@ -2227,7 +2477,7 @@ impl ParameterCollection {
                 }
                 GeneralParameterType::Index(idx) => {
                     // Find the parameter itself
-                    let p = self
+                    let entry = self
                         .general_u64
                         .get(*idx.deref())
                         .ok_or(ParameterCollectionGeneralCalculationError::U64IndexNotFound(*idx))?;
@@ -2236,6 +2486,12 @@ impl ParameterCollection {
                         .get_general_mut_u64_state(*idx)
                         .ok_or(ParameterCollectionGeneralCalculationError::U64IndexNotFound(*idx))?;
 
+                    let op = entry.after.as_ref().ok_or(
+                        ParameterCollectionGeneralCalculationError::AfterNotImplemented {
+                            name: entry.name().clone(),
+                        },
+                    )?;
+
                     let ctx = GeneralParameterContext {
                         timestep,
                         scenario_index,
@@ -2243,19 +2499,31 @@ impl ParameterCollection {
                         state,
                     };
 
-                    let value = p.after(ctx, internal_state).map_err(|source| {
-                        ParameterCollectionGeneralCalculationError::CalculationError {
-                            name: p.name().clone(),
-                            source: Box::new(source),
-                        }
-                    })?;
+                    match op {
+                        GeneralAfterOperation::Value(p) => {
+                            let value = p.after(ctx, internal_state).map_err(|source| {
+                                ParameterCollectionGeneralCalculationError::CalculationError {
+                                    name: entry.name().clone(),
+                                    source: Box::new(source),
+                                }
+                            })?;
 
-                    state.set_general_parameter_index_after(*idx, value).map_err(|source| {
-                        ParameterCollectionGeneralCalculationError::U64SetStateError {
-                            name: p.name().clone(),
-                            source,
+                            state.set_general_parameter_index_after(*idx, value).map_err(|source| {
+                                ParameterCollectionGeneralCalculationError::U64SetStateError {
+                                    name: entry.name().clone(),
+                                    source,
+                                }
+                            })?;
                         }
-                    })?;
+                        GeneralAfterOperation::Hook(p) => {
+                            p.after(ctx, internal_state).map_err(|source| {
+                                ParameterCollectionGeneralCalculationError::CalculationError {
+                                    name: entry.name().clone(),
+                                    source: Box::new(source),
+                                }
+                            })?;
+                        }
+                    }
 
                     if let Some(timings) = timings.as_deref_mut() {
                         unsafe {
@@ -2265,7 +2533,7 @@ impl ParameterCollection {
                 }
                 GeneralParameterType::Multi(idx) => {
                     // Find the parameter itself
-                    let p = self
+                    let entry = self
                         .general_multi
                         .get(*idx.deref())
                         .ok_or(ParameterCollectionGeneralCalculationError::MultiIndexNotFound(*idx))?;
@@ -2274,6 +2542,12 @@ impl ParameterCollection {
                         .get_general_mut_multi_state(*idx)
                         .ok_or(ParameterCollectionGeneralCalculationError::MultiIndexNotFound(*idx))?;
 
+                    let op = entry.after.as_ref().ok_or(
+                        ParameterCollectionGeneralCalculationError::AfterNotImplemented {
+                            name: entry.name().clone(),
+                        },
+                    )?;
+
                     let ctx = GeneralParameterContext {
                         timestep,
                         scenario_index,
@@ -2281,21 +2555,33 @@ impl ParameterCollection {
                         state,
                     };
 
-                    let value = p.after(ctx, internal_state).map_err(|source| {
-                        ParameterCollectionGeneralCalculationError::CalculationError {
-                            name: p.name().clone(),
-                            source: Box::new(source),
-                        }
-                    })?;
+                    match op {
+                        GeneralAfterOperation::Value(p) => {
+                            let value = p.after(ctx, internal_state).map_err(|source| {
+                                ParameterCollectionGeneralCalculationError::CalculationError {
+                                    name: entry.name().clone(),
+                                    source: Box::new(source),
+                                }
+                            })?;
 
-                    state
-                        .set_general_multi_parameter_value_after(*idx, value)
-                        .map_err(
-                            |source| ParameterCollectionGeneralCalculationError::MultiSetStateError {
-                                name: p.name().clone(),
-                                source,
-                            },
-                        )?;
+                            state
+                                .set_general_multi_parameter_value_after(*idx, value)
+                                .map_err(
+                                    |source| ParameterCollectionGeneralCalculationError::MultiSetStateError {
+                                        name: entry.name().clone(),
+                                        source,
+                                    },
+                                )?;
+                        }
+                        GeneralAfterOperation::Hook(p) => {
+                            p.after(ctx, internal_state).map_err(|source| {
+                                ParameterCollectionGeneralCalculationError::CalculationError {
+                                    name: entry.name().clone(),
+                                    source: Box::new(source),
+                                }
+                            })?;
+                        }
+                    }
 
                     if let Some(timings) = timings.as_deref_mut() {
                         unsafe {
@@ -2309,18 +2595,18 @@ impl ParameterCollection {
         Ok(())
     }
 
-    pub fn compute_simple(
+    pub fn before_simple(
         &self,
         timestep: &Timestep,
         scenario_index: &ScenarioIndex,
         state: &mut State,
         internal_states: &mut ParameterStates,
     ) -> Result<(), ParameterCollectionSimpleCalculationError> {
-        for p in &self.simple_resolve_order {
+        for p in &self.simple_before_order {
             match p {
                 SimpleParameterType::Parameter(idx) => {
                     // Find the parameter itself
-                    let p = self
+                    let entry = self
                         .simple_f64
                         .get(*idx.deref())
                         .ok_or(ParameterCollectionSimpleCalculationError::F64IndexNotFound(*idx))?;
@@ -2328,6 +2614,12 @@ impl ParameterCollection {
                     let internal_state = internal_states
                         .get_simple_mut_f64_state(*idx)
                         .ok_or(ParameterCollectionSimpleCalculationError::F64IndexNotFound(*idx))?;
+
+                    let p = entry.before.as_ref().ok_or(
+                        ParameterCollectionSimpleCalculationError::BeforeNotImplemented {
+                            name: entry.name().clone(),
+                        },
+                    )?;
 
                     let ctx = SimpleParameterContext {
                         timestep,
@@ -2337,21 +2629,21 @@ impl ParameterCollection {
 
                     let value = p.before(ctx, internal_state).map_err(|source| {
                         ParameterCollectionSimpleCalculationError::CalculationError {
-                            name: p.name().clone(),
+                            name: entry.name().clone(),
                             source,
                         }
                     })?;
 
                     state.set_simple_parameter_value_before(*idx, value).map_err(|source| {
                         ParameterCollectionSimpleCalculationError::F64SetStateError {
-                            name: p.name().clone(),
+                            name: entry.name().clone(),
                             source,
                         }
                     })?;
                 }
                 SimpleParameterType::Index(idx) => {
                     // Find the parameter itself
-                    let p = self
+                    let entry = self
                         .simple_u64
                         .get(*idx.deref())
                         .ok_or(ParameterCollectionSimpleCalculationError::U64IndexNotFound(*idx))?;
@@ -2359,6 +2651,12 @@ impl ParameterCollection {
                     let internal_state = internal_states
                         .get_simple_mut_u64_state(*idx)
                         .ok_or(ParameterCollectionSimpleCalculationError::U64IndexNotFound(*idx))?;
+
+                    let p = entry.before.as_ref().ok_or(
+                        ParameterCollectionSimpleCalculationError::BeforeNotImplemented {
+                            name: entry.name().clone(),
+                        },
+                    )?;
 
                     let ctx = SimpleParameterContext {
                         timestep,
@@ -2382,7 +2680,7 @@ impl ParameterCollection {
                 }
                 SimpleParameterType::Multi(idx) => {
                     // Find the parameter itself
-                    let p = self
+                    let entry = self
                         .simple_multi
                         .get(*idx.deref())
                         .ok_or(ParameterCollectionSimpleCalculationError::MultiIndexNotFound(*idx))?;
@@ -2390,6 +2688,12 @@ impl ParameterCollection {
                     let internal_state = internal_states
                         .get_simple_mut_multi_state(*idx)
                         .ok_or(ParameterCollectionSimpleCalculationError::MultiIndexNotFound(*idx))?;
+
+                    let p = entry.before.as_ref().ok_or(
+                        ParameterCollectionSimpleCalculationError::BeforeNotImplemented {
+                            name: entry.name().clone(),
+                        },
+                    )?;
 
                     let ctx = SimpleParameterContext {
                         timestep,
@@ -2425,11 +2729,11 @@ impl ParameterCollection {
         state: &mut State,
         internal_states: &mut ParameterStates,
     ) -> Result<(), ParameterCollectionSimpleCalculationError> {
-        for p in &self.simple_resolve_order {
+        for p in &self.simple_after_order {
             match p {
                 SimpleParameterType::Parameter(idx) => {
                     // Find the parameter itself
-                    let p = self
+                    let entry = self
                         .simple_f64
                         .get(*idx.deref())
                         .ok_or(ParameterCollectionSimpleCalculationError::F64IndexNotFound(*idx))?;
@@ -2438,22 +2742,49 @@ impl ParameterCollection {
                         .get_simple_mut_f64_state(*idx)
                         .ok_or(ParameterCollectionSimpleCalculationError::F64IndexNotFound(*idx))?;
 
+                    let op =
+                        entry
+                            .after
+                            .as_ref()
+                            .ok_or(ParameterCollectionSimpleCalculationError::AfterNotImplemented {
+                                name: entry.name().clone(),
+                            })?;
+
                     let ctx = SimpleParameterContext {
                         timestep,
                         scenario_index,
                         values: &state.get_simple_parameter_values(),
                     };
 
-                    p.after(ctx, internal_state).map_err(|source| {
-                        ParameterCollectionSimpleCalculationError::CalculationError {
-                            name: p.name().clone(),
-                            source,
+                    match op {
+                        SimpleAfterOperation::Value(p) => {
+                            let value = p.after(ctx, internal_state).map_err(|source| {
+                                ParameterCollectionSimpleCalculationError::CalculationError {
+                                    name: entry.name().clone(),
+                                    source,
+                                }
+                            })?;
+
+                            state.set_simple_parameter_value_after(*idx, value).map_err(|source| {
+                                ParameterCollectionSimpleCalculationError::F64SetStateError {
+                                    name: entry.name().clone(),
+                                    source,
+                                }
+                            })?;
                         }
-                    })?;
+                        SimpleAfterOperation::Hook(p) => {
+                            p.after(ctx, internal_state).map_err(|source| {
+                                ParameterCollectionSimpleCalculationError::CalculationError {
+                                    name: entry.name().clone(),
+                                    source,
+                                }
+                            })?;
+                        }
+                    }
                 }
                 SimpleParameterType::Index(idx) => {
                     // Find the parameter itself
-                    let p = self
+                    let entry = self
                         .simple_u64
                         .get(*idx.deref())
                         .ok_or(ParameterCollectionSimpleCalculationError::U64IndexNotFound(*idx))?;
@@ -2462,22 +2793,49 @@ impl ParameterCollection {
                         .get_simple_mut_u64_state(*idx)
                         .ok_or(ParameterCollectionSimpleCalculationError::U64IndexNotFound(*idx))?;
 
+                    let op =
+                        entry
+                            .after
+                            .as_ref()
+                            .ok_or(ParameterCollectionSimpleCalculationError::AfterNotImplemented {
+                                name: entry.name().clone(),
+                            })?;
+
                     let ctx = SimpleParameterContext {
                         timestep,
                         scenario_index,
                         values: &state.get_simple_parameter_values(),
                     };
 
-                    p.after(ctx, internal_state).map_err(|source| {
-                        ParameterCollectionSimpleCalculationError::CalculationError {
-                            name: p.name().clone(),
-                            source,
+                    match op {
+                        SimpleAfterOperation::Value(p) => {
+                            let value = p.after(ctx, internal_state).map_err(|source| {
+                                ParameterCollectionSimpleCalculationError::CalculationError {
+                                    name: entry.name().clone(),
+                                    source,
+                                }
+                            })?;
+
+                            state.set_simple_parameter_index_after(*idx, value).map_err(|source| {
+                                ParameterCollectionSimpleCalculationError::U64SetStateError {
+                                    name: entry.name().clone(),
+                                    source,
+                                }
+                            })?;
                         }
-                    })?;
+                        SimpleAfterOperation::Hook(p) => {
+                            p.after(ctx, internal_state).map_err(|source| {
+                                ParameterCollectionSimpleCalculationError::CalculationError {
+                                    name: entry.name().clone(),
+                                    source,
+                                }
+                            })?;
+                        }
+                    }
                 }
                 SimpleParameterType::Multi(idx) => {
                     // Find the parameter itself
-                    let p = self
+                    let entry = self
                         .simple_multi
                         .get(*idx.deref())
                         .ok_or(ParameterCollectionSimpleCalculationError::MultiIndexNotFound(*idx))?;
@@ -2486,18 +2844,45 @@ impl ParameterCollection {
                         .get_simple_mut_multi_state(*idx)
                         .ok_or(ParameterCollectionSimpleCalculationError::MultiIndexNotFound(*idx))?;
 
+                    let op =
+                        entry
+                            .after
+                            .as_ref()
+                            .ok_or(ParameterCollectionSimpleCalculationError::AfterNotImplemented {
+                                name: entry.name().clone(),
+                            })?;
+
                     let ctx = SimpleParameterContext {
                         timestep,
                         scenario_index,
                         values: &state.get_simple_parameter_values(),
                     };
 
-                    p.after(ctx, internal_state).map_err(|source| {
-                        ParameterCollectionSimpleCalculationError::CalculationError {
-                            name: p.name().clone(),
-                            source,
+                    match op {
+                        SimpleAfterOperation::Value(p) => {
+                            let value = p.after(ctx, internal_state).map_err(|source| {
+                                ParameterCollectionSimpleCalculationError::CalculationError {
+                                    name: entry.name().clone(),
+                                    source,
+                                }
+                            })?;
+
+                            state
+                                .set_simple_multi_parameter_value_after(*idx, value)
+                                .map_err(|source| ParameterCollectionSimpleCalculationError::MultiSetStateError {
+                                    name: entry.name().clone(),
+                                    source,
+                                })?;
                         }
-                    })?;
+                        SimpleAfterOperation::Hook(p) => {
+                            p.after(ctx, internal_state).map_err(|source| {
+                                ParameterCollectionSimpleCalculationError::CalculationError {
+                                    name: entry.name().clone(),
+                                    source,
+                                }
+                            })?;
+                        }
+                    }
                 }
             }
         }
@@ -2817,9 +3202,10 @@ impl ParameterCollectionBuilder {
 #[cfg(test)]
 mod tests {
     use super::{
-        BuiltParameter, ConstParameter, GeneralCalculationError, GeneralParameter, GeneralParameterContext,
-        MaybeBuiltParameter, Parameter, ParameterBuildError, ParameterBuilder, ParameterCollectionBuilder,
-        ParameterMeta, ParameterName, ParameterState, SimpleParameter, SimpleParameterContext,
+        BuiltParameter, ConstParameter, GeneralBeforeParameter, GeneralCalculationError, GeneralParameter,
+        GeneralParameterContext, MaybeBuiltParameter, Parameter, ParameterBuildError, ParameterBuilder,
+        ParameterCollectionBuilder, ParameterMeta, ParameterName, ParameterState, SimpleBeforeParameter,
+        SimpleParameter, SimpleParameterContext,
     };
     use crate::network::ResolutionMaps;
     use crate::parameters::errors::{ConstCalculationError, SimpleCalculationError};
@@ -2919,7 +3305,13 @@ mod tests {
             self
         }
     }
-    impl<T> SimpleParameter<T> for TestParameter
+    impl SimpleParameter for TestParameter {
+        fn as_parameter(&self) -> &dyn Parameter {
+            self
+        }
+    }
+
+    impl<T> SimpleBeforeParameter<T> for TestParameter
     where
         T: From<u8>,
     {
@@ -2927,29 +3319,27 @@ mod tests {
             &self,
             _ctx: SimpleParameterContext<'_>,
             _internal_state: &mut Option<Box<dyn ParameterState>>,
-        ) -> Result<Option<T>, SimpleCalculationError> {
-            Ok(Some(T::from(1)))
-        }
-
-        fn as_parameter(&self) -> &dyn Parameter {
-            self
+        ) -> Result<T, SimpleCalculationError> {
+            Ok(T::from(1))
         }
     }
 
-    impl SimpleParameter<MultiValue> for TestParameter {
+    impl SimpleBeforeParameter<MultiValue> for TestParameter {
         fn before(
             &self,
             _ctx: SimpleParameterContext<'_>,
             _internal_state: &mut Option<Box<dyn ParameterState>>,
-        ) -> Result<Option<MultiValue>, SimpleCalculationError> {
-            Ok(Some(MultiValue::default()))
+        ) -> Result<MultiValue, SimpleCalculationError> {
+            Ok(MultiValue::default())
         }
-
+    }
+    impl GeneralParameter for TestParameter {
         fn as_parameter(&self) -> &dyn Parameter {
             self
         }
     }
-    impl<T> GeneralParameter<T> for TestParameter
+
+    impl<T> GeneralBeforeParameter<T> for TestParameter
     where
         T: From<u8>,
     {
@@ -2957,26 +3347,18 @@ mod tests {
             &self,
             _ctx: GeneralParameterContext<'_>,
             _internal_state: &mut Option<Box<dyn ParameterState>>,
-        ) -> Result<Option<T>, GeneralCalculationError> {
-            Ok(Some(T::from(1)))
-        }
-
-        fn as_parameter(&self) -> &dyn Parameter {
-            self
+        ) -> Result<T, GeneralCalculationError> {
+            Ok(T::from(1))
         }
     }
 
-    impl GeneralParameter<MultiValue> for TestParameter {
+    impl GeneralBeforeParameter<MultiValue> for TestParameter {
         fn before(
             &self,
             _ctx: GeneralParameterContext<'_>,
             _internal_state: &mut Option<Box<dyn ParameterState>>,
-        ) -> Result<Option<MultiValue>, GeneralCalculationError> {
-            Ok(Some(MultiValue::default()))
-        }
-
-        fn as_parameter(&self) -> &dyn Parameter {
-            self
+        ) -> Result<MultiValue, GeneralCalculationError> {
+            Ok(MultiValue::default())
         }
     }
 

--- a/pywr-core/src/parameters/mod.rs
+++ b/pywr-core/src/parameters/mod.rs
@@ -309,7 +309,7 @@ impl ParameterIndex<f64> {
     pub fn into_metric_f64(self, return_value: ParameterReturnValue) -> MetricF64 {
         match self {
             ParameterIndex::Const(idx) => ConstantMetricF64::ParameterValue(idx).into(),
-            ParameterIndex::Simple(idx) => SimpleMetricF64::ParameterValue(idx).into(),
+            ParameterIndex::Simple(index) => SimpleMetricF64::ParameterValue { index, return_value }.into(),
             ParameterIndex::General(index) => MetricF64::ParameterValue { index, return_value },
         }
     }
@@ -334,7 +334,7 @@ impl ParameterIndex<u64> {
     pub fn into_metric_f64(self, return_value: ParameterReturnValue) -> MetricF64 {
         match self {
             ParameterIndex::Const(idx) => ConstantMetricF64::IndexParameterValue(idx).into(),
-            ParameterIndex::Simple(idx) => SimpleMetricF64::IndexParameterValue(idx).into(),
+            ParameterIndex::Simple(index) => SimpleMetricF64::IndexParameterValue { index, return_value }.into(),
             ParameterIndex::General(index) => MetricF64::IndexParameterValue { index, return_value },
         }
     }
@@ -350,7 +350,7 @@ impl ParameterIndex<u64> {
     pub fn into_metric_u64(self, return_value: ParameterReturnValue) -> MetricU64 {
         match self {
             ParameterIndex::Const(idx) => ConstantMetricU64::IndexParameterValue(idx).into(),
-            ParameterIndex::Simple(idx) => SimpleMetricU64::IndexParameterValue(idx).into(),
+            ParameterIndex::Simple(index) => SimpleMetricU64::IndexParameterValue { index, return_value }.into(),
             ParameterIndex::General(index) => MetricU64::IndexParameterValue { index, return_value },
         }
     }
@@ -369,7 +369,12 @@ impl ParameterIndex<MultiValue> {
         let key = key.to_string();
         match self {
             ParameterIndex::Const(index) => ConstantMetricF64::MultiParameterValue { index, key }.into(),
-            ParameterIndex::Simple(index) => SimpleMetricF64::MultiParameterValue { index, key }.into(),
+            ParameterIndex::Simple(index) => SimpleMetricF64::MultiParameterValue {
+                index,
+                key,
+                return_value,
+            }
+            .into(),
             ParameterIndex::General(index) => MetricF64::MultiParameterValue {
                 index,
                 key,
@@ -390,7 +395,12 @@ impl ParameterIndex<MultiValue> {
         let key = key.to_string();
         match self {
             ParameterIndex::Const(index) => ConstantMetricU64::MultiParameterValue { index, key }.into(),
-            ParameterIndex::Simple(index) => SimpleMetricU64::MultiParameterValue { index, key }.into(),
+            ParameterIndex::Simple(index) => SimpleMetricU64::MultiParameterValue {
+                index,
+                key,
+                return_value,
+            }
+            .into(),
             ParameterIndex::General(index) => MetricU64::MultiParameterValue {
                 index,
                 key,
@@ -887,7 +897,7 @@ pub enum ParameterBuildError {
 
 pub enum BuiltParameter<T> {
     General(GeneralParameterEntry<T>),
-    Simple(SimpleParameterEntry<T>),
+    Simple(Box<dyn SimpleParameter<T>>),
     Const(Box<dyn ConstParameter<T>>),
 }
 
@@ -1176,119 +1186,13 @@ pub struct SimpleParameterContext<'a> {
 ///
 /// See [`SimpleBeforeParameter`] and [`SimpleAfterParameter`] for more specific traits that define
 /// the behaviour of parameters that produce values before or after the network is updated.
-pub trait SimpleParameter: Parameter {
+pub trait SimpleParameter<T>: Parameter {
+    fn compute(
+        &self,
+        context: SimpleParameterContext<'_>,
+        internal_state: &mut Option<Box<dyn ParameterState>>,
+    ) -> Result<T, SimpleCalculationError>;
     fn as_parameter(&self) -> &dyn Parameter;
-}
-
-pub trait SimpleBeforeParameter<T>: SimpleParameter {
-    fn before(
-        &self,
-        context: SimpleParameterContext<'_>,
-        internal_state: &mut Option<Box<dyn ParameterState>>,
-    ) -> Result<T, SimpleCalculationError>;
-}
-
-pub trait SimpleAfterParameter<T>: SimpleParameter {
-    fn after(
-        &self,
-        context: SimpleParameterContext<'_>,
-        internal_state: &mut Option<Box<dyn ParameterState>>,
-    ) -> Result<T, SimpleCalculationError>;
-}
-
-pub trait SimpleAfterParameterHook<T>: SimpleParameter {
-    fn after(
-        &self,
-        context: SimpleParameterContext<'_>,
-        internal_state: &mut Option<Box<dyn ParameterState>>,
-    ) -> Result<(), SimpleCalculationError>;
-}
-
-#[derive(Debug)]
-enum SimpleAfterOperation<T> {
-    Value(Arc<dyn SimpleAfterParameter<T>>),
-    Hook(Arc<dyn SimpleAfterParameterHook<T>>),
-}
-
-#[derive(Debug)]
-pub struct SimpleParameterEntry<T> {
-    parameter: Arc<dyn SimpleParameter>,
-    before: Option<Arc<dyn SimpleBeforeParameter<T>>>,
-    after: Option<SimpleAfterOperation<T>>,
-}
-
-impl<T: 'static> SimpleParameterEntry<T> {
-    pub fn before<P>(parameter: P) -> Self
-    where
-        P: SimpleBeforeParameter<T> + 'static,
-    {
-        let parameter = Arc::new(parameter);
-        Self {
-            parameter: parameter.clone(),
-            before: Some(parameter),
-            after: None,
-        }
-    }
-
-    pub fn after<P>(parameter: P) -> Self
-    where
-        P: SimpleAfterParameter<T> + 'static,
-    {
-        let parameter = Arc::new(parameter);
-        Self {
-            parameter: parameter.clone(),
-            before: None,
-            after: Some(SimpleAfterOperation::Value(parameter)),
-        }
-    }
-
-    pub fn both<P>(parameter: P) -> Self
-    where
-        P: SimpleBeforeParameter<T> + SimpleAfterParameter<T> + 'static,
-    {
-        let parameter = Arc::new(parameter);
-        Self {
-            parameter: parameter.clone(),
-            before: Some(parameter.clone()),
-            after: Some(SimpleAfterOperation::Value(parameter)),
-        }
-    }
-
-    pub fn before_with_after_hook<P>(parameter: P) -> Self
-    where
-        P: SimpleBeforeParameter<T> + SimpleAfterParameterHook<T> + 'static,
-    {
-        let parameter = Arc::new(parameter);
-        Self {
-            parameter: parameter.clone(),
-            before: Some(parameter.clone()),
-            after: Some(SimpleAfterOperation::Hook(parameter)),
-        }
-    }
-
-    fn setup(
-        &self,
-        timesteps: &[Timestep],
-        scenario_index: &ScenarioIndex,
-    ) -> Result<Option<Box<dyn ParameterState>>, ParameterSetupError> {
-        self.parameter.setup(timesteps, scenario_index)
-    }
-
-    pub fn name(&self) -> &ParameterName {
-        self.parameter.name()
-    }
-
-    fn as_parameter(&self) -> &dyn Parameter {
-        self.parameter.as_parameter()
-    }
-
-    fn has_before(&self) -> bool {
-        self.before.is_some()
-    }
-
-    fn has_after(&self) -> bool {
-        self.after.is_some()
-    }
 }
 
 /// A trait that defines a component that produces a value each time-step.
@@ -1739,11 +1643,10 @@ pub struct ParameterCollection {
     constant_multi: Vec<Box<dyn ConstParameter<MultiValue>>>,
     constant_resolve_order: Vec<ConstParameterType>,
 
-    simple_f64: Vec<SimpleParameterEntry<f64>>,
-    simple_u64: Vec<SimpleParameterEntry<u64>>,
-    simple_multi: Vec<SimpleParameterEntry<MultiValue>>,
-    simple_before_order: Vec<SimpleParameterType>,
-    simple_after_order: Vec<SimpleParameterType>,
+    simple_f64: Vec<Box<dyn SimpleParameter<f64>>>,
+    simple_u64: Vec<Box<dyn SimpleParameter<u64>>>,
+    simple_multi: Vec<Box<dyn SimpleParameter<MultiValue>>>,
+    simple_resolve_order: Vec<SimpleParameterType>,
 
     general_f64: Vec<GeneralParameterEntry<f64>>,
     general_u64: Vec<GeneralParameterEntry<u64>>,
@@ -1763,8 +1666,7 @@ impl Default for ParameterCollection {
             simple_f64: Vec::new(),
             simple_u64: Vec::new(),
             simple_multi: Vec::new(),
-            simple_before_order: Vec::new(),
-            simple_after_order: Vec::new(),
+            simple_resolve_order: Vec::new(),
             general_f64: Vec::new(),
             general_u64: Vec::new(),
             general_multi: Vec::new(),
@@ -1980,17 +1882,11 @@ impl ParameterCollection {
     /// Push a new simple parameter to the collection.
     ///
     /// SAFETY: This must remain a private function to maintain the indexing guarantees.
-    fn push_simple_f64(&mut self, entry: SimpleParameterEntry<f64>) -> ParameterIndex<f64> {
+    fn push_simple_f64(&mut self, parameter: Box<dyn SimpleParameter<f64>>) -> ParameterIndex<f64> {
         let index = SimpleParameterIndex::new(self.simple_f64.len());
 
-        if entry.has_before() {
-            self.simple_before_order.push(index.into());
-        }
-
-        if entry.has_after() {
-            self.simple_after_order.push(index.into());
-        }
-        self.simple_f64.push(entry);
+        self.simple_f64.push(parameter);
+        self.simple_resolve_order.push(index.into());
 
         ParameterIndex::Simple(index)
     }
@@ -2073,17 +1969,11 @@ impl ParameterCollection {
     /// The new parameter will be simplified as much as possible.
     ///
     /// SAFETY: This must remain a private function to maintain the indexing guarantees.
-    fn push_simple_u64(&mut self, entry: SimpleParameterEntry<u64>) -> ParameterIndex<u64> {
+    fn push_simple_u64(&mut self, parameter: Box<dyn SimpleParameter<u64>>) -> ParameterIndex<u64> {
         let index = SimpleParameterIndex::new(self.simple_u64.len());
 
-        if entry.has_before() {
-            self.simple_before_order.push(index.into());
-        }
-
-        if entry.has_after() {
-            self.simple_after_order.push(index.into());
-        }
-        self.simple_u64.push(entry);
+        self.simple_u64.push(parameter);
+        self.simple_resolve_order.push(index.into());
 
         ParameterIndex::Simple(index)
     }
@@ -2168,17 +2058,11 @@ impl ParameterCollection {
     /// The new parameter will be simplified as much as possible.
     ///
     /// SAFETY: This must remain a private function to maintain the indexing guarantees.
-    fn push_simple_multi(&mut self, entry: SimpleParameterEntry<MultiValue>) -> ParameterIndex<MultiValue> {
+    fn push_simple_multi(&mut self, parameter: Box<dyn SimpleParameter<MultiValue>>) -> ParameterIndex<MultiValue> {
         let index = SimpleParameterIndex::new(self.simple_multi.len());
 
-        if entry.has_before() {
-            self.simple_before_order.push(index.into());
-        }
-
-        if entry.has_after() {
-            self.simple_after_order.push(index.into());
-        }
-        self.simple_multi.push(entry);
+        self.simple_multi.push(parameter);
+        self.simple_resolve_order.push(index.into());
 
         ParameterIndex::Simple(index)
     }
@@ -2595,18 +2479,18 @@ impl ParameterCollection {
         Ok(())
     }
 
-    pub fn before_simple(
+    pub fn compute_simple(
         &self,
         timestep: &Timestep,
         scenario_index: &ScenarioIndex,
         state: &mut State,
         internal_states: &mut ParameterStates,
     ) -> Result<(), ParameterCollectionSimpleCalculationError> {
-        for p in &self.simple_before_order {
+        for p in &self.simple_resolve_order {
             match p {
                 SimpleParameterType::Parameter(idx) => {
                     // Find the parameter itself
-                    let entry = self
+                    let p = self
                         .simple_f64
                         .get(*idx.deref())
                         .ok_or(ParameterCollectionSimpleCalculationError::F64IndexNotFound(*idx))?;
@@ -2615,35 +2499,29 @@ impl ParameterCollection {
                         .get_simple_mut_f64_state(*idx)
                         .ok_or(ParameterCollectionSimpleCalculationError::F64IndexNotFound(*idx))?;
 
-                    let p = entry.before.as_ref().ok_or(
-                        ParameterCollectionSimpleCalculationError::BeforeNotImplemented {
-                            name: entry.name().clone(),
-                        },
-                    )?;
-
                     let ctx = SimpleParameterContext {
                         timestep,
                         scenario_index,
                         values: &state.get_simple_parameter_values(),
                     };
 
-                    let value = p.before(ctx, internal_state).map_err(|source| {
+                    let value = p.compute(ctx, internal_state).map_err(|source| {
                         ParameterCollectionSimpleCalculationError::CalculationError {
-                            name: entry.name().clone(),
+                            name: p.name().clone(),
                             source,
                         }
                     })?;
 
                     state.set_simple_parameter_value_before(*idx, value).map_err(|source| {
                         ParameterCollectionSimpleCalculationError::F64SetStateError {
-                            name: entry.name().clone(),
+                            name: p.name().clone(),
                             source,
                         }
                     })?;
                 }
                 SimpleParameterType::Index(idx) => {
                     // Find the parameter itself
-                    let entry = self
+                    let p = self
                         .simple_u64
                         .get(*idx.deref())
                         .ok_or(ParameterCollectionSimpleCalculationError::U64IndexNotFound(*idx))?;
@@ -2652,19 +2530,13 @@ impl ParameterCollection {
                         .get_simple_mut_u64_state(*idx)
                         .ok_or(ParameterCollectionSimpleCalculationError::U64IndexNotFound(*idx))?;
 
-                    let p = entry.before.as_ref().ok_or(
-                        ParameterCollectionSimpleCalculationError::BeforeNotImplemented {
-                            name: entry.name().clone(),
-                        },
-                    )?;
-
                     let ctx = SimpleParameterContext {
                         timestep,
                         scenario_index,
                         values: &state.get_simple_parameter_values(),
                     };
 
-                    let value = p.before(ctx, internal_state).map_err(|source| {
+                    let value = p.compute(ctx, internal_state).map_err(|source| {
                         ParameterCollectionSimpleCalculationError::CalculationError {
                             name: p.name().clone(),
                             source,
@@ -2680,7 +2552,7 @@ impl ParameterCollection {
                 }
                 SimpleParameterType::Multi(idx) => {
                     // Find the parameter itself
-                    let entry = self
+                    let p = self
                         .simple_multi
                         .get(*idx.deref())
                         .ok_or(ParameterCollectionSimpleCalculationError::MultiIndexNotFound(*idx))?;
@@ -2689,19 +2561,13 @@ impl ParameterCollection {
                         .get_simple_mut_multi_state(*idx)
                         .ok_or(ParameterCollectionSimpleCalculationError::MultiIndexNotFound(*idx))?;
 
-                    let p = entry.before.as_ref().ok_or(
-                        ParameterCollectionSimpleCalculationError::BeforeNotImplemented {
-                            name: entry.name().clone(),
-                        },
-                    )?;
-
                     let ctx = SimpleParameterContext {
                         timestep,
                         scenario_index,
                         values: &state.get_simple_parameter_values(),
                     };
 
-                    let value = p.before(ctx, internal_state).map_err(|source| {
+                    let value = p.compute(ctx, internal_state).map_err(|source| {
                         ParameterCollectionSimpleCalculationError::CalculationError {
                             name: p.name().clone(),
                             source,
@@ -2714,175 +2580,6 @@ impl ParameterCollection {
                             name: p.name().clone(),
                             source,
                         })?;
-                }
-            }
-        }
-
-        Ok(())
-    }
-
-    /// Perform the after step for simple parameters.
-    pub fn after_simple(
-        &self,
-        timestep: &Timestep,
-        scenario_index: &ScenarioIndex,
-        state: &mut State,
-        internal_states: &mut ParameterStates,
-    ) -> Result<(), ParameterCollectionSimpleCalculationError> {
-        for p in &self.simple_after_order {
-            match p {
-                SimpleParameterType::Parameter(idx) => {
-                    // Find the parameter itself
-                    let entry = self
-                        .simple_f64
-                        .get(*idx.deref())
-                        .ok_or(ParameterCollectionSimpleCalculationError::F64IndexNotFound(*idx))?;
-                    // .. and its internal state
-                    let internal_state = internal_states
-                        .get_simple_mut_f64_state(*idx)
-                        .ok_or(ParameterCollectionSimpleCalculationError::F64IndexNotFound(*idx))?;
-
-                    let op =
-                        entry
-                            .after
-                            .as_ref()
-                            .ok_or(ParameterCollectionSimpleCalculationError::AfterNotImplemented {
-                                name: entry.name().clone(),
-                            })?;
-
-                    let ctx = SimpleParameterContext {
-                        timestep,
-                        scenario_index,
-                        values: &state.get_simple_parameter_values(),
-                    };
-
-                    match op {
-                        SimpleAfterOperation::Value(p) => {
-                            let value = p.after(ctx, internal_state).map_err(|source| {
-                                ParameterCollectionSimpleCalculationError::CalculationError {
-                                    name: entry.name().clone(),
-                                    source,
-                                }
-                            })?;
-
-                            state.set_simple_parameter_value_after(*idx, value).map_err(|source| {
-                                ParameterCollectionSimpleCalculationError::F64SetStateError {
-                                    name: entry.name().clone(),
-                                    source,
-                                }
-                            })?;
-                        }
-                        SimpleAfterOperation::Hook(p) => {
-                            p.after(ctx, internal_state).map_err(|source| {
-                                ParameterCollectionSimpleCalculationError::CalculationError {
-                                    name: entry.name().clone(),
-                                    source,
-                                }
-                            })?;
-                        }
-                    }
-                }
-                SimpleParameterType::Index(idx) => {
-                    // Find the parameter itself
-                    let entry = self
-                        .simple_u64
-                        .get(*idx.deref())
-                        .ok_or(ParameterCollectionSimpleCalculationError::U64IndexNotFound(*idx))?;
-                    // .. and its internal state
-                    let internal_state = internal_states
-                        .get_simple_mut_u64_state(*idx)
-                        .ok_or(ParameterCollectionSimpleCalculationError::U64IndexNotFound(*idx))?;
-
-                    let op =
-                        entry
-                            .after
-                            .as_ref()
-                            .ok_or(ParameterCollectionSimpleCalculationError::AfterNotImplemented {
-                                name: entry.name().clone(),
-                            })?;
-
-                    let ctx = SimpleParameterContext {
-                        timestep,
-                        scenario_index,
-                        values: &state.get_simple_parameter_values(),
-                    };
-
-                    match op {
-                        SimpleAfterOperation::Value(p) => {
-                            let value = p.after(ctx, internal_state).map_err(|source| {
-                                ParameterCollectionSimpleCalculationError::CalculationError {
-                                    name: entry.name().clone(),
-                                    source,
-                                }
-                            })?;
-
-                            state.set_simple_parameter_index_after(*idx, value).map_err(|source| {
-                                ParameterCollectionSimpleCalculationError::U64SetStateError {
-                                    name: entry.name().clone(),
-                                    source,
-                                }
-                            })?;
-                        }
-                        SimpleAfterOperation::Hook(p) => {
-                            p.after(ctx, internal_state).map_err(|source| {
-                                ParameterCollectionSimpleCalculationError::CalculationError {
-                                    name: entry.name().clone(),
-                                    source,
-                                }
-                            })?;
-                        }
-                    }
-                }
-                SimpleParameterType::Multi(idx) => {
-                    // Find the parameter itself
-                    let entry = self
-                        .simple_multi
-                        .get(*idx.deref())
-                        .ok_or(ParameterCollectionSimpleCalculationError::MultiIndexNotFound(*idx))?;
-                    // .. and its internal state
-                    let internal_state = internal_states
-                        .get_simple_mut_multi_state(*idx)
-                        .ok_or(ParameterCollectionSimpleCalculationError::MultiIndexNotFound(*idx))?;
-
-                    let op =
-                        entry
-                            .after
-                            .as_ref()
-                            .ok_or(ParameterCollectionSimpleCalculationError::AfterNotImplemented {
-                                name: entry.name().clone(),
-                            })?;
-
-                    let ctx = SimpleParameterContext {
-                        timestep,
-                        scenario_index,
-                        values: &state.get_simple_parameter_values(),
-                    };
-
-                    match op {
-                        SimpleAfterOperation::Value(p) => {
-                            let value = p.after(ctx, internal_state).map_err(|source| {
-                                ParameterCollectionSimpleCalculationError::CalculationError {
-                                    name: entry.name().clone(),
-                                    source,
-                                }
-                            })?;
-
-                            state
-                                .set_simple_multi_parameter_value_after(*idx, value)
-                                .map_err(|source| ParameterCollectionSimpleCalculationError::MultiSetStateError {
-                                    name: entry.name().clone(),
-                                    source,
-                                })?;
-                        }
-                        SimpleAfterOperation::Hook(p) => {
-                            p.after(ctx, internal_state).map_err(|source| {
-                                ParameterCollectionSimpleCalculationError::CalculationError {
-                                    name: entry.name().clone(),
-                                    source,
-                                }
-                            })?;
-                        }
-                    }
                 }
             }
         }
@@ -3202,16 +2899,19 @@ impl ParameterCollectionBuilder {
 #[cfg(test)]
 mod tests {
     use super::{
-        BuiltParameter, ConstParameter, GeneralBeforeParameter, GeneralCalculationError, GeneralParameter,
-        GeneralParameterContext, MaybeBuiltParameter, Parameter, ParameterBuildError, ParameterBuilder,
-        ParameterCollectionBuilder, ParameterMeta, ParameterName, ParameterState, SimpleBeforeParameter,
+        BuiltParameter, ConstParameter, GeneralAfterParameter, GeneralAfterParameterHook, GeneralBeforeParameter,
+        GeneralCalculationError, GeneralParameter, GeneralParameterContext, GeneralParameterEntry, MaybeBuiltParameter,
+        Parameter, ParameterBuildError, ParameterBuilder, ParameterCollection, ParameterCollectionBuilder,
+        ParameterIndex, ParameterMeta, ParameterName, ParameterReturnValue, ParameterState, ParameterStates,
         SimpleParameter, SimpleParameterContext,
     };
-    use crate::network::ResolutionMaps;
+    use crate::metric::{MetricF64, SimpleMetricF64};
+    use crate::network::{Network, ResolutionMaps};
     use crate::parameters::errors::{ConstCalculationError, SimpleCalculationError};
     use crate::scenario::ScenarioIndex;
-    use crate::state::{ConstParameterValues, MultiValue};
+    use crate::state::{ConstParameterValues, MultiValue, StateBuilder};
     use crate::test_utils::default_domain;
+    use std::sync::{Arc, Mutex};
 
     #[derive(Debug)]
     struct TestParameterBuilder {
@@ -3305,32 +3005,32 @@ mod tests {
             self
         }
     }
-    impl SimpleParameter for TestParameter {
-        fn as_parameter(&self) -> &dyn Parameter {
-            self
-        }
-    }
-
-    impl<T> SimpleBeforeParameter<T> for TestParameter
+    impl<T> SimpleParameter<T> for TestParameter
     where
         T: From<u8>,
     {
-        fn before(
+        fn compute(
             &self,
             _ctx: SimpleParameterContext<'_>,
             _internal_state: &mut Option<Box<dyn ParameterState>>,
         ) -> Result<T, SimpleCalculationError> {
             Ok(T::from(1))
         }
+        fn as_parameter(&self) -> &dyn Parameter {
+            self
+        }
     }
 
-    impl SimpleBeforeParameter<MultiValue> for TestParameter {
-        fn before(
+    impl SimpleParameter<MultiValue> for TestParameter {
+        fn compute(
             &self,
             _ctx: SimpleParameterContext<'_>,
             _internal_state: &mut Option<Box<dyn ParameterState>>,
         ) -> Result<MultiValue, SimpleCalculationError> {
             Ok(MultiValue::default())
+        }
+        fn as_parameter(&self) -> &dyn Parameter {
+            self
         }
     }
     impl GeneralParameter for TestParameter {
@@ -3385,5 +3085,546 @@ mod tests {
         collection.u64(Box::new(TestParameterBuilder::default()));
 
         assert!(collection.build(&mut ResolutionMaps::new(default_domain())).is_err());
+    }
+
+    #[derive(Debug)]
+    struct PhaseTestParameter {
+        meta: ParameterMeta,
+        events: Arc<Mutex<Vec<String>>>,
+    }
+
+    impl PhaseTestParameter {
+        fn new(name: &str, events: Arc<Mutex<Vec<String>>>) -> Self {
+            Self {
+                meta: ParameterMeta::new(name.into()),
+                events,
+            }
+        }
+
+        fn record(&self, phase: &str) {
+            self.events.lock().unwrap().push(format!("{}:{phase}", self.name()));
+        }
+    }
+
+    impl Parameter for PhaseTestParameter {
+        fn meta(&self) -> &ParameterMeta {
+            &self.meta
+        }
+    }
+
+    impl SimpleParameter<f64> for PhaseTestParameter {
+        fn compute(
+            &self,
+            _context: SimpleParameterContext<'_>,
+            _internal_state: &mut Option<Box<dyn ParameterState>>,
+        ) -> Result<f64, SimpleCalculationError> {
+            self.record("before");
+            Ok(11.0)
+        }
+
+        fn as_parameter(&self) -> &dyn Parameter {
+            self
+        }
+    }
+
+    impl GeneralParameter for PhaseTestParameter {
+        fn as_parameter(&self) -> &dyn Parameter {
+            self
+        }
+    }
+
+    impl GeneralBeforeParameter<f64> for PhaseTestParameter {
+        fn before(
+            &self,
+            _context: GeneralParameterContext<'_>,
+            _internal_state: &mut Option<Box<dyn ParameterState>>,
+        ) -> Result<f64, GeneralCalculationError> {
+            self.record("before");
+            Ok(11.0)
+        }
+    }
+
+    impl GeneralAfterParameter<f64> for PhaseTestParameter {
+        fn after(
+            &self,
+            _context: GeneralParameterContext<'_>,
+            _internal_state: &mut Option<Box<dyn ParameterState>>,
+        ) -> Result<f64, GeneralCalculationError> {
+            self.record("after");
+            Ok(22.0)
+        }
+    }
+
+    impl GeneralAfterParameterHook<f64> for PhaseTestParameter {
+        fn after(
+            &self,
+            _context: GeneralParameterContext<'_>,
+            _internal_state: &mut Option<Box<dyn ParameterState>>,
+        ) -> Result<(), GeneralCalculationError> {
+            self.record("hook");
+            Ok(())
+        }
+    }
+
+    fn simple_index(index: ParameterIndex<f64>) -> super::SimpleParameterIndex<f64> {
+        match index {
+            ParameterIndex::Simple(index) => index,
+            _ => panic!("expected a simple parameter index"),
+        }
+    }
+
+    fn general_index(index: ParameterIndex<f64>) -> super::GeneralParameterIndex<f64> {
+        match index {
+            ParameterIndex::General(index) => index,
+            _ => panic!("expected a general parameter index"),
+        }
+    }
+
+    #[derive(Debug)]
+    struct SimpleDependencyTestParameter {
+        meta: ParameterMeta,
+        metric: SimpleMetricF64,
+        observed_values: Arc<Mutex<Vec<f64>>>,
+    }
+
+    impl SimpleDependencyTestParameter {
+        fn new(name: &str, metric: SimpleMetricF64, observed_values: Arc<Mutex<Vec<f64>>>) -> Self {
+            Self {
+                meta: ParameterMeta::new(name.into()),
+                metric,
+                observed_values,
+            }
+        }
+
+        fn calculate(&self, context: SimpleParameterContext<'_>) -> Result<f64, SimpleCalculationError> {
+            let value = self.metric.get_value(context.values)?;
+            self.observed_values.lock().unwrap().push(value);
+
+            // Returning a transformed value makes it clear that this parameter
+            // consumed the dependency rather than simply reproducing a constant.
+            Ok(value * 2.0)
+        }
+    }
+
+    impl Parameter for SimpleDependencyTestParameter {
+        fn meta(&self) -> &ParameterMeta {
+            &self.meta
+        }
+    }
+
+    impl SimpleParameter<f64> for SimpleDependencyTestParameter {
+        fn compute(
+            &self,
+            context: SimpleParameterContext<'_>,
+            _internal_state: &mut Option<Box<dyn ParameterState>>,
+        ) -> Result<f64, SimpleCalculationError> {
+            self.calculate(context)
+        }
+        fn as_parameter(&self) -> &dyn Parameter {
+            self
+        }
+    }
+
+    #[derive(Debug)]
+    struct GeneralDependencyTestParameter {
+        meta: ParameterMeta,
+        metric: MetricF64,
+        observed_values: Arc<Mutex<Vec<f64>>>,
+    }
+
+    impl GeneralDependencyTestParameter {
+        fn new(name: &str, metric: MetricF64, observed_values: Arc<Mutex<Vec<f64>>>) -> Self {
+            Self {
+                meta: ParameterMeta::new(name.into()),
+                metric,
+                observed_values,
+            }
+        }
+
+        fn calculate(&self, context: GeneralParameterContext<'_>) -> Result<f64, GeneralCalculationError> {
+            let value = self.metric.get_value(context.network, context.state)?;
+            self.observed_values.lock().unwrap().push(value);
+
+            Ok(value * 2.0)
+        }
+    }
+
+    impl Parameter for GeneralDependencyTestParameter {
+        fn meta(&self) -> &ParameterMeta {
+            &self.meta
+        }
+    }
+
+    impl GeneralParameter for GeneralDependencyTestParameter {
+        fn as_parameter(&self) -> &dyn Parameter {
+            self
+        }
+    }
+
+    impl GeneralBeforeParameter<f64> for GeneralDependencyTestParameter {
+        fn before(
+            &self,
+            context: GeneralParameterContext<'_>,
+            _internal_state: &mut Option<Box<dyn ParameterState>>,
+        ) -> Result<f64, GeneralCalculationError> {
+            self.calculate(context)
+        }
+    }
+
+    impl GeneralAfterParameter<f64> for GeneralDependencyTestParameter {
+        fn after(
+            &self,
+            context: GeneralParameterContext<'_>,
+            _internal_state: &mut Option<Box<dyn ParameterState>>,
+        ) -> Result<f64, GeneralCalculationError> {
+            self.calculate(context)
+        }
+    }
+
+    /// Extract a simple metric from the public ParameterIndex conversion API.
+    ///
+    /// Going through `ParameterIndex::into_metric_f64_*` is important for the
+    /// regression test: this is currently where the requested phase is discarded
+    /// for simple parameters.
+    fn expect_simple_metric(metric: MetricF64) -> SimpleMetricF64 {
+        match metric {
+            MetricF64::Simple(metric) => metric,
+            other => panic!("expected a simple metric, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn simple_parameters_run() {
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let mut collection = ParameterCollection::default();
+
+        let before_index = simple_index(
+            collection.push_simple_f64(Box::new(PhaseTestParameter::new("simple-before", events.clone()))),
+        );
+
+        let domain = default_domain();
+        let timesteps = domain.time().timesteps();
+        let timestep = &timesteps[0];
+        let scenario_index = ScenarioIndex::default();
+
+        let mut state = StateBuilder::new(Vec::new(), 0).with_parameters(&collection).build();
+
+        let mut internal_states = ParameterStates::from_collection(&collection, timesteps, &scenario_index).unwrap();
+
+        collection
+            .compute_simple(timestep, &scenario_index, &mut state, &mut internal_states)
+            .unwrap();
+
+        // Only entries with a before implementation should have run.
+        assert_eq!(events.lock().unwrap().as_slice(), ["simple-before:before",]);
+
+        let values = state.get_simple_parameter_values();
+
+        assert_eq!(
+            values.get_f64(before_index, ParameterReturnValue::Before).unwrap(),
+            11.0
+        );
+
+        assert_eq!(events.lock().unwrap().as_slice(), ["simple-before:before",]);
+
+        // SimpleParameterValues exposes before-phase values. These should not be
+        // changed by after-phase calculations.
+        let values = state.get_simple_parameter_values();
+
+        assert_eq!(
+            values.get_f64(before_index, ParameterReturnValue::Before).unwrap(),
+            11.0
+        );
+    }
+
+    #[test]
+    fn general_parameters_run_their_configured_phases() {
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let mut collection = ParameterCollection::default();
+
+        let before_index = general_index(collection.push_general_f64(GeneralParameterEntry::before(
+            PhaseTestParameter::new("general-before", events.clone()),
+        )));
+
+        let after_index = general_index(collection.push_general_f64(GeneralParameterEntry::after(
+            PhaseTestParameter::new("general-after", events.clone()),
+        )));
+
+        let both_index = general_index(collection.push_general_f64(GeneralParameterEntry::both(
+            PhaseTestParameter::new("general-both", events.clone()),
+        )));
+
+        let hook_index = general_index(
+            collection.push_general_f64(GeneralParameterEntry::before_with_after_hook(PhaseTestParameter::new(
+                "general-hook",
+                events.clone(),
+            ))),
+        );
+
+        let domain = default_domain();
+        let timesteps = domain.time().timesteps();
+        let timestep = &timesteps[0];
+        let scenario_index = ScenarioIndex::default();
+        let network = Network::default();
+
+        let mut state = StateBuilder::new(Vec::new(), 0).with_parameters(&collection).build();
+
+        let mut internal_states = ParameterStates::from_collection(&collection, timesteps, &scenario_index).unwrap();
+
+        collection
+            .before_general(
+                timestep,
+                &scenario_index,
+                &network,
+                &mut state,
+                &mut internal_states,
+                None,
+            )
+            .unwrap();
+
+        assert_eq!(
+            events.lock().unwrap().as_slice(),
+            ["general-before:before", "general-both:before", "general-hook:before",]
+        );
+
+        assert_eq!(
+            state
+                .get_general_parameter_value(before_index, ParameterReturnValue::Before,)
+                .unwrap(),
+            11.0
+        );
+        assert_eq!(
+            state
+                .get_general_parameter_value(after_index, ParameterReturnValue::Before,)
+                .unwrap(),
+            0.0
+        );
+        assert_eq!(
+            state
+                .get_general_parameter_value(both_index, ParameterReturnValue::Before,)
+                .unwrap(),
+            11.0
+        );
+        assert_eq!(
+            state
+                .get_general_parameter_value(hook_index, ParameterReturnValue::Before,)
+                .unwrap(),
+            11.0
+        );
+
+        collection
+            .after_general(
+                timestep,
+                &scenario_index,
+                &network,
+                &mut state,
+                &mut internal_states,
+                None,
+            )
+            .unwrap();
+
+        assert_eq!(
+            events.lock().unwrap().as_slice(),
+            [
+                "general-before:before",
+                "general-both:before",
+                "general-hook:before",
+                "general-after:after",
+                "general-both:after",
+                "general-hook:hook",
+            ]
+        );
+
+        // Value-producing after operations write their result.
+        assert_eq!(
+            state
+                .get_general_parameter_value(after_index, ParameterReturnValue::After,)
+                .unwrap(),
+            22.0
+        );
+        assert_eq!(
+            state
+                .get_general_parameter_value(both_index, ParameterReturnValue::After,)
+                .unwrap(),
+            22.0
+        );
+
+        // Before-only entries and after hooks do not write an after value.
+        assert_eq!(
+            state
+                .get_general_parameter_value(before_index, ParameterReturnValue::After,)
+                .unwrap(),
+            0.0
+        );
+        assert_eq!(
+            state
+                .get_general_parameter_value(hook_index, ParameterReturnValue::After,)
+                .unwrap(),
+            0.0
+        );
+    }
+
+    #[test]
+    fn simple_before_parameter_can_depend_on_simple_before_value() {
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let observed_values = Arc::new(Mutex::new(Vec::new()));
+        let mut collection = ParameterCollection::default();
+
+        let source_index = collection.push_simple_f64(Box::new(PhaseTestParameter::new("source", events)));
+
+        let dependency_metric = expect_simple_metric(source_index.into_metric_f64_before());
+
+        let dependent_index = simple_index(collection.push_simple_f64(Box::new(SimpleDependencyTestParameter::new(
+            "dependent",
+            dependency_metric,
+            observed_values.clone(),
+        ))));
+
+        let domain = default_domain();
+        let timesteps = domain.time().timesteps();
+        let timestep = &timesteps[0];
+        let scenario_index = ScenarioIndex::default();
+
+        let mut state = StateBuilder::new(Vec::new(), 0).with_parameters(&collection).build();
+
+        let mut internal_states = ParameterStates::from_collection(&collection, timesteps, &scenario_index).unwrap();
+
+        collection
+            .compute_simple(timestep, &scenario_index, &mut state, &mut internal_states)
+            .unwrap();
+
+        // The source returns 11.0 and the dependent returns source * 2.
+        assert_eq!(observed_values.lock().unwrap().as_slice(), [11.0]);
+        assert_eq!(
+            state
+                .get_simple_parameter_values()
+                .get_f64(dependent_index, ParameterReturnValue::Before)
+                .unwrap(),
+            22.0
+        );
+    }
+
+    #[test]
+    fn general_before_parameter_can_depend_on_general_before_value() {
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let observed_values = Arc::new(Mutex::new(Vec::new()));
+        let mut collection = ParameterCollection::default();
+
+        let source_index =
+            collection.push_general_f64(GeneralParameterEntry::before(PhaseTestParameter::new("source", events)));
+
+        let dependent_index = general_index(collection.push_general_f64(GeneralParameterEntry::before(
+            GeneralDependencyTestParameter::new(
+                "dependent",
+                source_index.into_metric_f64_before(),
+                observed_values.clone(),
+            ),
+        )));
+
+        let domain = default_domain();
+        let timesteps = domain.time().timesteps();
+        let timestep = &timesteps[0];
+        let scenario_index = ScenarioIndex::default();
+        let network = Network::default();
+
+        let mut state = StateBuilder::new(Vec::new(), 0).with_parameters(&collection).build();
+
+        let mut internal_states = ParameterStates::from_collection(&collection, timesteps, &scenario_index).unwrap();
+
+        collection
+            .before_general(
+                timestep,
+                &scenario_index,
+                &network,
+                &mut state,
+                &mut internal_states,
+                None,
+            )
+            .unwrap();
+
+        assert_eq!(observed_values.lock().unwrap().as_slice(), [11.0]);
+        assert_eq!(
+            state
+                .get_general_parameter_value(dependent_index, ParameterReturnValue::Before,)
+                .unwrap(),
+            22.0
+        );
+    }
+
+    #[test]
+    fn general_after_dependencies_respect_the_requested_phase() {
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let observed_before = Arc::new(Mutex::new(Vec::new()));
+        let observed_after = Arc::new(Mutex::new(Vec::new()));
+        let mut collection = ParameterCollection::default();
+
+        // This source produces 11.0 before and 22.0 after.
+        let source_index =
+            collection.push_general_f64(GeneralParameterEntry::both(PhaseTestParameter::new("source", events)));
+
+        let dependent_on_before_index = general_index(collection.push_general_f64(GeneralParameterEntry::after(
+            GeneralDependencyTestParameter::new(
+                "dependent-on-before",
+                source_index.into_metric_f64_before(),
+                observed_before.clone(),
+            ),
+        )));
+
+        let dependent_on_after_index = general_index(collection.push_general_f64(GeneralParameterEntry::after(
+            GeneralDependencyTestParameter::new(
+                "dependent-on-after",
+                source_index.into_metric_f64_after(),
+                observed_after.clone(),
+            ),
+        )));
+
+        let domain = default_domain();
+        let timesteps = domain.time().timesteps();
+        let timestep = &timesteps[0];
+        let scenario_index = ScenarioIndex::default();
+        let network = Network::default();
+
+        let mut state = StateBuilder::new(Vec::new(), 0).with_parameters(&collection).build();
+
+        let mut internal_states = ParameterStates::from_collection(&collection, timesteps, &scenario_index).unwrap();
+
+        collection
+            .before_general(
+                timestep,
+                &scenario_index,
+                &network,
+                &mut state,
+                &mut internal_states,
+                None,
+            )
+            .unwrap();
+
+        collection
+            .after_general(
+                timestep,
+                &scenario_index,
+                &network,
+                &mut state,
+                &mut internal_states,
+                None,
+            )
+            .unwrap();
+
+        assert_eq!(observed_before.lock().unwrap().as_slice(), [11.0]);
+        assert_eq!(observed_after.lock().unwrap().as_slice(), [22.0]);
+
+        assert_eq!(
+            state
+                .get_general_parameter_value(dependent_on_before_index, ParameterReturnValue::After,)
+                .unwrap(),
+            22.0
+        );
+
+        assert_eq!(
+            state
+                .get_general_parameter_value(dependent_on_after_index, ParameterReturnValue::After,)
+                .unwrap(),
+            44.0
+        );
     }
 }

--- a/pywr-core/src/parameters/multi_threshold.rs
+++ b/pywr-core/src/parameters/multi_threshold.rs
@@ -2,8 +2,9 @@ use crate::metric::{MetricF64, UnresolvedMetricF64};
 use crate::network::ResolutionMaps;
 use crate::parameters::errors::{GeneralCalculationError, ParameterSetupError};
 use crate::parameters::{
-    BuiltParameter, GeneralParameter, GeneralParameterContext, MaybeBuiltParameter, Parameter, ParameterBuildError,
-    ParameterBuilder, ParameterMeta, ParameterName, ParameterState, Predicate, downcast_internal_state_mut,
+    BuiltParameter, GeneralBeforeParameter, GeneralParameter, GeneralParameterContext, GeneralParameterEntry,
+    MaybeBuiltParameter, Parameter, ParameterBuildError, ParameterBuilder, ParameterMeta, ParameterName,
+    ParameterState, Predicate, downcast_internal_state_mut,
 };
 use crate::scenario::ScenarioIndex;
 use crate::timestep::Timestep;
@@ -34,12 +35,21 @@ impl Parameter for MultiThresholdParameter {
     }
 }
 
-impl GeneralParameter<u64> for MultiThresholdParameter {
+impl GeneralParameter for MultiThresholdParameter {
+    fn as_parameter(&self) -> &dyn Parameter
+    where
+        Self: Sized,
+    {
+        self
+    }
+}
+
+impl GeneralBeforeParameter<u64> for MultiThresholdParameter {
     fn before(
         &self,
         ctx: GeneralParameterContext<'_>,
         internal_state: &mut Option<Box<dyn ParameterState>>,
-    ) -> Result<Option<u64>, GeneralCalculationError> {
+    ) -> Result<u64, GeneralCalculationError> {
         // Downcast the internal state to the correct type
         let previous_max = downcast_internal_state_mut::<u64>(internal_state);
 
@@ -62,18 +72,11 @@ impl GeneralParameter<u64> for MultiThresholdParameter {
             if position > *previous_max {
                 *previous_max = position;
             } else {
-                return Ok(Some(*previous_max));
+                return Ok(*previous_max);
             }
         }
 
-        Ok(Some(position))
-    }
-
-    fn as_parameter(&self) -> &dyn Parameter
-    where
-        Self: Sized,
-    {
-        self
+        Ok(position)
     }
 }
 
@@ -130,8 +133,8 @@ impl ParameterBuilder<u64> for MultiThresholdParameterBuilder {
             ratchet: self.ratchet,
         };
 
-        let bp = BuiltParameter::General(Box::new(p));
-        Ok(MaybeBuiltParameter::Built(bp))
+        let bp = BuiltParameter::General(GeneralParameterEntry::before(p));
+        Ok(bp.into())
     }
 }
 

--- a/pywr-core/src/parameters/multi_threshold.rs
+++ b/pywr-core/src/parameters/multi_threshold.rs
@@ -1,12 +1,11 @@
 use crate::metric::{MetricF64, UnresolvedMetricF64};
-use crate::network::{Network, ResolutionMaps};
+use crate::network::ResolutionMaps;
 use crate::parameters::errors::{GeneralCalculationError, ParameterSetupError};
 use crate::parameters::{
-    BuiltParameter, GeneralParameter, MaybeBuiltParameter, Parameter, ParameterBuildError, ParameterBuilder,
-    ParameterMeta, ParameterName, ParameterState, Predicate, downcast_internal_state_mut,
+    BuiltParameter, GeneralParameter, GeneralParameterContext, MaybeBuiltParameter, Parameter, ParameterBuildError,
+    ParameterBuilder, ParameterMeta, ParameterName, ParameterState, Predicate, downcast_internal_state_mut,
 };
 use crate::scenario::ScenarioIndex;
-use crate::state::State;
 use crate::timestep::Timestep;
 use crate::{resolve_metric_f64, resolve_metric_f64_vec};
 
@@ -38,21 +37,18 @@ impl Parameter for MultiThresholdParameter {
 impl GeneralParameter<u64> for MultiThresholdParameter {
     fn before(
         &self,
-        _timestep: &Timestep,
-        _scenario_index: &ScenarioIndex,
-        model: &Network,
-        state: &State,
+        ctx: GeneralParameterContext<'_>,
         internal_state: &mut Option<Box<dyn ParameterState>>,
     ) -> Result<Option<u64>, GeneralCalculationError> {
         // Downcast the internal state to the correct type
         let previous_max = downcast_internal_state_mut::<u64>(internal_state);
 
-        let value = self.metric.get_value(model, state)?;
+        let value = self.metric.get_value(ctx.network, ctx.state)?;
 
         // Determine the first threshold that is met
         let mut position: u64 = 0;
         for threshold in &self.thresholds {
-            let t = threshold.get_value(model, state)?;
+            let t = threshold.get_value(ctx.network, ctx.state)?;
             let active = self.predicate.apply(value, t);
 
             if active {

--- a/pywr-core/src/parameters/muskingum.rs
+++ b/pywr-core/src/parameters/muskingum.rs
@@ -1,13 +1,11 @@
 use crate::metric::{MetricF64, UnresolvedMetricF64};
-use crate::network::{Network, ResolutionMaps};
+use crate::network::ResolutionMaps;
 use crate::parameters::{
-    BuiltParameter, GeneralCalculationError, GeneralParameter, MaybeBuiltParameter, Parameter, ParameterBuildError,
-    ParameterBuilder, ParameterMeta, ParameterName, ParameterState,
+    BuiltParameter, GeneralCalculationError, GeneralParameter, GeneralParameterContext, MaybeBuiltParameter, Parameter,
+    ParameterBuildError, ParameterBuilder, ParameterMeta, ParameterName, ParameterState,
 };
 use crate::resolve_metric_f64;
-use crate::scenario::ScenarioIndex;
-use crate::state::{MultiValue, State};
-use crate::timestep::Timestep;
+use crate::state::MultiValue;
 use std::collections::HashMap;
 
 #[derive(Debug)]
@@ -55,17 +53,14 @@ impl Parameter for MuskingumParameter {
 impl GeneralParameter<MultiValue> for MuskingumParameter {
     fn before(
         &self,
-        timestep: &Timestep,
-        _scenario_index: &ScenarioIndex,
-        model: &Network,
-        state: &State,
+        ctx: GeneralParameterContext<'_>,
         _internal_state: &mut Option<Box<dyn ParameterState>>,
     ) -> Result<Option<MultiValue>, GeneralCalculationError> {
-        let weight = self.weight.get_value(model, state)?;
-        let travel_time = self.travel_time.get_value(model, state)?;
+        let weight = self.weight.get_value(ctx.network, ctx.state)?;
+        let travel_time = self.travel_time.get_value(ctx.network, ctx.state)?;
 
         // The inflow and outflow metrics from the previous time-step
-        let (inflow, outflow) = if timestep.is_first() {
+        let (inflow, outflow) = if ctx.timestep.is_first() {
             match &self.initial_condition {
                 MuskingumInitialCondition::SteadyState => {
                     // For steady-state the inflow and outflow are equal
@@ -81,8 +76,8 @@ impl GeneralParameter<MultiValue> for MuskingumParameter {
             }
         } else {
             (
-                self.inflow.get_value(model, state)?,
-                self.outflow.get_value(model, state)?,
+                self.inflow.get_value(ctx.network, ctx.state)?,
+                self.outflow.get_value(ctx.network, ctx.state)?,
             )
         };
 

--- a/pywr-core/src/parameters/muskingum.rs
+++ b/pywr-core/src/parameters/muskingum.rs
@@ -1,8 +1,9 @@
 use crate::metric::{MetricF64, UnresolvedMetricF64};
 use crate::network::ResolutionMaps;
 use crate::parameters::{
-    BuiltParameter, GeneralCalculationError, GeneralParameter, GeneralParameterContext, MaybeBuiltParameter, Parameter,
-    ParameterBuildError, ParameterBuilder, ParameterMeta, ParameterName, ParameterState,
+    BuiltParameter, GeneralBeforeParameter, GeneralCalculationError, GeneralParameter, GeneralParameterContext,
+    GeneralParameterEntry, MaybeBuiltParameter, Parameter, ParameterBuildError, ParameterBuilder, ParameterMeta,
+    ParameterName, ParameterState,
 };
 use crate::resolve_metric_f64;
 use crate::state::MultiValue;
@@ -50,12 +51,21 @@ impl Parameter for MuskingumParameter {
     }
 }
 
-impl GeneralParameter<MultiValue> for MuskingumParameter {
+impl GeneralParameter for MuskingumParameter {
+    fn as_parameter(&self) -> &dyn Parameter
+    where
+        Self: Sized,
+    {
+        self
+    }
+}
+
+impl GeneralBeforeParameter<MultiValue> for MuskingumParameter {
     fn before(
         &self,
         ctx: GeneralParameterContext<'_>,
         _internal_state: &mut Option<Box<dyn ParameterState>>,
-    ) -> Result<Option<MultiValue>, GeneralCalculationError> {
+    ) -> Result<MultiValue, GeneralCalculationError> {
         let weight = self.weight.get_value(ctx.network, ctx.state)?;
         let travel_time = self.travel_time.get_value(ctx.network, ctx.state)?;
 
@@ -70,7 +80,7 @@ impl GeneralParameter<MultiValue> for MuskingumParameter {
                     let mut values = HashMap::new();
                     values.insert("inflow_factor".to_string(), -inflow_factor / outflow_factor);
                     values.insert("rhs".to_string(), 0.0);
-                    return Ok(Some(MultiValue::new(values, HashMap::new())));
+                    return Ok(MultiValue::new(values, HashMap::new()));
                 }
                 MuskingumInitialCondition::Specified { inflow, outflow } => (*inflow, *outflow),
             }
@@ -84,14 +94,7 @@ impl GeneralParameter<MultiValue> for MuskingumParameter {
         let mut values = HashMap::new();
         values.insert("inflow_factor".to_string(), -inflow_factor(weight, travel_time));
         values.insert("rhs".to_string(), rhs(inflow, outflow, weight, travel_time));
-        Ok(Some(MultiValue::new(values, HashMap::new())))
-    }
-
-    fn as_parameter(&self) -> &dyn Parameter
-    where
-        Self: Sized,
-    {
-        self
+        Ok(MultiValue::new(values, HashMap::new()))
     }
 }
 
@@ -175,6 +178,6 @@ impl ParameterBuilder<MultiValue> for MuskingumParameterBuilder {
             initial_condition: self.initial_condition,
         };
 
-        Ok(MaybeBuiltParameter::Built(BuiltParameter::General(Box::new(p))))
+        Ok(BuiltParameter::General(GeneralParameterEntry::before(p)).into())
     }
 }

--- a/pywr-core/src/parameters/negative.rs
+++ b/pywr-core/src/parameters/negative.rs
@@ -2,8 +2,9 @@ use crate::metric::{MetricF64, UnresolvedMetricF64};
 use crate::network::ResolutionMaps;
 use crate::parameters::errors::GeneralCalculationError;
 use crate::parameters::{
-    BuiltParameter, GeneralParameter, GeneralParameterContext, MaybeBuiltParameter, Parameter, ParameterBuildError,
-    ParameterBuilder, ParameterMeta, ParameterName, ParameterState,
+    BuiltParameter, GeneralBeforeParameter, GeneralParameter, GeneralParameterContext, GeneralParameterEntry,
+    MaybeBuiltParameter, Parameter, ParameterBuildError, ParameterBuilder, ParameterMeta, ParameterName,
+    ParameterState,
 };
 use crate::resolve_metric_f64;
 
@@ -19,22 +20,24 @@ impl Parameter for NegativeParameter {
     }
 }
 
-impl GeneralParameter<f64> for NegativeParameter {
-    fn before(
-        &self,
-        ctx: GeneralParameterContext<'_>,
-        _internal_state: &mut Option<Box<dyn ParameterState>>,
-    ) -> Result<Option<f64>, GeneralCalculationError> {
-        // Current value
-        let x = self.metric.get_value(ctx.network, ctx.state)?;
-        Ok(Some(-x))
-    }
-
+impl GeneralParameter for NegativeParameter {
     fn as_parameter(&self) -> &dyn Parameter
     where
         Self: Sized,
     {
         self
+    }
+}
+
+impl GeneralBeforeParameter<f64> for NegativeParameter {
+    fn before(
+        &self,
+        ctx: GeneralParameterContext<'_>,
+        _internal_state: &mut Option<Box<dyn ParameterState>>,
+    ) -> Result<f64, GeneralCalculationError> {
+        // Current value
+        let x = self.metric.get_value(ctx.network, ctx.state)?;
+        Ok(-x)
     }
 }
 
@@ -69,6 +72,6 @@ impl ParameterBuilder<f64> for NegativeParameterBuilder {
             metric,
         };
 
-        Ok(MaybeBuiltParameter::Built(BuiltParameter::General(Box::new(p))))
+        Ok(BuiltParameter::General(GeneralParameterEntry::before(p)).into())
     }
 }

--- a/pywr-core/src/parameters/negative.rs
+++ b/pywr-core/src/parameters/negative.rs
@@ -1,14 +1,11 @@
 use crate::metric::{MetricF64, UnresolvedMetricF64};
-use crate::network::{Network, ResolutionMaps};
+use crate::network::ResolutionMaps;
 use crate::parameters::errors::GeneralCalculationError;
 use crate::parameters::{
-    BuiltParameter, GeneralParameter, MaybeBuiltParameter, Parameter, ParameterBuildError, ParameterBuilder,
-    ParameterMeta, ParameterName, ParameterState,
+    BuiltParameter, GeneralParameter, GeneralParameterContext, MaybeBuiltParameter, Parameter, ParameterBuildError,
+    ParameterBuilder, ParameterMeta, ParameterName, ParameterState,
 };
 use crate::resolve_metric_f64;
-use crate::scenario::ScenarioIndex;
-use crate::state::State;
-use crate::timestep::Timestep;
 
 #[derive(Debug)]
 pub struct NegativeParameter {
@@ -25,14 +22,11 @@ impl Parameter for NegativeParameter {
 impl GeneralParameter<f64> for NegativeParameter {
     fn before(
         &self,
-        _timestep: &Timestep,
-        _scenario_index: &ScenarioIndex,
-        model: &Network,
-        state: &State,
+        ctx: GeneralParameterContext<'_>,
         _internal_state: &mut Option<Box<dyn ParameterState>>,
     ) -> Result<Option<f64>, GeneralCalculationError> {
         // Current value
-        let x = self.metric.get_value(model, state)?;
+        let x = self.metric.get_value(ctx.network, ctx.state)?;
         Ok(Some(-x))
     }
 

--- a/pywr-core/src/parameters/negativemax.rs
+++ b/pywr-core/src/parameters/negativemax.rs
@@ -2,8 +2,9 @@ use crate::metric::{MetricF64, UnresolvedMetricF64};
 use crate::network::ResolutionMaps;
 use crate::parameters::errors::GeneralCalculationError;
 use crate::parameters::{
-    BuiltParameter, GeneralParameter, GeneralParameterContext, MaybeBuiltParameter, Parameter, ParameterBuildError,
-    ParameterBuilder, ParameterMeta, ParameterName, ParameterState,
+    BuiltParameter, GeneralBeforeParameter, GeneralParameter, GeneralParameterContext, GeneralParameterEntry,
+    MaybeBuiltParameter, Parameter, ParameterBuildError, ParameterBuilder, ParameterMeta, ParameterName,
+    ParameterState,
 };
 use crate::resolve_metric_f64;
 
@@ -19,21 +20,23 @@ impl Parameter for NegativeMaxParameter {
         &self.meta
     }
 }
-impl GeneralParameter<f64> for NegativeMaxParameter {
-    fn before(
-        &self,
-        ctx: GeneralParameterContext<'_>,
-        _internal_state: &mut Option<Box<dyn ParameterState>>,
-    ) -> Result<Option<f64>, GeneralCalculationError> {
-        let x = -self.metric.get_value(ctx.network, ctx.state)?;
-        Ok(Some(x.max(self.threshold)))
-    }
-
+impl GeneralParameter for NegativeMaxParameter {
     fn as_parameter(&self) -> &dyn Parameter
     where
         Self: Sized,
     {
         self
+    }
+}
+
+impl GeneralBeforeParameter<f64> for NegativeMaxParameter {
+    fn before(
+        &self,
+        ctx: GeneralParameterContext<'_>,
+        _internal_state: &mut Option<Box<dyn ParameterState>>,
+    ) -> Result<f64, GeneralCalculationError> {
+        let x = -self.metric.get_value(ctx.network, ctx.state)?;
+        Ok(x.max(self.threshold))
     }
 }
 
@@ -71,6 +74,6 @@ impl ParameterBuilder<f64> for NegativeMaxParameterBuilder {
             threshold: self.threshold,
         };
 
-        Ok(MaybeBuiltParameter::Built(BuiltParameter::General(Box::new(p))))
+        Ok(BuiltParameter::General(GeneralParameterEntry::before(p)).into())
     }
 }

--- a/pywr-core/src/parameters/negativemax.rs
+++ b/pywr-core/src/parameters/negativemax.rs
@@ -1,14 +1,11 @@
 use crate::metric::{MetricF64, UnresolvedMetricF64};
-use crate::network::{Network, ResolutionMaps};
+use crate::network::ResolutionMaps;
 use crate::parameters::errors::GeneralCalculationError;
 use crate::parameters::{
-    BuiltParameter, GeneralParameter, MaybeBuiltParameter, Parameter, ParameterBuildError, ParameterBuilder,
-    ParameterMeta, ParameterName, ParameterState,
+    BuiltParameter, GeneralParameter, GeneralParameterContext, MaybeBuiltParameter, Parameter, ParameterBuildError,
+    ParameterBuilder, ParameterMeta, ParameterName, ParameterState,
 };
 use crate::resolve_metric_f64;
-use crate::scenario::ScenarioIndex;
-use crate::state::State;
-use crate::timestep::Timestep;
 
 #[derive(Debug)]
 pub struct NegativeMaxParameter {
@@ -25,13 +22,10 @@ impl Parameter for NegativeMaxParameter {
 impl GeneralParameter<f64> for NegativeMaxParameter {
     fn before(
         &self,
-        _timestep: &Timestep,
-        _scenario_index: &ScenarioIndex,
-        network: &Network,
-        state: &State,
+        ctx: GeneralParameterContext<'_>,
         _internal_state: &mut Option<Box<dyn ParameterState>>,
     ) -> Result<Option<f64>, GeneralCalculationError> {
-        let x = -self.metric.get_value(network, state)?;
+        let x = -self.metric.get_value(ctx.network, ctx.state)?;
         Ok(Some(x.max(self.threshold)))
     }
 

--- a/pywr-core/src/parameters/negativemin.rs
+++ b/pywr-core/src/parameters/negativemin.rs
@@ -2,8 +2,9 @@ use crate::metric::{MetricF64, UnresolvedMetricF64};
 use crate::network::ResolutionMaps;
 use crate::parameters::errors::GeneralCalculationError;
 use crate::parameters::{
-    BuiltParameter, GeneralParameter, GeneralParameterContext, MaybeBuiltParameter, Parameter, ParameterBuildError,
-    ParameterBuilder, ParameterMeta, ParameterName, ParameterState,
+    BuiltParameter, GeneralBeforeParameter, GeneralParameter, GeneralParameterContext, GeneralParameterEntry,
+    MaybeBuiltParameter, Parameter, ParameterBuildError, ParameterBuilder, ParameterMeta, ParameterName,
+    ParameterState,
 };
 use crate::resolve_metric_f64;
 
@@ -19,21 +20,23 @@ impl Parameter for NegativeMinParameter {
         &self.meta
     }
 }
-impl GeneralParameter<f64> for NegativeMinParameter {
-    fn before(
-        &self,
-        ctx: GeneralParameterContext<'_>,
-        _internal_state: &mut Option<Box<dyn ParameterState>>,
-    ) -> Result<Option<f64>, GeneralCalculationError> {
-        let x = -self.metric.get_value(ctx.network, ctx.state)?;
-        Ok(Some(x.min(self.threshold)))
-    }
-
+impl GeneralParameter for NegativeMinParameter {
     fn as_parameter(&self) -> &dyn Parameter
     where
         Self: Sized,
     {
         self
+    }
+}
+
+impl GeneralBeforeParameter<f64> for NegativeMinParameter {
+    fn before(
+        &self,
+        ctx: GeneralParameterContext<'_>,
+        _internal_state: &mut Option<Box<dyn ParameterState>>,
+    ) -> Result<f64, GeneralCalculationError> {
+        let x = -self.metric.get_value(ctx.network, ctx.state)?;
+        Ok(x.min(self.threshold))
     }
 }
 
@@ -71,6 +74,6 @@ impl ParameterBuilder<f64> for NegativeMinParameterBuilder {
             threshold: self.threshold,
         };
 
-        Ok(MaybeBuiltParameter::Built(BuiltParameter::General(Box::new(p))))
+        Ok(BuiltParameter::General(GeneralParameterEntry::before(p)).into())
     }
 }

--- a/pywr-core/src/parameters/negativemin.rs
+++ b/pywr-core/src/parameters/negativemin.rs
@@ -1,14 +1,11 @@
 use crate::metric::{MetricF64, UnresolvedMetricF64};
-use crate::network::{Network, ResolutionMaps};
+use crate::network::ResolutionMaps;
 use crate::parameters::errors::GeneralCalculationError;
 use crate::parameters::{
-    BuiltParameter, GeneralParameter, MaybeBuiltParameter, Parameter, ParameterBuildError, ParameterBuilder,
-    ParameterMeta, ParameterName, ParameterState,
+    BuiltParameter, GeneralParameter, GeneralParameterContext, MaybeBuiltParameter, Parameter, ParameterBuildError,
+    ParameterBuilder, ParameterMeta, ParameterName, ParameterState,
 };
 use crate::resolve_metric_f64;
-use crate::scenario::ScenarioIndex;
-use crate::state::State;
-use crate::timestep::Timestep;
 
 #[derive(Debug)]
 pub struct NegativeMinParameter {
@@ -25,13 +22,10 @@ impl Parameter for NegativeMinParameter {
 impl GeneralParameter<f64> for NegativeMinParameter {
     fn before(
         &self,
-        _timestep: &Timestep,
-        _scenario_index: &ScenarioIndex,
-        network: &Network,
-        state: &State,
+        ctx: GeneralParameterContext<'_>,
         _internal_state: &mut Option<Box<dyn ParameterState>>,
     ) -> Result<Option<f64>, GeneralCalculationError> {
-        let x = -self.metric.get_value(network, state)?;
+        let x = -self.metric.get_value(ctx.network, ctx.state)?;
         Ok(Some(x.min(self.threshold)))
     }
 

--- a/pywr-core/src/parameters/offset.rs
+++ b/pywr-core/src/parameters/offset.rs
@@ -2,10 +2,10 @@ use crate::metric::{MetricF64, UnresolvedMetricF64};
 use crate::network::ResolutionMaps;
 use crate::parameters::errors::GeneralCalculationError;
 use crate::parameters::{
-    ActivationFunction, BuiltParameter, GeneralParameter, GeneralParameterContext, MaybeBuiltParameter, Parameter,
-    ParameterBuildError, ParameterBuilder, ParameterMeta, ParameterName, ParameterState, VariableConfig,
-    VariableParameter, VariableParameterError, downcast_internal_state_mut, downcast_internal_state_ref,
-    downcast_variable_config_ref,
+    ActivationFunction, BuiltParameter, GeneralBeforeParameter, GeneralParameter, GeneralParameterContext,
+    GeneralParameterEntry, MaybeBuiltParameter, Parameter, ParameterBuildError, ParameterBuilder, ParameterMeta,
+    ParameterName, ParameterState, VariableConfig, VariableParameter, VariableParameterError,
+    downcast_internal_state_mut, downcast_internal_state_ref, downcast_variable_config_ref,
 };
 use crate::resolve_metric_f64;
 
@@ -44,18 +44,7 @@ impl Parameter for OffsetParameter {
         Some(self)
     }
 }
-impl GeneralParameter<f64> for OffsetParameter {
-    fn before(
-        &self,
-        ctx: GeneralParameterContext<'_>,
-        internal_state: &mut Option<Box<dyn ParameterState>>,
-    ) -> Result<Option<f64>, GeneralCalculationError> {
-        let offset = self.offset(internal_state);
-        // Current value
-        let x = self.metric.get_value(ctx.network, ctx.state)?;
-        Ok(Some(x + offset))
-    }
-
+impl GeneralParameter for OffsetParameter {
     fn as_parameter(&self) -> &dyn Parameter
     where
         Self: Sized,
@@ -63,7 +52,18 @@ impl GeneralParameter<f64> for OffsetParameter {
         self
     }
 }
-
+impl GeneralBeforeParameter<f64> for OffsetParameter {
+    fn before(
+        &self,
+        ctx: GeneralParameterContext<'_>,
+        internal_state: &mut Option<Box<dyn ParameterState>>,
+    ) -> Result<f64, GeneralCalculationError> {
+        let offset = self.offset(internal_state);
+        // Current value
+        let x = self.metric.get_value(ctx.network, ctx.state)?;
+        Ok(x + offset)
+    }
+}
 impl VariableParameter<f64> for OffsetParameter {
     fn meta(&self) -> &ParameterMeta {
         &self.meta
@@ -144,6 +144,6 @@ impl ParameterBuilder<f64> for OffsetParameterBuilder {
             offset: self.offset,
         };
 
-        Ok(MaybeBuiltParameter::Built(BuiltParameter::General(Box::new(p))))
+        Ok(BuiltParameter::General(GeneralParameterEntry::before(p)).into())
     }
 }

--- a/pywr-core/src/parameters/offset.rs
+++ b/pywr-core/src/parameters/offset.rs
@@ -1,15 +1,13 @@
 use crate::metric::{MetricF64, UnresolvedMetricF64};
-use crate::network::{Network, ResolutionMaps};
+use crate::network::ResolutionMaps;
 use crate::parameters::errors::GeneralCalculationError;
 use crate::parameters::{
-    ActivationFunction, BuiltParameter, GeneralParameter, MaybeBuiltParameter, Parameter, ParameterBuildError,
-    ParameterBuilder, ParameterMeta, ParameterName, ParameterState, VariableConfig, VariableParameter,
-    VariableParameterError, downcast_internal_state_mut, downcast_internal_state_ref, downcast_variable_config_ref,
+    ActivationFunction, BuiltParameter, GeneralParameter, GeneralParameterContext, MaybeBuiltParameter, Parameter,
+    ParameterBuildError, ParameterBuilder, ParameterMeta, ParameterName, ParameterState, VariableConfig,
+    VariableParameter, VariableParameterError, downcast_internal_state_mut, downcast_internal_state_ref,
+    downcast_variable_config_ref,
 };
 use crate::resolve_metric_f64;
-use crate::scenario::ScenarioIndex;
-use crate::state::State;
-use crate::timestep::Timestep;
 
 #[derive(Debug)]
 pub struct OffsetParameter {
@@ -49,15 +47,12 @@ impl Parameter for OffsetParameter {
 impl GeneralParameter<f64> for OffsetParameter {
     fn before(
         &self,
-        _timestep: &Timestep,
-        _scenario_index: &ScenarioIndex,
-        model: &Network,
-        state: &State,
+        ctx: GeneralParameterContext<'_>,
         internal_state: &mut Option<Box<dyn ParameterState>>,
     ) -> Result<Option<f64>, GeneralCalculationError> {
         let offset = self.offset(internal_state);
         // Current value
-        let x = self.metric.get_value(model, state)?;
+        let x = self.metric.get_value(ctx.network, ctx.state)?;
         Ok(Some(x + offset))
     }
 

--- a/pywr-core/src/parameters/polynomial.rs
+++ b/pywr-core/src/parameters/polynomial.rs
@@ -2,8 +2,9 @@ use crate::metric::{MetricF64, UnresolvedMetricF64};
 use crate::network::ResolutionMaps;
 use crate::parameters::errors::GeneralCalculationError;
 use crate::parameters::{
-    BuiltParameter, GeneralParameter, GeneralParameterContext, MaybeBuiltParameter, Parameter, ParameterBuildError,
-    ParameterBuilder, ParameterMeta, ParameterName, ParameterState,
+    BuiltParameter, GeneralBeforeParameter, GeneralParameter, GeneralParameterContext, GeneralParameterEntry,
+    MaybeBuiltParameter, Parameter, ParameterBuildError, ParameterBuilder, ParameterMeta, ParameterName,
+    ParameterState,
 };
 use crate::resolve_metric_f64;
 
@@ -22,12 +23,21 @@ impl Parameter for Polynomial1DParameter {
     }
 }
 
-impl GeneralParameter<f64> for Polynomial1DParameter {
+impl GeneralParameter for Polynomial1DParameter {
+    fn as_parameter(&self) -> &dyn Parameter
+    where
+        Self: Sized,
+    {
+        self
+    }
+}
+
+impl GeneralBeforeParameter<f64> for Polynomial1DParameter {
     fn before(
         &self,
         ctx: GeneralParameterContext<'_>,
         _internal_state: &mut Option<Box<dyn ParameterState>>,
-    ) -> Result<Option<f64>, GeneralCalculationError> {
+    ) -> Result<f64, GeneralCalculationError> {
         // Current value
         let x = self.metric.get_value(ctx.network, ctx.state)?;
         let x = x * self.scale + self.offset;
@@ -37,14 +47,7 @@ impl GeneralParameter<f64> for Polynomial1DParameter {
             .iter()
             .enumerate()
             .fold(0.0, |y, (i, c)| y + c * x.powi(i as i32));
-        Ok(Some(y))
-    }
-
-    fn as_parameter(&self) -> &dyn Parameter
-    where
-        Self: Sized,
-    {
-        self
+        Ok(y)
     }
 }
 
@@ -98,6 +101,6 @@ impl ParameterBuilder<f64> for Polynomial1DParameterBuilder {
             offset: self.offset,
         };
 
-        Ok(MaybeBuiltParameter::Built(BuiltParameter::General(Box::new(p))))
+        Ok(BuiltParameter::General(GeneralParameterEntry::before(p)).into())
     }
 }

--- a/pywr-core/src/parameters/polynomial.rs
+++ b/pywr-core/src/parameters/polynomial.rs
@@ -1,14 +1,11 @@
 use crate::metric::{MetricF64, UnresolvedMetricF64};
-use crate::network::{Network, ResolutionMaps};
+use crate::network::ResolutionMaps;
 use crate::parameters::errors::GeneralCalculationError;
 use crate::parameters::{
-    BuiltParameter, GeneralParameter, MaybeBuiltParameter, Parameter, ParameterBuildError, ParameterBuilder,
-    ParameterMeta, ParameterName, ParameterState,
+    BuiltParameter, GeneralParameter, GeneralParameterContext, MaybeBuiltParameter, Parameter, ParameterBuildError,
+    ParameterBuilder, ParameterMeta, ParameterName, ParameterState,
 };
 use crate::resolve_metric_f64;
-use crate::scenario::ScenarioIndex;
-use crate::state::State;
-use crate::timestep::Timestep;
 
 #[derive(Debug)]
 pub struct Polynomial1DParameter {
@@ -28,14 +25,11 @@ impl Parameter for Polynomial1DParameter {
 impl GeneralParameter<f64> for Polynomial1DParameter {
     fn before(
         &self,
-        _timestep: &Timestep,
-        _scenario_index: &ScenarioIndex,
-        model: &Network,
-        state: &State,
+        ctx: GeneralParameterContext<'_>,
         _internal_state: &mut Option<Box<dyn ParameterState>>,
     ) -> Result<Option<f64>, GeneralCalculationError> {
         // Current value
-        let x = self.metric.get_value(model, state)?;
+        let x = self.metric.get_value(ctx.network, ctx.state)?;
         let x = x * self.scale + self.offset;
         // Calculate the polynomial value
         let y = self

--- a/pywr-core/src/parameters/profiles/daily.rs
+++ b/pywr-core/src/parameters/profiles/daily.rs
@@ -2,11 +2,8 @@ use crate::network::ResolutionMaps;
 use crate::parameters::errors::SimpleCalculationError;
 use crate::parameters::{
     BuiltParameter, MaybeBuiltParameter, Parameter, ParameterBuildError, ParameterBuilder, ParameterMeta,
-    ParameterName, ParameterState, SimpleParameter,
+    ParameterName, ParameterState, SimpleParameter, SimpleParameterContext,
 };
-use crate::scenario::ScenarioIndex;
-use crate::state::SimpleParameterValues;
-use crate::timestep::Timestep;
 
 #[derive(Debug)]
 pub struct DailyProfileParameter {
@@ -23,12 +20,10 @@ impl Parameter for DailyProfileParameter {
 impl SimpleParameter<f64> for DailyProfileParameter {
     fn before(
         &self,
-        timestep: &Timestep,
-        _scenario_index: &ScenarioIndex,
-        _values: &SimpleParameterValues,
+        ctx: SimpleParameterContext<'_>,
         _internal_state: &mut Option<Box<dyn ParameterState>>,
     ) -> Result<Option<f64>, SimpleCalculationError> {
-        Ok(Some(self.values[timestep.day_of_year_index()]))
+        Ok(Some(self.values[ctx.timestep.day_of_year_index()]))
     }
 
     fn as_parameter(&self) -> &dyn Parameter

--- a/pywr-core/src/parameters/profiles/daily.rs
+++ b/pywr-core/src/parameters/profiles/daily.rs
@@ -2,8 +2,7 @@ use crate::network::ResolutionMaps;
 use crate::parameters::errors::SimpleCalculationError;
 use crate::parameters::{
     BuiltParameter, MaybeBuiltParameter, Parameter, ParameterBuildError, ParameterBuilder, ParameterMeta,
-    ParameterName, ParameterState, SimpleBeforeParameter, SimpleParameter, SimpleParameterContext,
-    SimpleParameterEntry,
+    ParameterName, ParameterState, SimpleParameter, SimpleParameterContext,
 };
 
 #[derive(Debug)]
@@ -18,22 +17,19 @@ impl Parameter for DailyProfileParameter {
     }
 }
 
-impl SimpleParameter for DailyProfileParameter {
-    fn as_parameter(&self) -> &dyn Parameter
-    where
-        Self: Sized,
-    {
-        self
-    }
-}
-
-impl SimpleBeforeParameter<f64> for DailyProfileParameter {
-    fn before(
+impl SimpleParameter<f64> for DailyProfileParameter {
+    fn compute(
         &self,
         ctx: SimpleParameterContext<'_>,
         _internal_state: &mut Option<Box<dyn ParameterState>>,
     ) -> Result<f64, SimpleCalculationError> {
         Ok(self.values[ctx.timestep.day_of_year_index()])
+    }
+    fn as_parameter(&self) -> &dyn Parameter
+    where
+        Self: Sized,
+    {
+        self
     }
 }
 
@@ -66,6 +62,6 @@ impl ParameterBuilder<f64> for DailyProfileParameterBuilder {
             values: self.values,
         };
 
-        Ok(BuiltParameter::Simple(SimpleParameterEntry::before(p)).into())
+        Ok(BuiltParameter::Simple(Box::new(p)).into())
     }
 }

--- a/pywr-core/src/parameters/profiles/daily.rs
+++ b/pywr-core/src/parameters/profiles/daily.rs
@@ -2,7 +2,8 @@ use crate::network::ResolutionMaps;
 use crate::parameters::errors::SimpleCalculationError;
 use crate::parameters::{
     BuiltParameter, MaybeBuiltParameter, Parameter, ParameterBuildError, ParameterBuilder, ParameterMeta,
-    ParameterName, ParameterState, SimpleParameter, SimpleParameterContext,
+    ParameterName, ParameterState, SimpleBeforeParameter, SimpleParameter, SimpleParameterContext,
+    SimpleParameterEntry,
 };
 
 #[derive(Debug)]
@@ -17,20 +18,22 @@ impl Parameter for DailyProfileParameter {
     }
 }
 
-impl SimpleParameter<f64> for DailyProfileParameter {
-    fn before(
-        &self,
-        ctx: SimpleParameterContext<'_>,
-        _internal_state: &mut Option<Box<dyn ParameterState>>,
-    ) -> Result<Option<f64>, SimpleCalculationError> {
-        Ok(Some(self.values[ctx.timestep.day_of_year_index()]))
-    }
-
+impl SimpleParameter for DailyProfileParameter {
     fn as_parameter(&self) -> &dyn Parameter
     where
         Self: Sized,
     {
         self
+    }
+}
+
+impl SimpleBeforeParameter<f64> for DailyProfileParameter {
+    fn before(
+        &self,
+        ctx: SimpleParameterContext<'_>,
+        _internal_state: &mut Option<Box<dyn ParameterState>>,
+    ) -> Result<f64, SimpleCalculationError> {
+        Ok(self.values[ctx.timestep.day_of_year_index()])
     }
 }
 
@@ -63,6 +66,6 @@ impl ParameterBuilder<f64> for DailyProfileParameterBuilder {
             values: self.values,
         };
 
-        Ok(MaybeBuiltParameter::Built(BuiltParameter::Simple(Box::new(p))))
+        Ok(BuiltParameter::Simple(SimpleParameterEntry::before(p)).into())
     }
 }

--- a/pywr-core/src/parameters/profiles/diurnal.rs
+++ b/pywr-core/src/parameters/profiles/diurnal.rs
@@ -2,8 +2,7 @@ use crate::network::ResolutionMaps;
 use crate::parameters::errors::SimpleCalculationError;
 use crate::parameters::{
     BuiltParameter, MaybeBuiltParameter, Parameter, ParameterBuildError, ParameterBuilder, ParameterMeta,
-    ParameterName, ParameterState, SimpleBeforeParameter, SimpleParameter, SimpleParameterContext,
-    SimpleParameterEntry,
+    ParameterName, ParameterState, SimpleParameter, SimpleParameterContext,
 };
 use chrono::Timelike;
 
@@ -22,22 +21,19 @@ impl Parameter for DiurnalProfileParameter {
     }
 }
 
-impl SimpleParameter for DiurnalProfileParameter {
-    fn as_parameter(&self) -> &dyn Parameter
-    where
-        Self: Sized,
-    {
-        self
-    }
-}
-
-impl SimpleBeforeParameter<f64> for DiurnalProfileParameter {
-    fn before(
+impl SimpleParameter<f64> for DiurnalProfileParameter {
+    fn compute(
         &self,
         ctx: SimpleParameterContext<'_>,
         _internal_state: &mut Option<Box<dyn ParameterState>>,
     ) -> Result<f64, SimpleCalculationError> {
         Ok(self.values[ctx.timestep.date.time().hour() as usize])
+    }
+    fn as_parameter(&self) -> &dyn Parameter
+    where
+        Self: Sized,
+    {
+        self
     }
 }
 
@@ -70,6 +66,6 @@ impl ParameterBuilder<f64> for DiurnalProfileParameterBuilder {
             values: self.values,
         };
 
-        Ok(BuiltParameter::Simple(SimpleParameterEntry::before(p)).into())
+        Ok(BuiltParameter::Simple(Box::new(p)).into())
     }
 }

--- a/pywr-core/src/parameters/profiles/diurnal.rs
+++ b/pywr-core/src/parameters/profiles/diurnal.rs
@@ -2,7 +2,8 @@ use crate::network::ResolutionMaps;
 use crate::parameters::errors::SimpleCalculationError;
 use crate::parameters::{
     BuiltParameter, MaybeBuiltParameter, Parameter, ParameterBuildError, ParameterBuilder, ParameterMeta,
-    ParameterName, ParameterState, SimpleParameter, SimpleParameterContext,
+    ParameterName, ParameterState, SimpleBeforeParameter, SimpleParameter, SimpleParameterContext,
+    SimpleParameterEntry,
 };
 use chrono::Timelike;
 
@@ -21,20 +22,22 @@ impl Parameter for DiurnalProfileParameter {
     }
 }
 
-impl SimpleParameter<f64> for DiurnalProfileParameter {
-    fn before(
-        &self,
-        ctx: SimpleParameterContext<'_>,
-        _internal_state: &mut Option<Box<dyn ParameterState>>,
-    ) -> Result<Option<f64>, SimpleCalculationError> {
-        Ok(Some(self.values[ctx.timestep.date.time().hour() as usize]))
-    }
-
+impl SimpleParameter for DiurnalProfileParameter {
     fn as_parameter(&self) -> &dyn Parameter
     where
         Self: Sized,
     {
         self
+    }
+}
+
+impl SimpleBeforeParameter<f64> for DiurnalProfileParameter {
+    fn before(
+        &self,
+        ctx: SimpleParameterContext<'_>,
+        _internal_state: &mut Option<Box<dyn ParameterState>>,
+    ) -> Result<f64, SimpleCalculationError> {
+        Ok(self.values[ctx.timestep.date.time().hour() as usize])
     }
 }
 
@@ -67,6 +70,6 @@ impl ParameterBuilder<f64> for DiurnalProfileParameterBuilder {
             values: self.values,
         };
 
-        Ok(MaybeBuiltParameter::Built(BuiltParameter::Simple(Box::new(p))))
+        Ok(BuiltParameter::Simple(SimpleParameterEntry::before(p)).into())
     }
 }

--- a/pywr-core/src/parameters/profiles/diurnal.rs
+++ b/pywr-core/src/parameters/profiles/diurnal.rs
@@ -2,11 +2,8 @@ use crate::network::ResolutionMaps;
 use crate::parameters::errors::SimpleCalculationError;
 use crate::parameters::{
     BuiltParameter, MaybeBuiltParameter, Parameter, ParameterBuildError, ParameterBuilder, ParameterMeta,
-    ParameterName, ParameterState, SimpleParameter,
+    ParameterName, ParameterState, SimpleParameter, SimpleParameterContext,
 };
-use crate::scenario::ScenarioIndex;
-use crate::state::SimpleParameterValues;
-use crate::timestep::Timestep;
 use chrono::Timelike;
 
 /// A parameter that defines a profile over a 24-hour period.
@@ -27,12 +24,10 @@ impl Parameter for DiurnalProfileParameter {
 impl SimpleParameter<f64> for DiurnalProfileParameter {
     fn before(
         &self,
-        timestep: &Timestep,
-        _scenario_index: &ScenarioIndex,
-        _values: &SimpleParameterValues,
+        ctx: SimpleParameterContext<'_>,
         _internal_state: &mut Option<Box<dyn ParameterState>>,
     ) -> Result<Option<f64>, SimpleCalculationError> {
-        Ok(Some(self.values[timestep.date.time().hour() as usize]))
+        Ok(Some(self.values[ctx.timestep.date.time().hour() as usize]))
     }
 
     fn as_parameter(&self) -> &dyn Parameter

--- a/pywr-core/src/parameters/profiles/monthly.rs
+++ b/pywr-core/src/parameters/profiles/monthly.rs
@@ -2,11 +2,8 @@ use crate::network::ResolutionMaps;
 use crate::parameters::errors::SimpleCalculationError;
 use crate::parameters::{
     BuiltParameter, MaybeBuiltParameter, Parameter, ParameterBuildError, ParameterBuilder, ParameterMeta,
-    ParameterName, ParameterState, SimpleParameter,
+    ParameterName, ParameterState, SimpleParameter, SimpleParameterContext,
 };
-use crate::scenario::ScenarioIndex;
-use crate::state::SimpleParameterValues;
-use crate::timestep::Timestep;
 use chrono::{Datelike, NaiveDateTime, Timelike};
 
 #[derive(Debug, Copy, Clone)]
@@ -112,30 +109,28 @@ impl Parameter for MonthlyProfileParameter {
 impl SimpleParameter<f64> for MonthlyProfileParameter {
     fn before(
         &self,
-        timestep: &Timestep,
-        _scenario_index: &ScenarioIndex,
-        _values: &SimpleParameterValues,
+        ctx: SimpleParameterContext<'_>,
         _internal_state: &mut Option<Box<dyn ParameterState>>,
     ) -> Result<Option<f64>, SimpleCalculationError> {
         let v = match &self.interp_day {
             Some(interp_day) => match interp_day {
                 MonthlyInterpDay::First => {
-                    let next_month0 = (timestep.date.month0() + 1) % 12;
-                    let first_value = self.values[timestep.date.month0() as usize];
+                    let next_month0 = (ctx.timestep.date.month0() + 1) % 12;
+                    let first_value = self.values[ctx.timestep.date.month0() as usize];
                     let last_value = self.values[next_month0 as usize];
 
-                    interpolate_first(&timestep.date, first_value, last_value)
+                    interpolate_first(&ctx.timestep.date, first_value, last_value)
                 }
                 MonthlyInterpDay::Last => {
-                    let current_month = timestep.date.month();
+                    let current_month = ctx.timestep.date.month();
                     let last_month = if current_month == 1 { 12 } else { current_month - 1 };
                     let first_value = self.values[last_month as usize - 1];
-                    let last_value = self.values[timestep.date.month() as usize - 1];
+                    let last_value = self.values[ctx.timestep.date.month() as usize - 1];
 
-                    interpolate_last(&timestep.date, first_value, last_value)
+                    interpolate_last(&ctx.timestep.date, first_value, last_value)
                 }
             },
-            None => self.values[timestep.date.month() as usize - 1],
+            None => self.values[ctx.timestep.date.month() as usize - 1],
         };
         Ok(Some(v))
     }

--- a/pywr-core/src/parameters/profiles/monthly.rs
+++ b/pywr-core/src/parameters/profiles/monthly.rs
@@ -2,8 +2,7 @@ use crate::network::ResolutionMaps;
 use crate::parameters::errors::SimpleCalculationError;
 use crate::parameters::{
     BuiltParameter, MaybeBuiltParameter, Parameter, ParameterBuildError, ParameterBuilder, ParameterMeta,
-    ParameterName, ParameterState, SimpleBeforeParameter, SimpleParameter, SimpleParameterContext,
-    SimpleParameterEntry,
+    ParameterName, ParameterState, SimpleParameter, SimpleParameterContext,
 };
 use chrono::{Datelike, NaiveDateTime, Timelike};
 
@@ -67,17 +66,8 @@ impl Parameter for MonthlyProfileParameter {
         &self.meta
     }
 }
-impl SimpleParameter for MonthlyProfileParameter {
-    fn as_parameter(&self) -> &dyn Parameter
-    where
-        Self: Sized,
-    {
-        self
-    }
-}
-
-impl SimpleBeforeParameter<f64> for MonthlyProfileParameter {
-    fn before(
+impl SimpleParameter<f64> for MonthlyProfileParameter {
+    fn compute(
         &self,
         ctx: SimpleParameterContext<'_>,
         _internal_state: &mut Option<Box<dyn ParameterState>>,
@@ -103,6 +93,12 @@ impl SimpleBeforeParameter<f64> for MonthlyProfileParameter {
             None => self.values[ctx.timestep.date.month() as usize - 1],
         };
         Ok(v)
+    }
+    fn as_parameter(&self) -> &dyn Parameter
+    where
+        Self: Sized,
+    {
+        self
     }
 }
 
@@ -142,6 +138,6 @@ impl ParameterBuilder<f64> for MonthlyProfileParameterBuilder {
             values: self.values,
             interp_day: self.interp_day,
         };
-        Ok(BuiltParameter::Simple(SimpleParameterEntry::before(p)).into())
+        Ok(BuiltParameter::Simple(Box::new(p)).into())
     }
 }

--- a/pywr-core/src/parameters/profiles/monthly.rs
+++ b/pywr-core/src/parameters/profiles/monthly.rs
@@ -2,7 +2,8 @@ use crate::network::ResolutionMaps;
 use crate::parameters::errors::SimpleCalculationError;
 use crate::parameters::{
     BuiltParameter, MaybeBuiltParameter, Parameter, ParameterBuildError, ParameterBuilder, ParameterMeta,
-    ParameterName, ParameterState, SimpleParameter, SimpleParameterContext,
+    ParameterName, ParameterState, SimpleBeforeParameter, SimpleParameter, SimpleParameterContext,
+    SimpleParameterEntry,
 };
 use chrono::{Datelike, NaiveDateTime, Timelike};
 
@@ -17,46 +18,6 @@ pub struct MonthlyProfileParameter {
     meta: ParameterMeta,
     values: [f64; 12],
     interp_day: Option<MonthlyInterpDay>,
-}
-
-#[derive(Debug)]
-pub struct MonthlyProfileParameterBuilder {
-    meta: ParameterMeta,
-    values: [f64; 12],
-    interp_day: Option<MonthlyInterpDay>,
-}
-
-impl MonthlyProfileParameterBuilder {
-    pub fn new(name: ParameterName, values: [f64; 12]) -> Self {
-        Self {
-            meta: ParameterMeta::new(name),
-            values,
-            interp_day: None,
-        }
-    }
-
-    pub fn interp_day(&mut self, interp_day: MonthlyInterpDay) -> &mut Self {
-        self.interp_day = Some(interp_day);
-        self
-    }
-}
-
-impl ParameterBuilder<f64> for MonthlyProfileParameterBuilder {
-    fn name(&self) -> &ParameterName {
-        &self.meta.name
-    }
-
-    fn build(
-        self: Box<Self>,
-        _resolution_maps: &ResolutionMaps,
-    ) -> Result<MaybeBuiltParameter<f64>, ParameterBuildError> {
-        Ok(BuiltParameter::Simple(Box::new(MonthlyProfileParameter {
-            meta: self.meta,
-            values: self.values,
-            interp_day: self.interp_day,
-        }))
-        .into())
-    }
 }
 
 fn days_in_year_month(datetime: &NaiveDateTime) -> u32 {
@@ -106,12 +67,21 @@ impl Parameter for MonthlyProfileParameter {
         &self.meta
     }
 }
-impl SimpleParameter<f64> for MonthlyProfileParameter {
+impl SimpleParameter for MonthlyProfileParameter {
+    fn as_parameter(&self) -> &dyn Parameter
+    where
+        Self: Sized,
+    {
+        self
+    }
+}
+
+impl SimpleBeforeParameter<f64> for MonthlyProfileParameter {
     fn before(
         &self,
         ctx: SimpleParameterContext<'_>,
         _internal_state: &mut Option<Box<dyn ParameterState>>,
-    ) -> Result<Option<f64>, SimpleCalculationError> {
+    ) -> Result<f64, SimpleCalculationError> {
         let v = match &self.interp_day {
             Some(interp_day) => match interp_day {
                 MonthlyInterpDay::First => {
@@ -132,13 +102,46 @@ impl SimpleParameter<f64> for MonthlyProfileParameter {
             },
             None => self.values[ctx.timestep.date.month() as usize - 1],
         };
-        Ok(Some(v))
+        Ok(v)
+    }
+}
+
+#[derive(Debug)]
+pub struct MonthlyProfileParameterBuilder {
+    meta: ParameterMeta,
+    values: [f64; 12],
+    interp_day: Option<MonthlyInterpDay>,
+}
+
+impl MonthlyProfileParameterBuilder {
+    pub fn new(name: ParameterName, values: [f64; 12]) -> Self {
+        Self {
+            meta: ParameterMeta::new(name),
+            values,
+            interp_day: None,
+        }
     }
 
-    fn as_parameter(&self) -> &dyn Parameter
-    where
-        Self: Sized,
-    {
+    pub fn interp_day(&mut self, interp_day: MonthlyInterpDay) -> &mut Self {
+        self.interp_day = Some(interp_day);
         self
+    }
+}
+
+impl ParameterBuilder<f64> for MonthlyProfileParameterBuilder {
+    fn name(&self) -> &ParameterName {
+        &self.meta.name
+    }
+
+    fn build(
+        self: Box<Self>,
+        _resolution_maps: &ResolutionMaps,
+    ) -> Result<MaybeBuiltParameter<f64>, ParameterBuildError> {
+        let p = MonthlyProfileParameter {
+            meta: self.meta,
+            values: self.values,
+            interp_day: self.interp_day,
+        };
+        Ok(BuiltParameter::Simple(SimpleParameterEntry::before(p)).into())
     }
 }

--- a/pywr-core/src/parameters/profiles/rbf.rs
+++ b/pywr-core/src/parameters/profiles/rbf.rs
@@ -2,9 +2,8 @@ use crate::network::ResolutionMaps;
 use crate::parameters::errors::{ParameterSetupError, SimpleCalculationError};
 use crate::parameters::{
     BuiltParameter, MaybeBuiltParameter, Parameter, ParameterBuildError, ParameterBuilder, ParameterMeta,
-    ParameterName, ParameterState, SimpleBeforeParameter, SimpleParameter, SimpleParameterContext,
-    SimpleParameterEntry, VariableConfig, VariableParameter, VariableParameterError, downcast_internal_state_mut,
-    downcast_internal_state_ref, downcast_variable_config_ref,
+    ParameterName, ParameterState, SimpleParameter, SimpleParameterContext, VariableConfig, VariableParameter,
+    VariableParameterError, downcast_internal_state_mut, downcast_internal_state_ref, downcast_variable_config_ref,
 };
 use crate::scenario::ScenarioIndex;
 use crate::timestep::Timestep;
@@ -133,17 +132,8 @@ impl Parameter for RbfProfileParameter {
     }
 }
 
-impl SimpleParameter for RbfProfileParameter {
-    fn as_parameter(&self) -> &dyn Parameter
-    where
-        Self: Sized,
-    {
-        self
-    }
-}
-
-impl SimpleBeforeParameter<f64> for RbfProfileParameter {
-    fn before(
+impl SimpleParameter<f64> for RbfProfileParameter {
+    fn compute(
         &self,
         ctx: SimpleParameterContext<'_>,
         internal_state: &mut Option<Box<dyn ParameterState>>,
@@ -152,6 +142,12 @@ impl SimpleBeforeParameter<f64> for RbfProfileParameter {
         let internal_state = downcast_internal_state_ref::<RbfProfileInternalState>(internal_state);
         // Return today's value from the profile
         Ok(internal_state.profile[ctx.timestep.day_of_year_index()])
+    }
+    fn as_parameter(&self) -> &dyn Parameter
+    where
+        Self: Sized,
+    {
+        self
     }
 }
 
@@ -411,7 +407,7 @@ impl ParameterBuilder<f64> for RbfProfileParameterBuilder {
             function: self.function,
         };
 
-        Ok(BuiltParameter::Simple(SimpleParameterEntry::before(p)).into())
+        Ok(BuiltParameter::Simple(Box::new(p)).into())
     }
 }
 

--- a/pywr-core/src/parameters/profiles/rbf.rs
+++ b/pywr-core/src/parameters/profiles/rbf.rs
@@ -2,8 +2,9 @@ use crate::network::ResolutionMaps;
 use crate::parameters::errors::{ParameterSetupError, SimpleCalculationError};
 use crate::parameters::{
     BuiltParameter, MaybeBuiltParameter, Parameter, ParameterBuildError, ParameterBuilder, ParameterMeta,
-    ParameterName, ParameterState, SimpleParameter, SimpleParameterContext, VariableConfig, VariableParameter,
-    VariableParameterError, downcast_internal_state_mut, downcast_internal_state_ref, downcast_variable_config_ref,
+    ParameterName, ParameterState, SimpleBeforeParameter, SimpleParameter, SimpleParameterContext,
+    SimpleParameterEntry, VariableConfig, VariableParameter, VariableParameterError, downcast_internal_state_mut,
+    downcast_internal_state_ref, downcast_variable_config_ref,
 };
 use crate::scenario::ScenarioIndex;
 use crate::timestep::Timestep;
@@ -132,23 +133,25 @@ impl Parameter for RbfProfileParameter {
     }
 }
 
-impl SimpleParameter<f64> for RbfProfileParameter {
-    fn before(
-        &self,
-        ctx: SimpleParameterContext<'_>,
-        internal_state: &mut Option<Box<dyn ParameterState>>,
-    ) -> Result<Option<f64>, SimpleCalculationError> {
-        // Get the profile from the internal state
-        let internal_state = downcast_internal_state_ref::<RbfProfileInternalState>(internal_state);
-        // Return today's value from the profile
-        Ok(Some(internal_state.profile[ctx.timestep.day_of_year_index()]))
-    }
-
+impl SimpleParameter for RbfProfileParameter {
     fn as_parameter(&self) -> &dyn Parameter
     where
         Self: Sized,
     {
         self
+    }
+}
+
+impl SimpleBeforeParameter<f64> for RbfProfileParameter {
+    fn before(
+        &self,
+        ctx: SimpleParameterContext<'_>,
+        internal_state: &mut Option<Box<dyn ParameterState>>,
+    ) -> Result<f64, SimpleCalculationError> {
+        // Get the profile from the internal state
+        let internal_state = downcast_internal_state_ref::<RbfProfileInternalState>(internal_state);
+        // Return today's value from the profile
+        Ok(internal_state.profile[ctx.timestep.day_of_year_index()])
     }
 }
 
@@ -408,7 +411,7 @@ impl ParameterBuilder<f64> for RbfProfileParameterBuilder {
             function: self.function,
         };
 
-        Ok(MaybeBuiltParameter::Built(BuiltParameter::Simple(Box::new(p))))
+        Ok(BuiltParameter::Simple(SimpleParameterEntry::before(p)).into())
     }
 }
 

--- a/pywr-core/src/parameters/profiles/rbf.rs
+++ b/pywr-core/src/parameters/profiles/rbf.rs
@@ -2,11 +2,10 @@ use crate::network::ResolutionMaps;
 use crate::parameters::errors::{ParameterSetupError, SimpleCalculationError};
 use crate::parameters::{
     BuiltParameter, MaybeBuiltParameter, Parameter, ParameterBuildError, ParameterBuilder, ParameterMeta,
-    ParameterName, ParameterState, SimpleParameter, VariableConfig, VariableParameter, VariableParameterError,
-    downcast_internal_state_mut, downcast_internal_state_ref, downcast_variable_config_ref,
+    ParameterName, ParameterState, SimpleParameter, SimpleParameterContext, VariableConfig, VariableParameter,
+    VariableParameterError, downcast_internal_state_mut, downcast_internal_state_ref, downcast_variable_config_ref,
 };
 use crate::scenario::ScenarioIndex;
-use crate::state::SimpleParameterValues;
 use crate::timestep::Timestep;
 use nalgebra::DMatrix;
 
@@ -136,15 +135,13 @@ impl Parameter for RbfProfileParameter {
 impl SimpleParameter<f64> for RbfProfileParameter {
     fn before(
         &self,
-        timestep: &Timestep,
-        _scenario_index: &ScenarioIndex,
-        _values: &SimpleParameterValues,
+        ctx: SimpleParameterContext<'_>,
         internal_state: &mut Option<Box<dyn ParameterState>>,
     ) -> Result<Option<f64>, SimpleCalculationError> {
         // Get the profile from the internal state
         let internal_state = downcast_internal_state_ref::<RbfProfileInternalState>(internal_state);
         // Return today's value from the profile
-        Ok(Some(internal_state.profile[timestep.day_of_year_index()]))
+        Ok(Some(internal_state.profile[ctx.timestep.day_of_year_index()]))
     }
 
     fn as_parameter(&self) -> &dyn Parameter

--- a/pywr-core/src/parameters/profiles/uniform_drawdown.rs
+++ b/pywr-core/src/parameters/profiles/uniform_drawdown.rs
@@ -2,8 +2,7 @@ use crate::network::ResolutionMaps;
 use crate::parameters::errors::SimpleCalculationError;
 use crate::parameters::{
     BuiltParameter, MaybeBuiltParameter, Parameter, ParameterBuildError, ParameterBuilder, ParameterMeta,
-    ParameterName, ParameterState, SimpleBeforeParameter, SimpleParameter, SimpleParameterContext,
-    SimpleParameterEntry,
+    ParameterName, ParameterState, SimpleParameter, SimpleParameterContext,
 };
 use chrono::{Datelike, NaiveDate};
 
@@ -23,17 +22,8 @@ impl Parameter for UniformDrawdownProfileParameter {
         &self.meta
     }
 }
-impl SimpleParameter for UniformDrawdownProfileParameter {
-    fn as_parameter(&self) -> &dyn Parameter
-    where
-        Self: Sized,
-    {
-        self
-    }
-}
-
-impl SimpleBeforeParameter<f64> for UniformDrawdownProfileParameter {
-    fn before(
+impl SimpleParameter<f64> for UniformDrawdownProfileParameter {
+    fn compute(
         &self,
         ctx: SimpleParameterContext<'_>,
         _internal_state: &mut Option<Box<dyn ParameterState>>,
@@ -71,6 +61,12 @@ impl SimpleBeforeParameter<f64> for UniformDrawdownProfileParameter {
         let slope = (residual_proportion - 1.0) / total_days_in_period as f64;
 
         Ok(1.0 + (slope * days_into_period as f64))
+    }
+    fn as_parameter(&self) -> &dyn Parameter
+    where
+        Self: Sized,
+    {
+        self
     }
 }
 
@@ -121,6 +117,6 @@ impl ParameterBuilder<f64> for UniformDrawdownProfileParameterBuilder {
             reset_doy,
         };
 
-        Ok(BuiltParameter::Simple(SimpleParameterEntry::before(p)).into())
+        Ok(BuiltParameter::Simple(Box::new(p)).into())
     }
 }

--- a/pywr-core/src/parameters/profiles/uniform_drawdown.rs
+++ b/pywr-core/src/parameters/profiles/uniform_drawdown.rs
@@ -2,7 +2,8 @@ use crate::network::ResolutionMaps;
 use crate::parameters::errors::SimpleCalculationError;
 use crate::parameters::{
     BuiltParameter, MaybeBuiltParameter, Parameter, ParameterBuildError, ParameterBuilder, ParameterMeta,
-    ParameterName, ParameterState, SimpleParameter, SimpleParameterContext,
+    ParameterName, ParameterState, SimpleBeforeParameter, SimpleParameter, SimpleParameterContext,
+    SimpleParameterEntry,
 };
 use chrono::{Datelike, NaiveDate};
 
@@ -22,12 +23,21 @@ impl Parameter for UniformDrawdownProfileParameter {
         &self.meta
     }
 }
-impl SimpleParameter<f64> for UniformDrawdownProfileParameter {
+impl SimpleParameter for UniformDrawdownProfileParameter {
+    fn as_parameter(&self) -> &dyn Parameter
+    where
+        Self: Sized,
+    {
+        self
+    }
+}
+
+impl SimpleBeforeParameter<f64> for UniformDrawdownProfileParameter {
     fn before(
         &self,
         ctx: SimpleParameterContext<'_>,
         _internal_state: &mut Option<Box<dyn ParameterState>>,
-    ) -> Result<Option<f64>, SimpleCalculationError> {
+    ) -> Result<f64, SimpleCalculationError> {
         // Current calendar year (might be adjusted depending on position of reset day)
         let mut year = ctx.timestep.date.year();
 
@@ -60,14 +70,7 @@ impl SimpleParameter<f64> for UniformDrawdownProfileParameter {
         let residual_proportion = self.residual_days as f64 / total_days_in_period as f64;
         let slope = (residual_proportion - 1.0) / total_days_in_period as f64;
 
-        Ok(Some(1.0 + (slope * days_into_period as f64)))
-    }
-
-    fn as_parameter(&self) -> &dyn Parameter
-    where
-        Self: Sized,
-    {
-        self
+        Ok(1.0 + (slope * days_into_period as f64))
     }
 }
 
@@ -118,6 +121,6 @@ impl ParameterBuilder<f64> for UniformDrawdownProfileParameterBuilder {
             reset_doy,
         };
 
-        Ok(MaybeBuiltParameter::Built(BuiltParameter::Simple(Box::new(p))))
+        Ok(BuiltParameter::Simple(SimpleParameterEntry::before(p)).into())
     }
 }

--- a/pywr-core/src/parameters/profiles/uniform_drawdown.rs
+++ b/pywr-core/src/parameters/profiles/uniform_drawdown.rs
@@ -2,11 +2,8 @@ use crate::network::ResolutionMaps;
 use crate::parameters::errors::SimpleCalculationError;
 use crate::parameters::{
     BuiltParameter, MaybeBuiltParameter, Parameter, ParameterBuildError, ParameterBuilder, ParameterMeta,
-    ParameterName, ParameterState, SimpleParameter,
+    ParameterName, ParameterState, SimpleParameter, SimpleParameterContext,
 };
-use crate::scenario::ScenarioIndex;
-use crate::state::SimpleParameterValues;
-use crate::timestep::Timestep;
 use chrono::{Datelike, NaiveDate};
 
 fn is_leap_year(year: i32) -> bool {
@@ -28,16 +25,14 @@ impl Parameter for UniformDrawdownProfileParameter {
 impl SimpleParameter<f64> for UniformDrawdownProfileParameter {
     fn before(
         &self,
-        timestep: &Timestep,
-        _scenario_index: &ScenarioIndex,
-        _values: &SimpleParameterValues,
+        ctx: SimpleParameterContext<'_>,
         _internal_state: &mut Option<Box<dyn ParameterState>>,
     ) -> Result<Option<f64>, SimpleCalculationError> {
         // Current calendar year (might be adjusted depending on position of reset day)
-        let mut year = timestep.date.year();
+        let mut year = ctx.timestep.date.year();
 
         // Current day of the year.
-        let current_doy = timestep.day_of_year_index() + 1;
+        let current_doy = ctx.timestep.day_of_year_index() + 1;
         let mut days_into_period: i32 = current_doy as i32 - self.reset_doy as i32;
         if days_into_period < 0 {
             // We're not past the reset day yet; use the previous year
@@ -57,7 +52,7 @@ impl SimpleParameter<f64> for UniformDrawdownProfileParameter {
             days_into_period += 366;
             // Need to adjust for post 29th Feb in non-leap years.
             // Recall `current_doy` was incremented by 1 if it is a non-leap already (hence comparison to 60)
-            if !is_leap_year(timestep.date.year()) && current_doy > 60 {
+            if !is_leap_year(ctx.timestep.date.year()) && current_doy > 60 {
                 days_into_period -= 1;
             }
         }

--- a/pywr-core/src/parameters/profiles/weekly.rs
+++ b/pywr-core/src/parameters/profiles/weekly.rs
@@ -2,10 +2,8 @@ use crate::network::ResolutionMaps;
 use crate::parameters::errors::SimpleCalculationError;
 use crate::parameters::{
     BuiltParameter, MaybeBuiltParameter, Parameter, ParameterBuildError, ParameterBuilder, ParameterMeta,
-    ParameterName, ParameterState, SimpleParameter,
+    ParameterName, ParameterState, SimpleParameter, SimpleParameterContext,
 };
-use crate::scenario::ScenarioIndex;
-use crate::state::SimpleParameterValues;
 use crate::timestep::Timestep;
 use thiserror::Error;
 
@@ -175,12 +173,10 @@ impl Parameter for WeeklyProfileParameter {
 impl SimpleParameter<f64> for WeeklyProfileParameter {
     fn before(
         &self,
-        timestep: &Timestep,
-        _scenario_index: &ScenarioIndex,
-        _values: &SimpleParameterValues,
+        ctx: SimpleParameterContext<'_>,
         _internal_state: &mut Option<Box<dyn ParameterState>>,
     ) -> Result<Option<f64>, SimpleCalculationError> {
-        Ok(Some(self.values.value(timestep, &self.interp_day)))
+        Ok(Some(self.values.value(ctx.timestep, &self.interp_day)))
     }
 
     fn as_parameter(&self) -> &dyn Parameter

--- a/pywr-core/src/parameters/profiles/weekly.rs
+++ b/pywr-core/src/parameters/profiles/weekly.rs
@@ -2,7 +2,8 @@ use crate::network::ResolutionMaps;
 use crate::parameters::errors::SimpleCalculationError;
 use crate::parameters::{
     BuiltParameter, MaybeBuiltParameter, Parameter, ParameterBuildError, ParameterBuilder, ParameterMeta,
-    ParameterName, ParameterState, SimpleParameter, SimpleParameterContext,
+    ParameterName, ParameterState, SimpleBeforeParameter, SimpleParameter, SimpleParameterContext,
+    SimpleParameterEntry,
 };
 use crate::timestep::Timestep;
 use thiserror::Error;
@@ -170,20 +171,22 @@ impl Parameter for WeeklyProfileParameter {
     }
 }
 
-impl SimpleParameter<f64> for WeeklyProfileParameter {
-    fn before(
-        &self,
-        ctx: SimpleParameterContext<'_>,
-        _internal_state: &mut Option<Box<dyn ParameterState>>,
-    ) -> Result<Option<f64>, SimpleCalculationError> {
-        Ok(Some(self.values.value(ctx.timestep, &self.interp_day)))
-    }
-
+impl SimpleParameter for WeeklyProfileParameter {
     fn as_parameter(&self) -> &dyn Parameter
     where
         Self: Sized,
     {
         self
+    }
+}
+
+impl SimpleBeforeParameter<f64> for WeeklyProfileParameter {
+    fn before(
+        &self,
+        ctx: SimpleParameterContext<'_>,
+        _internal_state: &mut Option<Box<dyn ParameterState>>,
+    ) -> Result<f64, SimpleCalculationError> {
+        Ok(self.values.value(ctx.timestep, &self.interp_day))
     }
 }
 
@@ -224,7 +227,7 @@ impl ParameterBuilder<f64> for WeeklyProfileParameterBuilder {
             interp_day: self.interp_day,
         };
 
-        Ok(MaybeBuiltParameter::Built(BuiltParameter::Simple(Box::new(p))))
+        Ok(BuiltParameter::Simple(SimpleParameterEntry::before(p)).into())
     }
 }
 

--- a/pywr-core/src/parameters/profiles/weekly.rs
+++ b/pywr-core/src/parameters/profiles/weekly.rs
@@ -2,8 +2,7 @@ use crate::network::ResolutionMaps;
 use crate::parameters::errors::SimpleCalculationError;
 use crate::parameters::{
     BuiltParameter, MaybeBuiltParameter, Parameter, ParameterBuildError, ParameterBuilder, ParameterMeta,
-    ParameterName, ParameterState, SimpleBeforeParameter, SimpleParameter, SimpleParameterContext,
-    SimpleParameterEntry,
+    ParameterName, ParameterState, SimpleParameter, SimpleParameterContext,
 };
 use crate::timestep::Timestep;
 use thiserror::Error;
@@ -171,22 +170,19 @@ impl Parameter for WeeklyProfileParameter {
     }
 }
 
-impl SimpleParameter for WeeklyProfileParameter {
-    fn as_parameter(&self) -> &dyn Parameter
-    where
-        Self: Sized,
-    {
-        self
-    }
-}
-
-impl SimpleBeforeParameter<f64> for WeeklyProfileParameter {
-    fn before(
+impl SimpleParameter<f64> for WeeklyProfileParameter {
+    fn compute(
         &self,
         ctx: SimpleParameterContext<'_>,
         _internal_state: &mut Option<Box<dyn ParameterState>>,
     ) -> Result<f64, SimpleCalculationError> {
         Ok(self.values.value(ctx.timestep, &self.interp_day))
+    }
+    fn as_parameter(&self) -> &dyn Parameter
+    where
+        Self: Sized,
+    {
+        self
     }
 }
 
@@ -227,7 +223,7 @@ impl ParameterBuilder<f64> for WeeklyProfileParameterBuilder {
             interp_day: self.interp_day,
         };
 
-        Ok(BuiltParameter::Simple(SimpleParameterEntry::before(p)).into())
+        Ok(BuiltParameter::Simple(Box::new(p)).into())
     }
 }
 

--- a/pywr-core/src/parameters/py.rs
+++ b/pywr-core/src/parameters/py.rs
@@ -1,6 +1,6 @@
 use super::{
-    BuiltParameter, GeneralParameter, MaybeBuiltParameter, Parameter, ParameterBuildError, ParameterBuilder,
-    ParameterMeta, ParameterName, ParameterState, Timestep,
+    BuiltParameter, GeneralParameter, GeneralParameterContext, MaybeBuiltParameter, Parameter, ParameterBuildError,
+    ParameterBuilder, ParameterMeta, ParameterName, ParameterState, Timestep,
 };
 use crate::metric::{MetricF64, MetricU64, UnresolvedMetricF64, UnresolvedMetricU64};
 use crate::network::{Network, ResolutionMaps};
@@ -209,10 +209,7 @@ impl PyClassParameter {
     fn call_method<T>(
         &self,
         method: &str,
-        timestep: &Timestep,
-        scenario_index: &ScenarioIndex,
-        network: &Network,
-        state: &State,
+        ctx: GeneralParameterContext<'_>,
         internal_state: &mut Option<Box<dyn ParameterState>>,
     ) -> Result<Option<T>, GeneralCalculationError>
     where
@@ -220,7 +217,7 @@ impl PyClassParameter {
     {
         let internal = downcast_internal_state_mut::<InternalObj>(internal_state);
 
-        ensure_parameter_info(&mut internal.info_obj, timestep, scenario_index).map_err(|py_error| {
+        ensure_parameter_info(&mut internal.info_obj, ctx.timestep, ctx.scenario_index).map_err(|py_error| {
             GeneralCalculationError::PythonError {
                 name: self.common.meta.name.to_string(),
                 object: self.class.to_string(),
@@ -236,12 +233,13 @@ impl PyClassParameter {
                 let info_bind = info.bind(py);
                 {
                     let mut info_mut = info_bind.borrow_mut();
-                    info_mut.timestep = *timestep;
-                    info_mut.scenario_index = scenario_index.clone();
+                    info_mut.timestep = *ctx.timestep;
+                    info_mut.scenario_index = ctx.scenario_index.clone();
                     self.common
-                        .update_metrics(network, state, &mut info_mut.metric_values)?;
+                        .update_metrics(ctx.network, ctx.state, &mut info_mut.metric_values)?;
 
-                    self.common.update_indices(network, state, &mut info_mut.index_values)?;
+                    self.common
+                        .update_indices(ctx.network, ctx.state, &mut info_mut.index_values)?;
                 }
 
                 let args = PyTuple::new(py, [info_bind]).map_err(|py_error| GeneralCalculationError::PythonError {
@@ -291,24 +289,18 @@ impl Parameter for PyClassParameter {
 impl GeneralParameter<f64> for PyClassParameter {
     fn before(
         &self,
-        timestep: &Timestep,
-        scenario_index: &ScenarioIndex,
-        network: &Network,
-        state: &State,
+        ctx: GeneralParameterContext<'_>,
         internal_state: &mut Option<Box<dyn ParameterState>>,
     ) -> Result<Option<f64>, GeneralCalculationError> {
-        self.call_method("before", timestep, scenario_index, network, state, internal_state)
+        self.call_method("before", ctx, internal_state)
     }
 
     fn after(
         &self,
-        timestep: &Timestep,
-        scenario_index: &ScenarioIndex,
-        network: &Network,
-        state: &State,
+        ctx: GeneralParameterContext<'_>,
         internal_state: &mut Option<Box<dyn ParameterState>>,
     ) -> Result<Option<f64>, GeneralCalculationError> {
-        self.call_method("after", timestep, scenario_index, network, state, internal_state)
+        self.call_method("after", ctx, internal_state)
     }
 
     fn as_parameter(&self) -> &dyn Parameter
@@ -322,24 +314,18 @@ impl GeneralParameter<f64> for PyClassParameter {
 impl GeneralParameter<u64> for PyClassParameter {
     fn before(
         &self,
-        timestep: &Timestep,
-        scenario_index: &ScenarioIndex,
-        network: &Network,
-        state: &State,
+        ctx: GeneralParameterContext<'_>,
         internal_state: &mut Option<Box<dyn ParameterState>>,
     ) -> Result<Option<u64>, GeneralCalculationError> {
-        self.call_method("before", timestep, scenario_index, network, state, internal_state)
+        self.call_method("before", ctx, internal_state)
     }
 
     fn after(
         &self,
-        timestep: &Timestep,
-        scenario_index: &ScenarioIndex,
-        network: &Network,
-        state: &State,
+        ctx: GeneralParameterContext<'_>,
         internal_state: &mut Option<Box<dyn ParameterState>>,
     ) -> Result<Option<u64>, GeneralCalculationError> {
-        self.call_method("after", timestep, scenario_index, network, state, internal_state)
+        self.call_method("after", ctx, internal_state)
     }
 
     fn as_parameter(&self) -> &dyn Parameter
@@ -353,24 +339,18 @@ impl GeneralParameter<u64> for PyClassParameter {
 impl GeneralParameter<MultiValue> for PyClassParameter {
     fn before(
         &self,
-        timestep: &Timestep,
-        scenario_index: &ScenarioIndex,
-        network: &Network,
-        state: &State,
+        ctx: GeneralParameterContext<'_>,
         internal_state: &mut Option<Box<dyn ParameterState>>,
     ) -> Result<Option<MultiValue>, GeneralCalculationError> {
-        self.call_method("before", timestep, scenario_index, network, state, internal_state)
+        self.call_method("before", ctx, internal_state)
     }
 
     fn after(
         &self,
-        timestep: &Timestep,
-        scenario_index: &ScenarioIndex,
-        model: &Network,
-        state: &State,
+        ctx: GeneralParameterContext<'_>,
         internal_state: &mut Option<Box<dyn ParameterState>>,
     ) -> Result<Option<MultiValue>, GeneralCalculationError> {
-        self.call_method("after", timestep, scenario_index, model, state, internal_state)
+        self.call_method("after", ctx, internal_state)
     }
 
     fn as_parameter(&self) -> &dyn Parameter
@@ -531,10 +511,7 @@ impl PyFuncParameter {
 
     fn compute<T>(
         &self,
-        timestep: &Timestep,
-        scenario_index: &ScenarioIndex,
-        network: &Network,
-        state: &State,
+        ctx: GeneralParameterContext<'_>,
         internal_state: &mut Option<Box<dyn ParameterState>>,
     ) -> Result<T, GeneralCalculationError>
     where
@@ -542,7 +519,7 @@ impl PyFuncParameter {
     {
         let internal = downcast_internal_state_mut::<InternalInfo>(internal_state);
 
-        ensure_parameter_info(&mut internal.info_obj, timestep, scenario_index).map_err(|py_error| {
+        ensure_parameter_info(&mut internal.info_obj, ctx.timestep, ctx.scenario_index).map_err(|py_error| {
             GeneralCalculationError::PythonError {
                 name: self.common.meta.name.to_string(),
                 object: self.function.to_string(),
@@ -557,12 +534,13 @@ impl PyFuncParameter {
             let info_bind = info.bind(py);
             {
                 let mut info_mut = info_bind.borrow_mut();
-                info_mut.timestep = *timestep;
-                info_mut.scenario_index = scenario_index.clone();
+                info_mut.timestep = *ctx.timestep;
+                info_mut.scenario_index = ctx.scenario_index.clone();
                 self.common
-                    .update_metrics(network, state, &mut info_mut.metric_values)?;
+                    .update_metrics(ctx.network, ctx.state, &mut info_mut.metric_values)?;
 
-                self.common.update_indices(network, state, &mut info_mut.index_values)?;
+                self.common
+                    .update_indices(ctx.network, ctx.state, &mut info_mut.index_values)?;
             }
 
             let args = PyTuple::new(py, [info_bind]).map_err(|py_error| GeneralCalculationError::PythonError {
@@ -626,13 +604,10 @@ impl Parameter for PyFuncParameter {
 impl GeneralParameter<f64> for PyFuncParameter {
     fn before(
         &self,
-        timestep: &Timestep,
-        scenario_index: &ScenarioIndex,
-        network: &Network,
-        state: &State,
+        ctx: GeneralParameterContext<'_>,
         internal_state: &mut Option<Box<dyn ParameterState>>,
     ) -> Result<Option<f64>, GeneralCalculationError> {
-        self.compute(timestep, scenario_index, network, state, internal_state)
+        self.compute(ctx, internal_state)
     }
 
     fn as_parameter(&self) -> &dyn Parameter
@@ -646,13 +621,10 @@ impl GeneralParameter<f64> for PyFuncParameter {
 impl GeneralParameter<u64> for PyFuncParameter {
     fn before(
         &self,
-        timestep: &Timestep,
-        scenario_index: &ScenarioIndex,
-        network: &Network,
-        state: &State,
+        ctx: GeneralParameterContext<'_>,
         internal_state: &mut Option<Box<dyn ParameterState>>,
     ) -> Result<Option<u64>, GeneralCalculationError> {
-        self.compute(timestep, scenario_index, network, state, internal_state)
+        self.compute(ctx, internal_state)
     }
 
     fn as_parameter(&self) -> &dyn Parameter
@@ -666,13 +638,10 @@ impl GeneralParameter<u64> for PyFuncParameter {
 impl GeneralParameter<MultiValue> for PyFuncParameter {
     fn before(
         &self,
-        timestep: &Timestep,
-        scenario_index: &ScenarioIndex,
-        network: &Network,
-        state: &State,
+        ctx: GeneralParameterContext<'_>,
         internal_state: &mut Option<Box<dyn ParameterState>>,
     ) -> Result<Option<MultiValue>, GeneralCalculationError> {
-        self.compute(timestep, scenario_index, network, state, internal_state)
+        self.compute(ctx, internal_state)
     }
 
     fn as_parameter(&self) -> &dyn Parameter
@@ -913,11 +882,16 @@ class MyParameter:
 
         for ts in timesteps {
             for (si, internal) in scenario_indices.iter().zip(internal_p_states.iter_mut()) {
-                let before_value: Option<f64> =
-                    GeneralParameter::before(&param, ts, si, &model, &state, internal).unwrap();
+                let ctx = GeneralParameterContext {
+                    timestep: ts,
+                    scenario_index: si,
+                    network: &model,
+                    state: &state,
+                };
 
-                let after_value: Option<f64> =
-                    GeneralParameter::after(&param, ts, si, &model, &state, internal).unwrap();
+                let before_value: Option<f64> = GeneralParameter::before(&param, ctx, internal).unwrap();
+
+                let after_value: Option<f64> = GeneralParameter::after(&param, ctx, internal).unwrap();
 
                 match counter_parameter_type {
                     CounterParameterType::BeforeOnly => {
@@ -1019,7 +993,14 @@ class MyParameter:
 
         for ts in timesteps {
             for (si, internal) in scenario_indices.iter().zip(internal_p_states.iter_mut()) {
-                let value = GeneralParameter::<MultiValue>::before(&param, ts, si, &model, &state, internal)
+                let ctx = GeneralParameterContext {
+                    timestep: ts,
+                    scenario_index: si,
+                    network: &model,
+                    state: &state,
+                };
+
+                let value = GeneralParameter::<MultiValue>::before(&param, ctx, internal)
                     .unwrap()
                     .unwrap();
 
@@ -1088,9 +1069,14 @@ def my_function(info, count, **kwargs):
 
         for ts in timesteps {
             for (si, internal) in scenario_indices.iter().zip(internal_p_states.iter_mut()) {
-                let value = GeneralParameter::before(&param, ts, si, &model, &state, internal)
-                    .unwrap()
-                    .unwrap();
+                let ctx = GeneralParameterContext {
+                    timestep: ts,
+                    scenario_index: si,
+                    network: &model,
+                    state: &state,
+                };
+
+                let value = GeneralParameter::before(&param, ctx, internal).unwrap().unwrap();
 
                 assert_approx_eq!(f64, value, (2 + si.simulation_id() + ts.date.day() as usize) as f64);
             }

--- a/pywr-core/src/parameters/py.rs
+++ b/pywr-core/src/parameters/py.rs
@@ -1,6 +1,7 @@
 use super::{
-    BuiltParameter, GeneralParameter, GeneralParameterContext, MaybeBuiltParameter, Parameter, ParameterBuildError,
-    ParameterBuilder, ParameterMeta, ParameterName, ParameterState, Timestep,
+    BuiltParameter, GeneralAfterParameter, GeneralBeforeParameter, GeneralParameter, GeneralParameterContext,
+    GeneralParameterEntry, MaybeBuiltParameter, Parameter, ParameterBuildError, ParameterBuilder, ParameterMeta,
+    ParameterName, ParameterState, Timestep,
 };
 use crate::metric::{MetricF64, MetricU64, UnresolvedMetricF64, UnresolvedMetricU64};
 use crate::network::{Network, ResolutionMaps};
@@ -211,7 +212,7 @@ impl PyClassParameter {
         method: &str,
         ctx: GeneralParameterContext<'_>,
         internal_state: &mut Option<Box<dyn ParameterState>>,
-    ) -> Result<Option<T>, GeneralCalculationError>
+    ) -> Result<T, GeneralCalculationError>
     where
         T: for<'a, 'py> FromPyObject<'a, 'py>,
     {
@@ -228,7 +229,7 @@ impl PyClassParameter {
         // Safe to unwrap as we just ensured it is Some.
         let info = internal.info_obj.as_ref().unwrap();
 
-        let value: Option<T> = Python::attach(|py| {
+        let value: T = Python::attach(|py| {
             if internal.user_obj.getattr(py, method).is_ok() {
                 let info_bind = info.bind(py);
                 {
@@ -256,15 +257,18 @@ impl PyClassParameter {
                         object: self.class.to_string(),
                         py_error: Box::new(py_error),
                     })?
-                    .extract(py)
-                    .map_err(Into::into)
+                    .extract::<T>(py)
                     .map_err(|py_error| GeneralCalculationError::PythonError {
                         name: self.common.meta.name.to_string(),
                         object: self.class.to_string(),
-                        py_error: Box::new(py_error),
+                        py_error: Box::new(py_error.into()),
                     })
             } else {
-                Ok(None)
+                Err(GeneralCalculationError::PhaseNotEnabled {
+                    ty: "PyClassParameter".to_string(),
+                    phase: method.to_string(), // This is the method name, which corresponds to the phase (before/after)
+                    message: format!("The method `{method}` is not implemented in the Python class."),
+                })
             }
         })?;
 
@@ -286,23 +290,7 @@ impl Parameter for PyClassParameter {
     }
 }
 
-impl GeneralParameter<f64> for PyClassParameter {
-    fn before(
-        &self,
-        ctx: GeneralParameterContext<'_>,
-        internal_state: &mut Option<Box<dyn ParameterState>>,
-    ) -> Result<Option<f64>, GeneralCalculationError> {
-        self.call_method("before", ctx, internal_state)
-    }
-
-    fn after(
-        &self,
-        ctx: GeneralParameterContext<'_>,
-        internal_state: &mut Option<Box<dyn ParameterState>>,
-    ) -> Result<Option<f64>, GeneralCalculationError> {
-        self.call_method("after", ctx, internal_state)
-    }
-
+impl GeneralParameter for PyClassParameter {
     fn as_parameter(&self) -> &dyn Parameter
     where
         Self: Sized,
@@ -311,53 +299,60 @@ impl GeneralParameter<f64> for PyClassParameter {
     }
 }
 
-impl GeneralParameter<u64> for PyClassParameter {
+impl GeneralBeforeParameter<f64> for PyClassParameter {
     fn before(
         &self,
         ctx: GeneralParameterContext<'_>,
         internal_state: &mut Option<Box<dyn ParameterState>>,
-    ) -> Result<Option<u64>, GeneralCalculationError> {
+    ) -> Result<f64, GeneralCalculationError> {
         self.call_method("before", ctx, internal_state)
     }
-
+}
+impl GeneralAfterParameter<f64> for PyClassParameter {
     fn after(
         &self,
         ctx: GeneralParameterContext<'_>,
         internal_state: &mut Option<Box<dyn ParameterState>>,
-    ) -> Result<Option<u64>, GeneralCalculationError> {
+    ) -> Result<f64, GeneralCalculationError> {
         self.call_method("after", ctx, internal_state)
-    }
-
-    fn as_parameter(&self) -> &dyn Parameter
-    where
-        Self: Sized,
-    {
-        self
     }
 }
 
-impl GeneralParameter<MultiValue> for PyClassParameter {
+impl GeneralBeforeParameter<u64> for PyClassParameter {
     fn before(
         &self,
         ctx: GeneralParameterContext<'_>,
         internal_state: &mut Option<Box<dyn ParameterState>>,
-    ) -> Result<Option<MultiValue>, GeneralCalculationError> {
+    ) -> Result<u64, GeneralCalculationError> {
         self.call_method("before", ctx, internal_state)
     }
-
+}
+impl GeneralAfterParameter<u64> for PyClassParameter {
     fn after(
         &self,
         ctx: GeneralParameterContext<'_>,
         internal_state: &mut Option<Box<dyn ParameterState>>,
-    ) -> Result<Option<MultiValue>, GeneralCalculationError> {
+    ) -> Result<u64, GeneralCalculationError> {
         self.call_method("after", ctx, internal_state)
     }
+}
 
-    fn as_parameter(&self) -> &dyn Parameter
-    where
-        Self: Sized,
-    {
-        self
+impl GeneralBeforeParameter<MultiValue> for PyClassParameter {
+    fn before(
+        &self,
+        ctx: GeneralParameterContext<'_>,
+        internal_state: &mut Option<Box<dyn ParameterState>>,
+    ) -> Result<MultiValue, GeneralCalculationError> {
+        self.call_method("before", ctx, internal_state)
+    }
+}
+impl GeneralAfterParameter<MultiValue> for PyClassParameter {
+    fn after(
+        &self,
+        ctx: GeneralParameterContext<'_>,
+        internal_state: &mut Option<Box<dyn ParameterState>>,
+    ) -> Result<MultiValue, GeneralCalculationError> {
+        self.call_method("after", ctx, internal_state)
     }
 }
 
@@ -406,12 +401,30 @@ impl ParameterBuilder<f64> for PyClassParameterBuilder {
             indices,
         };
 
+        let (has_before, has_after) = Python::attach(|py| {
+            let has_before = self.class.getattr(py, "before").is_ok();
+            let has_after = self.class.getattr(py, "after").is_ok();
+            (has_before, has_after)
+        });
+
         let p = PyClassParameter {
             class: self.class,
             common,
         };
 
-        Ok(MaybeBuiltParameter::Built(BuiltParameter::General(Box::new(p))))
+        let entry = match (has_before, has_after) {
+            (true, true) => GeneralParameterEntry::both(p),
+            (true, false) => GeneralParameterEntry::before(p),
+            (false, true) => GeneralParameterEntry::after(p),
+            (false, false) => {
+                return Err(ParameterBuildError::NoCalculationPhase {
+                    detail: "PyClassParameterBuilder must have at least one of `before` or `after` methods defined."
+                        .into(),
+                });
+            }
+        };
+
+        Ok(BuiltParameter::General(entry).into())
     }
 }
 
@@ -435,12 +448,30 @@ impl ParameterBuilder<u64> for PyClassParameterBuilder {
             indices,
         };
 
+        let (has_before, has_after) = Python::attach(|py| {
+            let has_before = self.class.getattr(py, "before").is_ok();
+            let has_after = self.class.getattr(py, "after").is_ok();
+            (has_before, has_after)
+        });
+
         let p = PyClassParameter {
             class: self.class,
             common,
         };
 
-        Ok(MaybeBuiltParameter::Built(BuiltParameter::General(Box::new(p))))
+        let entry = match (has_before, has_after) {
+            (true, true) => GeneralParameterEntry::both(p),
+            (true, false) => GeneralParameterEntry::before(p),
+            (false, true) => GeneralParameterEntry::after(p),
+            (false, false) => {
+                return Err(ParameterBuildError::NoCalculationPhase {
+                    detail: "PyClassParameterBuilder must have at least one of `before` or `after` methods defined."
+                        .into(),
+                });
+            }
+        };
+
+        Ok(BuiltParameter::General(entry).into())
     }
 }
 
@@ -464,12 +495,30 @@ impl ParameterBuilder<MultiValue> for PyClassParameterBuilder {
             indices,
         };
 
+        let (has_before, has_after) = Python::attach(|py| {
+            let has_before = self.class.getattr(py, "before").is_ok();
+            let has_after = self.class.getattr(py, "after").is_ok();
+            (has_before, has_after)
+        });
+
         let p = PyClassParameter {
             class: self.class,
             common,
         };
 
-        Ok(MaybeBuiltParameter::Built(BuiltParameter::General(Box::new(p))))
+        let entry = match (has_before, has_after) {
+            (true, true) => GeneralParameterEntry::both(p),
+            (true, false) => GeneralParameterEntry::before(p),
+            (false, true) => GeneralParameterEntry::after(p),
+            (false, false) => {
+                return Err(ParameterBuildError::NoCalculationPhase {
+                    detail: "PyClassParameterBuilder must have at least one of `before` or `after` methods defined."
+                        .into(),
+                });
+            }
+        };
+
+        Ok(BuiltParameter::General(entry).into())
     }
 }
 
@@ -601,15 +650,7 @@ impl Parameter for PyFuncParameter {
         self.setup()
     }
 }
-impl GeneralParameter<f64> for PyFuncParameter {
-    fn before(
-        &self,
-        ctx: GeneralParameterContext<'_>,
-        internal_state: &mut Option<Box<dyn ParameterState>>,
-    ) -> Result<Option<f64>, GeneralCalculationError> {
-        self.compute(ctx, internal_state)
-    }
-
+impl GeneralParameter for PyFuncParameter {
     fn as_parameter(&self) -> &dyn Parameter
     where
         Self: Sized,
@@ -618,37 +659,33 @@ impl GeneralParameter<f64> for PyFuncParameter {
     }
 }
 
-impl GeneralParameter<u64> for PyFuncParameter {
+impl GeneralBeforeParameter<f64> for PyFuncParameter {
     fn before(
         &self,
         ctx: GeneralParameterContext<'_>,
         internal_state: &mut Option<Box<dyn ParameterState>>,
-    ) -> Result<Option<u64>, GeneralCalculationError> {
+    ) -> Result<f64, GeneralCalculationError> {
         self.compute(ctx, internal_state)
-    }
-
-    fn as_parameter(&self) -> &dyn Parameter
-    where
-        Self: Sized,
-    {
-        self
     }
 }
 
-impl GeneralParameter<MultiValue> for PyFuncParameter {
+impl GeneralBeforeParameter<u64> for PyFuncParameter {
     fn before(
         &self,
         ctx: GeneralParameterContext<'_>,
         internal_state: &mut Option<Box<dyn ParameterState>>,
-    ) -> Result<Option<MultiValue>, GeneralCalculationError> {
+    ) -> Result<u64, GeneralCalculationError> {
         self.compute(ctx, internal_state)
     }
+}
 
-    fn as_parameter(&self) -> &dyn Parameter
-    where
-        Self: Sized,
-    {
-        self
+impl GeneralBeforeParameter<MultiValue> for PyFuncParameter {
+    fn before(
+        &self,
+        ctx: GeneralParameterContext<'_>,
+        internal_state: &mut Option<Box<dyn ParameterState>>,
+    ) -> Result<MultiValue, GeneralCalculationError> {
+        self.compute(ctx, internal_state)
     }
 }
 
@@ -702,7 +739,7 @@ impl ParameterBuilder<f64> for PyFuncParameterBuilder {
             common,
         };
 
-        Ok(MaybeBuiltParameter::Built(BuiltParameter::General(Box::new(p))))
+        Ok(BuiltParameter::General(GeneralParameterEntry::before(p)).into())
     }
 }
 
@@ -731,7 +768,7 @@ impl ParameterBuilder<u64> for PyFuncParameterBuilder {
             common,
         };
 
-        Ok(MaybeBuiltParameter::Built(BuiltParameter::General(Box::new(p))))
+        Ok(BuiltParameter::General(GeneralParameterEntry::before(p)).into())
     }
 }
 
@@ -760,7 +797,7 @@ impl ParameterBuilder<MultiValue> for PyFuncParameterBuilder {
             common,
         };
 
-        Ok(MaybeBuiltParameter::Built(BuiltParameter::General(Box::new(p))))
+        Ok(BuiltParameter::General(GeneralParameterEntry::before(p)).into())
     }
 }
 
@@ -773,6 +810,7 @@ mod tests {
     use chrono::Datelike;
     use float_cmp::assert_approx_eq;
     use pyo3::ffi::c_str;
+    use std::assert_matches;
     use std::ffi::CStr;
 
     enum CounterParameterType {
@@ -889,9 +927,8 @@ class MyParameter:
                     state: &state,
                 };
 
-                let before_value: Option<f64> = GeneralParameter::before(&param, ctx, internal).unwrap();
-
-                let after_value: Option<f64> = GeneralParameter::after(&param, ctx, internal).unwrap();
+                let before_value = GeneralBeforeParameter::before(&param, ctx, internal);
+                let after_value = GeneralAfterParameter::after(&param, ctx, internal);
 
                 match counter_parameter_type {
                     CounterParameterType::BeforeOnly => {
@@ -900,7 +937,7 @@ class MyParameter:
                             before_value.expect("Expected a value from before()"),
                             ((ts.index + 1) * si.simulation_id() + ts.date.day() as usize) as f64
                         );
-                        assert!(after_value.is_none(), "Expected no value from after()");
+                        assert_matches!(after_value, Err(GeneralCalculationError::PhaseNotEnabled { .. }));
                     }
                     CounterParameterType::BeforeAfter => {
                         assert_approx_eq!(
@@ -915,7 +952,7 @@ class MyParameter:
                         );
                     }
                     CounterParameterType::AfterOnly => {
-                        assert!(before_value.is_none(), "Expected no value from before()");
+                        assert_matches!(before_value, Err(GeneralCalculationError::PhaseNotEnabled { .. }));
                         assert_approx_eq!(
                             f64,
                             after_value.expect("Expected a value from after()"),
@@ -1000,9 +1037,7 @@ class MyParameter:
                     state: &state,
                 };
 
-                let value = GeneralParameter::<MultiValue>::before(&param, ctx, internal)
-                    .unwrap()
-                    .unwrap();
+                let value = GeneralBeforeParameter::<MultiValue>::before(&param, ctx, internal).unwrap();
 
                 assert_approx_eq!(f64, *value.get_value("a-float").unwrap(), std::f64::consts::PI);
 
@@ -1076,7 +1111,7 @@ def my_function(info, count, **kwargs):
                     state: &state,
                 };
 
-                let value = GeneralParameter::before(&param, ctx, internal).unwrap().unwrap();
+                let value = GeneralBeforeParameter::before(&param, ctx, internal).unwrap();
 
                 assert_approx_eq!(f64, value, (2 + si.simulation_id() + ts.date.day() as usize) as f64);
             }

--- a/pywr-core/src/parameters/rolling.rs
+++ b/pywr-core/src/parameters/rolling.rs
@@ -6,9 +6,10 @@ use crate::metric::{
 use crate::network::ResolutionMaps;
 use crate::parameters::errors::{GeneralCalculationError, ParameterSetupError, SimpleCalculationError};
 use crate::parameters::{
-    BuiltParameter, GeneralParameter, GeneralParameterContext, MaybeBuiltParameter, Parameter, ParameterBuildError,
-    ParameterBuilder, ParameterMeta, ParameterName, ParameterState, SimpleParameter, SimpleParameterContext,
-    downcast_internal_state_mut, downcast_internal_state_ref,
+    BuiltParameter, GeneralAfterParameterHook, GeneralBeforeParameter, GeneralParameter, GeneralParameterContext,
+    GeneralParameterEntry, MaybeBuiltParameter, Parameter, ParameterBuildError, ParameterBuilder, ParameterMeta,
+    ParameterName, ParameterState, SimpleAfterParameterHook, SimpleBeforeParameter, SimpleParameter,
+    SimpleParameterContext, SimpleParameterEntry, downcast_internal_state_mut, downcast_internal_state_ref,
 };
 use crate::scenario::ScenarioIndex;
 use crate::timestep::Timestep;
@@ -104,28 +105,38 @@ where
     }
 }
 
-impl GeneralParameter<f64> for RollingParameter<MetricF64, f64, AggFuncF64> {
+impl GeneralParameter for RollingParameter<MetricF64, f64, AggFuncF64> {
+    fn as_parameter(&self) -> &dyn Parameter
+    where
+        Self: Sized,
+    {
+        self
+    }
+}
+
+impl GeneralBeforeParameter<f64> for RollingParameter<MetricF64, f64, AggFuncF64> {
     fn before(
         &self,
         _ctx: GeneralParameterContext<'_>,
         internal_state: &mut Option<Box<dyn ParameterState>>,
-    ) -> Result<Option<f64>, GeneralCalculationError> {
+    ) -> Result<f64, GeneralCalculationError> {
         // Downcast the internal state to the correct type
         let memory = downcast_internal_state_ref::<VecDeque<f64>>(internal_state);
 
         if memory.len() < self.min_values {
             // Not enough values collected yet, return the initial value
-            Ok(Some(self.initial_value))
+            Ok(self.initial_value)
         } else {
-            Ok(Some(self.agg_func.calc_iter_f64(memory)?))
+            Ok(self.agg_func.calc_iter_f64(memory)?)
         }
     }
-
+}
+impl GeneralAfterParameterHook<f64> for RollingParameter<MetricF64, f64, AggFuncF64> {
     fn after(
         &self,
         ctx: GeneralParameterContext<'_>,
         internal_state: &mut Option<Box<dyn ParameterState>>,
-    ) -> Result<Option<f64>, GeneralCalculationError> {
+    ) -> Result<(), GeneralCalculationError> {
         // Downcast the internal state to the correct type
         let memory = downcast_internal_state_mut::<VecDeque<f64>>(internal_state);
 
@@ -138,18 +149,11 @@ impl GeneralParameter<f64> for RollingParameter<MetricF64, f64, AggFuncF64> {
             memory.pop_front();
         }
 
-        Ok(None)
+        Ok(())
     }
+}
 
-    fn try_into_simple(&self) -> Option<Box<dyn SimpleParameter<f64>>>
-    where
-        Self: Sized,
-    {
-        self.try_into()
-            .ok()
-            .map(|p: RollingParameter<SimpleMetricF64, f64, AggFuncF64>| Box::new(p) as Box<dyn SimpleParameter<f64>>)
-    }
-
+impl SimpleParameter for RollingParameter<SimpleMetricF64, f64, AggFuncF64> {
     fn as_parameter(&self) -> &dyn Parameter
     where
         Self: Sized,
@@ -158,28 +162,29 @@ impl GeneralParameter<f64> for RollingParameter<MetricF64, f64, AggFuncF64> {
     }
 }
 
-impl SimpleParameter<f64> for RollingParameter<SimpleMetricF64, f64, AggFuncF64> {
+impl SimpleBeforeParameter<f64> for RollingParameter<SimpleMetricF64, f64, AggFuncF64> {
     fn before(
         &self,
         _ctx: SimpleParameterContext<'_>,
         internal_state: &mut Option<Box<dyn ParameterState>>,
-    ) -> Result<Option<f64>, SimpleCalculationError> {
+    ) -> Result<f64, SimpleCalculationError> {
         // Downcast the internal state to the correct type
         let memory = downcast_internal_state_ref::<VecDeque<f64>>(internal_state);
 
         if memory.len() < self.min_values {
             // Not enough values collected yet, return the initial value
-            Ok(Some(self.initial_value))
+            Ok(self.initial_value)
         } else {
-            Ok(Some(self.agg_func.calc_iter_f64(memory)?))
+            Ok(self.agg_func.calc_iter_f64(memory)?)
         }
     }
-
+}
+impl SimpleAfterParameterHook<f64> for RollingParameter<SimpleMetricF64, f64, AggFuncF64> {
     fn after(
         &self,
         ctx: SimpleParameterContext<'_>,
         internal_state: &mut Option<Box<dyn ParameterState>>,
-    ) -> Result<Option<f64>, SimpleCalculationError> {
+    ) -> Result<(), SimpleCalculationError> {
         // Downcast the internal state to the correct type
         let memory = downcast_internal_state_mut::<VecDeque<f64>>(internal_state);
 
@@ -192,9 +197,11 @@ impl SimpleParameter<f64> for RollingParameter<SimpleMetricF64, f64, AggFuncF64>
             memory.pop_front();
         }
 
-        Ok(None)
+        Ok(())
     }
+}
 
+impl GeneralParameter for RollingParameter<MetricU64, u64, AggFuncU64> {
     fn as_parameter(&self) -> &dyn Parameter
     where
         Self: Sized,
@@ -203,28 +210,29 @@ impl SimpleParameter<f64> for RollingParameter<SimpleMetricF64, f64, AggFuncF64>
     }
 }
 
-impl GeneralParameter<u64> for RollingParameter<MetricU64, u64, AggFuncU64> {
+impl GeneralBeforeParameter<u64> for RollingParameter<MetricU64, u64, AggFuncU64> {
     fn before(
         &self,
         _ctx: GeneralParameterContext<'_>,
         internal_state: &mut Option<Box<dyn ParameterState>>,
-    ) -> Result<Option<u64>, GeneralCalculationError> {
+    ) -> Result<u64, GeneralCalculationError> {
         // Downcast the internal state to the correct type
         let memory = downcast_internal_state_ref::<VecDeque<u64>>(internal_state);
 
         if memory.len() < self.min_values {
             // Not enough values collected yet, return the initial value
-            Ok(Some(self.initial_value))
+            Ok(self.initial_value)
         } else {
-            Ok(Some(self.agg_func.calc_iter_u64(memory.iter())?))
+            Ok(self.agg_func.calc_iter_u64(memory.iter())?)
         }
     }
-
+}
+impl GeneralAfterParameterHook<u64> for RollingParameter<MetricU64, u64, AggFuncU64> {
     fn after(
         &self,
         ctx: GeneralParameterContext<'_>,
         internal_state: &mut Option<Box<dyn ParameterState>>,
-    ) -> Result<Option<u64>, GeneralCalculationError> {
+    ) -> Result<(), GeneralCalculationError> {
         // Downcast the internal state to the correct type
         let memory = downcast_internal_state_mut::<VecDeque<u64>>(internal_state);
 
@@ -237,18 +245,11 @@ impl GeneralParameter<u64> for RollingParameter<MetricU64, u64, AggFuncU64> {
             memory.pop_front();
         }
 
-        Ok(None)
+        Ok(())
     }
+}
 
-    fn try_into_simple(&self) -> Option<Box<dyn SimpleParameter<u64>>>
-    where
-        Self: Sized,
-    {
-        self.try_into()
-            .ok()
-            .map(|p: RollingParameter<SimpleMetricU64, u64, AggFuncU64>| Box::new(p) as Box<dyn SimpleParameter<u64>>)
-    }
-
+impl SimpleParameter for RollingParameter<SimpleMetricU64, u64, AggFuncU64> {
     fn as_parameter(&self) -> &dyn Parameter
     where
         Self: Sized,
@@ -257,28 +258,29 @@ impl GeneralParameter<u64> for RollingParameter<MetricU64, u64, AggFuncU64> {
     }
 }
 
-impl SimpleParameter<u64> for RollingParameter<SimpleMetricU64, u64, AggFuncU64> {
+impl SimpleBeforeParameter<u64> for RollingParameter<SimpleMetricU64, u64, AggFuncU64> {
     fn before(
         &self,
         _ctx: SimpleParameterContext<'_>,
         internal_state: &mut Option<Box<dyn ParameterState>>,
-    ) -> Result<Option<u64>, SimpleCalculationError> {
+    ) -> Result<u64, SimpleCalculationError> {
         // Downcast the internal state to the correct type
         let memory = downcast_internal_state_ref::<VecDeque<u64>>(internal_state);
 
         if memory.len() < self.min_values {
             // Not enough values collected yet, return the initial value
-            Ok(Some(self.initial_value))
+            Ok(self.initial_value)
         } else {
-            Ok(Some(self.agg_func.calc_iter_u64(memory.iter())?))
+            Ok(self.agg_func.calc_iter_u64(memory.iter())?)
         }
     }
-
+}
+impl SimpleAfterParameterHook<u64> for RollingParameter<SimpleMetricU64, u64, AggFuncU64> {
     fn after(
         &self,
         ctx: SimpleParameterContext<'_>,
         internal_state: &mut Option<Box<dyn ParameterState>>,
-    ) -> Result<Option<u64>, SimpleCalculationError> {
+    ) -> Result<(), SimpleCalculationError> {
         // Downcast the internal state to the correct type
         let memory = downcast_internal_state_mut::<VecDeque<u64>>(internal_state);
 
@@ -291,14 +293,7 @@ impl SimpleParameter<u64> for RollingParameter<SimpleMetricU64, u64, AggFuncU64>
             memory.pop_front();
         }
 
-        Ok(None)
-    }
-
-    fn as_parameter(&self) -> &dyn Parameter
-    where
-        Self: Sized,
-    {
-        self
+        Ok(())
     }
 }
 
@@ -352,6 +347,21 @@ impl ParameterBuilder<f64> for RollingParameterBuilder<UnresolvedMetricF64, f64,
     ) -> Result<MaybeBuiltParameter<f64>, ParameterBuildError> {
         let metric = resolve_metric_f64!(self, self.metric, resolution_maps, "metric");
 
+        // We can make a simple version if the metric can be simplified
+        if let Ok(metric) = metric.clone().try_into() {
+            let p = RollingParameter {
+                meta: self.meta,
+                metric,
+                window_size: self.window_size,
+                initial_value: self.initial_value,
+                min_values: self.min_values,
+                agg_func: self.agg_func,
+            };
+
+            let bp = BuiltParameter::Simple(SimpleParameterEntry::before_with_after_hook(p));
+            return Ok(MaybeBuiltParameter::Built(bp));
+        }
+
         let p = RollingParameter {
             meta: self.meta,
             metric,
@@ -361,7 +371,7 @@ impl ParameterBuilder<f64> for RollingParameterBuilder<UnresolvedMetricF64, f64,
             agg_func: self.agg_func,
         };
 
-        let bp = BuiltParameter::General(Box::new(p));
+        let bp = BuiltParameter::General(GeneralParameterEntry::before_with_after_hook(p));
         Ok(MaybeBuiltParameter::Built(bp))
     }
 }
@@ -377,6 +387,21 @@ impl ParameterBuilder<u64> for RollingParameterBuilder<UnresolvedMetricU64, u64,
     ) -> Result<MaybeBuiltParameter<u64>, ParameterBuildError> {
         let metric = resolve_metric_u64!(self, self.metric, resolution_maps, "metric");
 
+        // We can make a simple version if the metric can be simplified
+        if let Ok(metric) = metric.clone().try_into() {
+            let p = RollingParameter {
+                meta: self.meta,
+                metric,
+                window_size: self.window_size,
+                initial_value: self.initial_value,
+                min_values: self.min_values,
+                agg_func: self.agg_func,
+            };
+
+            let bp = BuiltParameter::Simple(SimpleParameterEntry::before_with_after_hook(p));
+            return Ok(MaybeBuiltParameter::Built(bp));
+        }
+
         let p = RollingParameter {
             meta: self.meta,
             metric,
@@ -386,7 +411,7 @@ impl ParameterBuilder<u64> for RollingParameterBuilder<UnresolvedMetricU64, u64,
             agg_func: self.agg_func,
         };
 
-        let bp = BuiltParameter::General(Box::new(p));
+        let bp = BuiltParameter::General(GeneralParameterEntry::before_with_after_hook(p));
         Ok(MaybeBuiltParameter::Built(bp))
     }
 }

--- a/pywr-core/src/parameters/rolling.rs
+++ b/pywr-core/src/parameters/rolling.rs
@@ -7,11 +7,10 @@ use crate::network::ResolutionMaps;
 use crate::parameters::errors::{GeneralCalculationError, ParameterSetupError, SimpleCalculationError};
 use crate::parameters::{
     BuiltParameter, GeneralParameter, GeneralParameterContext, MaybeBuiltParameter, Parameter, ParameterBuildError,
-    ParameterBuilder, ParameterMeta, ParameterName, ParameterState, SimpleParameter, downcast_internal_state_mut,
-    downcast_internal_state_ref,
+    ParameterBuilder, ParameterMeta, ParameterName, ParameterState, SimpleParameter, SimpleParameterContext,
+    downcast_internal_state_mut, downcast_internal_state_ref,
 };
 use crate::scenario::ScenarioIndex;
-use crate::state::SimpleParameterValues;
 use crate::timestep::Timestep;
 use crate::{resolve_metric_f64, resolve_metric_u64};
 use std::collections::VecDeque;
@@ -162,9 +161,7 @@ impl GeneralParameter<f64> for RollingParameter<MetricF64, f64, AggFuncF64> {
 impl SimpleParameter<f64> for RollingParameter<SimpleMetricF64, f64, AggFuncF64> {
     fn before(
         &self,
-        _timestep: &Timestep,
-        _scenario_index: &ScenarioIndex,
-        _values: &SimpleParameterValues,
+        _ctx: SimpleParameterContext<'_>,
         internal_state: &mut Option<Box<dyn ParameterState>>,
     ) -> Result<Option<f64>, SimpleCalculationError> {
         // Downcast the internal state to the correct type
@@ -180,16 +177,14 @@ impl SimpleParameter<f64> for RollingParameter<SimpleMetricF64, f64, AggFuncF64>
 
     fn after(
         &self,
-        _timestep: &Timestep,
-        _scenario_index: &ScenarioIndex,
-        values: &SimpleParameterValues,
+        ctx: SimpleParameterContext<'_>,
         internal_state: &mut Option<Box<dyn ParameterState>>,
     ) -> Result<Option<f64>, SimpleCalculationError> {
         // Downcast the internal state to the correct type
         let memory = downcast_internal_state_mut::<VecDeque<f64>>(internal_state);
 
         // Get today's value from the metric
-        let value = self.metric.get_value(values)?;
+        let value = self.metric.get_value(ctx.values)?;
         memory.push_back(value);
 
         // If the memory exceeds the window size, remove the oldest value
@@ -265,9 +260,7 @@ impl GeneralParameter<u64> for RollingParameter<MetricU64, u64, AggFuncU64> {
 impl SimpleParameter<u64> for RollingParameter<SimpleMetricU64, u64, AggFuncU64> {
     fn before(
         &self,
-        _timestep: &Timestep,
-        _scenario_index: &ScenarioIndex,
-        _values: &SimpleParameterValues,
+        _ctx: SimpleParameterContext<'_>,
         internal_state: &mut Option<Box<dyn ParameterState>>,
     ) -> Result<Option<u64>, SimpleCalculationError> {
         // Downcast the internal state to the correct type
@@ -283,16 +276,14 @@ impl SimpleParameter<u64> for RollingParameter<SimpleMetricU64, u64, AggFuncU64>
 
     fn after(
         &self,
-        _timestep: &Timestep,
-        _scenario_index: &ScenarioIndex,
-        values: &SimpleParameterValues,
+        ctx: SimpleParameterContext<'_>,
         internal_state: &mut Option<Box<dyn ParameterState>>,
     ) -> Result<Option<u64>, SimpleCalculationError> {
         // Downcast the internal state to the correct type
         let memory = downcast_internal_state_mut::<VecDeque<u64>>(internal_state);
 
         // Get today's value from the metric
-        let value = self.metric.get_value(values)?;
+        let value = self.metric.get_value(ctx.values)?;
         memory.push_back(value);
 
         // If the memory exceeds the window size, remove the oldest value

--- a/pywr-core/src/parameters/rolling.rs
+++ b/pywr-core/src/parameters/rolling.rs
@@ -3,15 +3,15 @@ use crate::metric::{
     MetricF64, MetricF64Error, MetricU64, MetricU64Error, SimpleMetricF64, SimpleMetricU64, UnresolvedMetricF64,
     UnresolvedMetricU64,
 };
-use crate::network::{Network, ResolutionMaps};
+use crate::network::ResolutionMaps;
 use crate::parameters::errors::{GeneralCalculationError, ParameterSetupError, SimpleCalculationError};
 use crate::parameters::{
-    BuiltParameter, GeneralParameter, MaybeBuiltParameter, Parameter, ParameterBuildError, ParameterBuilder,
-    ParameterMeta, ParameterName, ParameterState, SimpleParameter, downcast_internal_state_mut,
+    BuiltParameter, GeneralParameter, GeneralParameterContext, MaybeBuiltParameter, Parameter, ParameterBuildError,
+    ParameterBuilder, ParameterMeta, ParameterName, ParameterState, SimpleParameter, downcast_internal_state_mut,
     downcast_internal_state_ref,
 };
 use crate::scenario::ScenarioIndex;
-use crate::state::{SimpleParameterValues, State};
+use crate::state::SimpleParameterValues;
 use crate::timestep::Timestep;
 use crate::{resolve_metric_f64, resolve_metric_u64};
 use std::collections::VecDeque;
@@ -108,10 +108,7 @@ where
 impl GeneralParameter<f64> for RollingParameter<MetricF64, f64, AggFuncF64> {
     fn before(
         &self,
-        _timestep: &Timestep,
-        _scenario_index: &ScenarioIndex,
-        _model: &Network,
-        _state: &State,
+        _ctx: GeneralParameterContext<'_>,
         internal_state: &mut Option<Box<dyn ParameterState>>,
     ) -> Result<Option<f64>, GeneralCalculationError> {
         // Downcast the internal state to the correct type
@@ -127,17 +124,14 @@ impl GeneralParameter<f64> for RollingParameter<MetricF64, f64, AggFuncF64> {
 
     fn after(
         &self,
-        _timestep: &Timestep,
-        _scenario_index: &ScenarioIndex,
-        model: &Network,
-        state: &State,
+        ctx: GeneralParameterContext<'_>,
         internal_state: &mut Option<Box<dyn ParameterState>>,
     ) -> Result<Option<f64>, GeneralCalculationError> {
         // Downcast the internal state to the correct type
         let memory = downcast_internal_state_mut::<VecDeque<f64>>(internal_state);
 
         // Get today's value from the metric
-        let value = self.metric.get_value(model, state)?;
+        let value = self.metric.get_value(ctx.network, ctx.state)?;
         memory.push_back(value);
 
         // If the memory exceeds the window size, remove the oldest value
@@ -217,10 +211,7 @@ impl SimpleParameter<f64> for RollingParameter<SimpleMetricF64, f64, AggFuncF64>
 impl GeneralParameter<u64> for RollingParameter<MetricU64, u64, AggFuncU64> {
     fn before(
         &self,
-        _timestep: &Timestep,
-        _scenario_index: &ScenarioIndex,
-        _model: &Network,
-        _state: &State,
+        _ctx: GeneralParameterContext<'_>,
         internal_state: &mut Option<Box<dyn ParameterState>>,
     ) -> Result<Option<u64>, GeneralCalculationError> {
         // Downcast the internal state to the correct type
@@ -236,17 +227,14 @@ impl GeneralParameter<u64> for RollingParameter<MetricU64, u64, AggFuncU64> {
 
     fn after(
         &self,
-        _timestep: &Timestep,
-        _scenario_index: &ScenarioIndex,
-        model: &Network,
-        state: &State,
+        ctx: GeneralParameterContext<'_>,
         internal_state: &mut Option<Box<dyn ParameterState>>,
     ) -> Result<Option<u64>, GeneralCalculationError> {
         // Downcast the internal state to the correct type
         let memory = downcast_internal_state_mut::<VecDeque<u64>>(internal_state);
 
         // Get today's value from the metric
-        let value = self.metric.get_value(model, state)?;
+        let value = self.metric.get_value(ctx.network, ctx.state)?;
         memory.push_back(value);
 
         // If the memory exceeds the window size, remove the oldest value

--- a/pywr-core/src/parameters/rolling.rs
+++ b/pywr-core/src/parameters/rolling.rs
@@ -8,14 +8,15 @@ use crate::parameters::errors::{GeneralCalculationError, ParameterSetupError, Si
 use crate::parameters::{
     BuiltParameter, GeneralAfterParameterHook, GeneralBeforeParameter, GeneralParameter, GeneralParameterContext,
     GeneralParameterEntry, MaybeBuiltParameter, Parameter, ParameterBuildError, ParameterBuilder, ParameterMeta,
-    ParameterName, ParameterState, SimpleAfterParameterHook, SimpleBeforeParameter, SimpleParameter,
-    SimpleParameterContext, SimpleParameterEntry, downcast_internal_state_mut, downcast_internal_state_ref,
+    ParameterName, ParameterState, SimpleParameter, SimpleParameterContext, downcast_internal_state_mut,
+    downcast_internal_state_ref,
 };
 use crate::scenario::ScenarioIndex;
 use crate::timestep::Timestep;
 use crate::{resolve_metric_f64, resolve_metric_u64};
 use std::collections::VecDeque;
 use std::fmt::Debug;
+use std::ops::Deref;
 
 /// A rolling parameter that computes an aggregated value over a specified window of metric
 /// values.
@@ -153,51 +154,38 @@ impl GeneralAfterParameterHook<f64> for RollingParameter<MetricF64, f64, AggFunc
     }
 }
 
-impl SimpleParameter for RollingParameter<SimpleMetricF64, f64, AggFuncF64> {
-    fn as_parameter(&self) -> &dyn Parameter
-    where
-        Self: Sized,
-    {
-        self
-    }
-}
-
-impl SimpleBeforeParameter<f64> for RollingParameter<SimpleMetricF64, f64, AggFuncF64> {
-    fn before(
-        &self,
-        _ctx: SimpleParameterContext<'_>,
-        internal_state: &mut Option<Box<dyn ParameterState>>,
-    ) -> Result<f64, SimpleCalculationError> {
-        // Downcast the internal state to the correct type
-        let memory = downcast_internal_state_ref::<VecDeque<f64>>(internal_state);
-
-        if memory.len() < self.min_values {
-            // Not enough values collected yet, return the initial value
-            Ok(self.initial_value)
-        } else {
-            Ok(self.agg_func.calc_iter_f64(memory)?)
-        }
-    }
-}
-impl SimpleAfterParameterHook<f64> for RollingParameter<SimpleMetricF64, f64, AggFuncF64> {
-    fn after(
+impl SimpleParameter<f64> for RollingParameter<SimpleMetricF64, f64, AggFuncF64> {
+    fn compute(
         &self,
         ctx: SimpleParameterContext<'_>,
         internal_state: &mut Option<Box<dyn ParameterState>>,
-    ) -> Result<(), SimpleCalculationError> {
+    ) -> Result<f64, SimpleCalculationError> {
         // Downcast the internal state to the correct type
         let memory = downcast_internal_state_mut::<VecDeque<f64>>(internal_state);
 
+        let value = if memory.len() < self.min_values {
+            // Not enough values collected yet, return the initial value
+            self.initial_value
+        } else {
+            self.agg_func.calc_iter_f64(memory.deref())?
+        };
+
         // Get today's value from the metric
-        let value = self.metric.get_value(ctx.values)?;
-        memory.push_back(value);
+        let todays_value = self.metric.get_value(ctx.values)?;
+        memory.push_back(todays_value);
 
         // If the memory exceeds the window size, remove the oldest value
         if memory.len() > self.window_size {
             memory.pop_front();
         }
 
-        Ok(())
+        Ok(value)
+    }
+    fn as_parameter(&self) -> &dyn Parameter
+    where
+        Self: Sized,
+    {
+        self
     }
 }
 
@@ -249,51 +237,38 @@ impl GeneralAfterParameterHook<u64> for RollingParameter<MetricU64, u64, AggFunc
     }
 }
 
-impl SimpleParameter for RollingParameter<SimpleMetricU64, u64, AggFuncU64> {
-    fn as_parameter(&self) -> &dyn Parameter
-    where
-        Self: Sized,
-    {
-        self
-    }
-}
-
-impl SimpleBeforeParameter<u64> for RollingParameter<SimpleMetricU64, u64, AggFuncU64> {
-    fn before(
-        &self,
-        _ctx: SimpleParameterContext<'_>,
-        internal_state: &mut Option<Box<dyn ParameterState>>,
-    ) -> Result<u64, SimpleCalculationError> {
-        // Downcast the internal state to the correct type
-        let memory = downcast_internal_state_ref::<VecDeque<u64>>(internal_state);
-
-        if memory.len() < self.min_values {
-            // Not enough values collected yet, return the initial value
-            Ok(self.initial_value)
-        } else {
-            Ok(self.agg_func.calc_iter_u64(memory.iter())?)
-        }
-    }
-}
-impl SimpleAfterParameterHook<u64> for RollingParameter<SimpleMetricU64, u64, AggFuncU64> {
-    fn after(
+impl SimpleParameter<u64> for RollingParameter<SimpleMetricU64, u64, AggFuncU64> {
+    fn compute(
         &self,
         ctx: SimpleParameterContext<'_>,
         internal_state: &mut Option<Box<dyn ParameterState>>,
-    ) -> Result<(), SimpleCalculationError> {
+    ) -> Result<u64, SimpleCalculationError> {
         // Downcast the internal state to the correct type
         let memory = downcast_internal_state_mut::<VecDeque<u64>>(internal_state);
 
+        let value = if memory.len() < self.min_values {
+            // Not enough values collected yet, return the initial value
+            self.initial_value
+        } else {
+            self.agg_func.calc_iter_u64(memory.iter())?
+        };
+
         // Get today's value from the metric
-        let value = self.metric.get_value(ctx.values)?;
-        memory.push_back(value);
+        let todays_value = self.metric.get_value(ctx.values)?;
+        memory.push_back(todays_value);
 
         // If the memory exceeds the window size, remove the oldest value
         if memory.len() > self.window_size {
             memory.pop_front();
         }
 
-        Ok(())
+        Ok(value)
+    }
+    fn as_parameter(&self) -> &dyn Parameter
+    where
+        Self: Sized,
+    {
+        self
     }
 }
 
@@ -358,7 +333,7 @@ impl ParameterBuilder<f64> for RollingParameterBuilder<UnresolvedMetricF64, f64,
                 agg_func: self.agg_func,
             };
 
-            let bp = BuiltParameter::Simple(SimpleParameterEntry::before_with_after_hook(p));
+            let bp = BuiltParameter::Simple(Box::new(p));
             return Ok(MaybeBuiltParameter::Built(bp));
         }
 
@@ -398,7 +373,7 @@ impl ParameterBuilder<u64> for RollingParameterBuilder<UnresolvedMetricU64, u64,
                 agg_func: self.agg_func,
             };
 
-            let bp = BuiltParameter::Simple(SimpleParameterEntry::before_with_after_hook(p));
+            let bp = BuiltParameter::Simple(Box::new(p));
             return Ok(MaybeBuiltParameter::Built(bp));
         }
 

--- a/pywr-core/src/parameters/threshold.rs
+++ b/pywr-core/src/parameters/threshold.rs
@@ -3,8 +3,9 @@ use crate::metric::{MetricF64, UnresolvedMetricF64};
 use crate::network::ResolutionMaps;
 use crate::parameters::errors::{GeneralCalculationError, ParameterSetupError};
 use crate::parameters::{
-    BuiltParameter, GeneralParameter, GeneralParameterContext, MaybeBuiltParameter, Parameter, ParameterBuildError,
-    ParameterBuilder, ParameterMeta, ParameterName, ParameterState, downcast_internal_state_mut,
+    BuiltParameter, GeneralBeforeParameter, GeneralParameter, GeneralParameterContext, GeneralParameterEntry,
+    MaybeBuiltParameter, Parameter, ParameterBuildError, ParameterBuilder, ParameterMeta, ParameterName,
+    ParameterState, downcast_internal_state_mut,
 };
 use crate::resolve_metric_f64;
 use crate::scenario::ScenarioIndex;
@@ -61,18 +62,27 @@ impl Parameter for ThresholdParameter {
     }
 }
 
-impl GeneralParameter<u64> for ThresholdParameter {
+impl GeneralParameter for ThresholdParameter {
+    fn as_parameter(&self) -> &dyn Parameter
+    where
+        Self: Sized,
+    {
+        self
+    }
+}
+
+impl GeneralBeforeParameter<u64> for ThresholdParameter {
     fn before(
         &self,
         ctx: GeneralParameterContext<'_>,
         internal_state: &mut Option<Box<dyn ParameterState>>,
-    ) -> Result<Option<u64>, GeneralCalculationError> {
+    ) -> Result<u64, GeneralCalculationError> {
         // Downcast the internal state to the correct type
         let previously_activated = downcast_internal_state_mut::<bool>(internal_state);
 
         // Return early if ratchet has been hit
         if self.ratchet & *previously_activated {
-            return Ok(Some(1));
+            return Ok(1);
         }
 
         let threshold = self.threshold.get_value(ctx.network, ctx.state)?;
@@ -82,17 +92,10 @@ impl GeneralParameter<u64> for ThresholdParameter {
         if active {
             // Update the internal state to remember we've been triggered!
             *previously_activated = true;
-            Ok(Some(1))
+            Ok(1)
         } else {
-            Ok(Some(0))
+            Ok(0)
         }
-    }
-
-    fn as_parameter(&self) -> &dyn Parameter
-    where
-        Self: Sized,
-    {
-        self
     }
 }
 
@@ -148,6 +151,6 @@ impl ParameterBuilder<u64> for ThresholdParameterBuilder {
             ratchet: self.ratchet,
         };
 
-        Ok(MaybeBuiltParameter::Built(BuiltParameter::General(Box::new(p))))
+        Ok(BuiltParameter::General(GeneralParameterEntry::before(p)).into())
     }
 }

--- a/pywr-core/src/parameters/threshold.rs
+++ b/pywr-core/src/parameters/threshold.rs
@@ -1,14 +1,13 @@
 use crate::FLOAT_EQ_TOLERANCE;
 use crate::metric::{MetricF64, UnresolvedMetricF64};
-use crate::network::{Network, ResolutionMaps};
+use crate::network::ResolutionMaps;
 use crate::parameters::errors::{GeneralCalculationError, ParameterSetupError};
 use crate::parameters::{
-    BuiltParameter, GeneralParameter, MaybeBuiltParameter, Parameter, ParameterBuildError, ParameterBuilder,
-    ParameterMeta, ParameterName, ParameterState, downcast_internal_state_mut,
+    BuiltParameter, GeneralParameter, GeneralParameterContext, MaybeBuiltParameter, Parameter, ParameterBuildError,
+    ParameterBuilder, ParameterMeta, ParameterName, ParameterState, downcast_internal_state_mut,
 };
 use crate::resolve_metric_f64;
 use crate::scenario::ScenarioIndex;
-use crate::state::State;
 use crate::timestep::Timestep;
 
 #[derive(Debug)]
@@ -65,10 +64,7 @@ impl Parameter for ThresholdParameter {
 impl GeneralParameter<u64> for ThresholdParameter {
     fn before(
         &self,
-        _timestep: &Timestep,
-        _scenario_index: &ScenarioIndex,
-        model: &Network,
-        state: &State,
+        ctx: GeneralParameterContext<'_>,
         internal_state: &mut Option<Box<dyn ParameterState>>,
     ) -> Result<Option<u64>, GeneralCalculationError> {
         // Downcast the internal state to the correct type
@@ -79,8 +75,8 @@ impl GeneralParameter<u64> for ThresholdParameter {
             return Ok(Some(1));
         }
 
-        let threshold = self.threshold.get_value(model, state)?;
-        let value = self.metric.get_value(model, state)?;
+        let threshold = self.threshold.get_value(ctx.network, ctx.state)?;
+        let value = self.metric.get_value(ctx.network, ctx.state)?;
         let active = self.predicate.apply(value, threshold);
 
         if active {

--- a/pywr-core/src/parameters/vector.rs
+++ b/pywr-core/src/parameters/vector.rs
@@ -1,8 +1,9 @@
 use crate::network::ResolutionMaps;
 use crate::parameters::errors::GeneralCalculationError;
 use crate::parameters::{
-    BuiltParameter, GeneralParameter, GeneralParameterContext, MaybeBuiltParameter, Parameter, ParameterBuildError,
-    ParameterBuilder, ParameterMeta, ParameterName, ParameterState,
+    BuiltParameter, GeneralBeforeParameter, GeneralParameter, GeneralParameterContext, GeneralParameterEntry,
+    MaybeBuiltParameter, Parameter, ParameterBuildError, ParameterBuilder, ParameterMeta, ParameterName,
+    ParameterState,
 };
 
 #[derive(Debug)]
@@ -17,27 +18,29 @@ impl Parameter for VectorParameter {
     }
 }
 
-impl GeneralParameter<f64> for VectorParameter {
+impl GeneralParameter for VectorParameter {
+    fn as_parameter(&self) -> &dyn Parameter
+    where
+        Self: Sized,
+    {
+        self
+    }
+}
+
+impl GeneralBeforeParameter<f64> for VectorParameter {
     fn before(
         &self,
         ctx: GeneralParameterContext<'_>,
         _internal_state: &mut Option<Box<dyn ParameterState>>,
-    ) -> Result<Option<f64>, GeneralCalculationError> {
+    ) -> Result<f64, GeneralCalculationError> {
         match self.values.get(ctx.timestep.index) {
-            Some(v) => Ok(Some(*v)),
+            Some(v) => Ok(*v),
             None => Err(GeneralCalculationError::OutOfBoundsError {
                 index: ctx.timestep.index,
                 length: self.values.len(),
                 axis: 0,
             }),
         }
-    }
-
-    fn as_parameter(&self) -> &dyn Parameter
-    where
-        Self: Sized,
-    {
-        self
     }
 }
 
@@ -70,7 +73,7 @@ impl ParameterBuilder<f64> for VectorParameterBuilder {
             values: self.values,
         };
 
-        let bp = BuiltParameter::General(Box::new(p));
+        let bp = BuiltParameter::General(GeneralParameterEntry::before(p));
         Ok(bp.into())
     }
 }

--- a/pywr-core/src/parameters/vector.rs
+++ b/pywr-core/src/parameters/vector.rs
@@ -1,12 +1,9 @@
-use crate::network::{Network, ResolutionMaps};
+use crate::network::ResolutionMaps;
 use crate::parameters::errors::GeneralCalculationError;
 use crate::parameters::{
-    BuiltParameter, GeneralParameter, MaybeBuiltParameter, Parameter, ParameterBuildError, ParameterBuilder,
-    ParameterMeta, ParameterName, ParameterState,
+    BuiltParameter, GeneralParameter, GeneralParameterContext, MaybeBuiltParameter, Parameter, ParameterBuildError,
+    ParameterBuilder, ParameterMeta, ParameterName, ParameterState,
 };
-use crate::scenario::ScenarioIndex;
-use crate::state::State;
-use crate::timestep::Timestep;
 
 #[derive(Debug)]
 pub struct VectorParameter {
@@ -23,16 +20,13 @@ impl Parameter for VectorParameter {
 impl GeneralParameter<f64> for VectorParameter {
     fn before(
         &self,
-        timestep: &Timestep,
-        _scenario_index: &ScenarioIndex,
-        _model: &Network,
-        _state: &State,
+        ctx: GeneralParameterContext<'_>,
         _internal_state: &mut Option<Box<dyn ParameterState>>,
     ) -> Result<Option<f64>, GeneralCalculationError> {
-        match self.values.get(timestep.index) {
+        match self.values.get(ctx.timestep.index) {
             Some(v) => Ok(Some(*v)),
             None => Err(GeneralCalculationError::OutOfBoundsError {
-                index: timestep.index,
+                index: ctx.timestep.index,
                 length: self.values.len(),
                 axis: 0,
             }),

--- a/pywr-core/src/state/mod.rs
+++ b/pywr-core/src/state/mod.rs
@@ -242,41 +242,41 @@ impl MultiValue {
 /// Values from parameters
 #[derive(Debug, Clone)]
 struct ParameterValues {
-    values: Vec<Option<f64>>,
-    indices: Vec<Option<u64>>,
-    multi_values: Vec<Option<MultiValue>>,
+    values: Vec<f64>,
+    indices: Vec<u64>,
+    multi_values: Vec<MultiValue>,
 }
 
 impl ParameterValues {
     fn new(num_values: usize, num_indices: usize, num_multi_values: usize) -> Self {
         Self {
-            values: vec![None; num_values],
-            indices: vec![None; num_indices],
-            multi_values: vec![None; num_multi_values],
+            values: vec![0.0; num_values],
+            indices: vec![0; num_indices],
+            multi_values: vec![MultiValue::default(); num_multi_values],
         }
     }
 
     fn get_value(&self, idx: usize) -> Option<f64> {
-        self.values.get(idx).copied().flatten()
+        self.values.get(idx).copied()
     }
 
-    fn get_value_mut(&mut self, idx: usize) -> Option<&mut Option<f64>> {
+    fn get_value_mut(&mut self, idx: usize) -> Option<&mut f64> {
         self.values.get_mut(idx)
     }
 
     fn get_index(&self, idx: usize) -> Option<u64> {
-        self.indices.get(idx).copied().flatten()
+        self.indices.get(idx).copied()
     }
 
-    fn get_index_mut(&mut self, idx: usize) -> Option<&mut Option<u64>> {
+    fn get_index_mut(&mut self, idx: usize) -> Option<&mut u64> {
         self.indices.get_mut(idx)
     }
 
     fn get_multi_value(&self, idx: usize) -> Option<&MultiValue> {
-        self.multi_values.get(idx).and_then(|s| s.as_ref())
+        self.multi_values.get(idx)
     }
 
-    fn get_multi_value_mut(&mut self, idx: usize) -> Option<&mut Option<MultiValue>> {
+    fn get_multi_value_mut(&mut self, idx: usize) -> Option<&mut MultiValue> {
         self.multi_values.get_mut(idx)
     }
 }
@@ -305,34 +305,28 @@ impl ParameterValuesCollection {
 
 #[derive(Default)]
 pub struct ParameterValuesRef<'a> {
-    values: &'a [Option<f64>],
-    indices: &'a [Option<u64>],
-    multi_values: &'a [Option<MultiValue>],
+    values: &'a [f64],
+    indices: &'a [u64],
+    multi_values: &'a [MultiValue],
 }
 
 impl ParameterValuesRef<'_> {
     /// Get the value at the given index.
     fn get_value(&self, idx: usize) -> Option<f64> {
-        self.values.get(idx).copied().flatten()
+        self.values.get(idx).copied()
     }
 
     /// Get the index at the given index.
     fn get_index(&self, idx: usize) -> Option<u64> {
-        self.indices.get(idx).copied().flatten()
+        self.indices.get(idx).copied()
     }
 
     fn get_multi_value(&self, idx: usize, key: &str) -> Option<f64> {
-        self.multi_values
-            .get(idx)
-            .and_then(|s| s.as_ref().map(|mv| mv.get_value(key).copied()))
-            .flatten()
+        self.multi_values.get(idx).and_then(|mv| mv.get_value(key).copied())
     }
 
     fn get_multi_index(&self, idx: usize, key: &str) -> Option<u64> {
-        self.multi_values
-            .get(idx)
-            .and_then(|s| s.as_ref().map(|mv| mv.get_index(key).copied()))
-            .flatten()
+        self.multi_values.get(idx).and_then(|mv| mv.get_index(key).copied())
     }
 }
 
@@ -808,7 +802,7 @@ impl State {
     pub fn set_general_parameter_value_before(
         &mut self,
         idx: GeneralParameterIndex<f64>,
-        value: Option<f64>,
+        value: f64,
     ) -> Result<(), SetStateError<GeneralParameterIndex<f64>>> {
         let v = self
             .parameters_before
@@ -816,7 +810,7 @@ impl State {
             .get_value_mut(*idx)
             .ok_or(SetStateError::IndexNotFound(idx))?;
 
-        if value.is_some_and(|v| v.is_nan()) {
+        if value.is_nan() {
             return Err(SetStateError::NaNValue(idx));
         }
 
@@ -829,7 +823,7 @@ impl State {
     pub fn set_general_parameter_value_after(
         &mut self,
         idx: GeneralParameterIndex<f64>,
-        value: Option<f64>,
+        value: f64,
     ) -> Result<(), SetStateError<GeneralParameterIndex<f64>>> {
         let v = self
             .parameters_after
@@ -837,7 +831,7 @@ impl State {
             .get_value_mut(*idx)
             .ok_or(SetStateError::IndexNotFound(idx))?;
 
-        if value.is_some_and(|v| v.is_nan()) {
+        if value.is_nan() {
             return Err(SetStateError::NaNValue(idx));
         }
 
@@ -849,7 +843,7 @@ impl State {
     pub fn set_simple_parameter_value_before(
         &mut self,
         idx: SimpleParameterIndex<f64>,
-        value: Option<f64>,
+        value: f64,
     ) -> Result<(), SetStateError<SimpleParameterIndex<f64>>> {
         let v = self
             .parameters_before
@@ -857,7 +851,27 @@ impl State {
             .get_value_mut(*idx)
             .ok_or(SetStateError::IndexNotFound(idx))?;
 
-        if value.is_some_and(|v| v.is_nan()) {
+        if value.is_nan() {
+            return Err(SetStateError::NaNValue(idx));
+        }
+
+        *v = value;
+
+        Ok(())
+    }
+
+    pub fn set_simple_parameter_value_after(
+        &mut self,
+        idx: SimpleParameterIndex<f64>,
+        value: f64,
+    ) -> Result<(), SetStateError<SimpleParameterIndex<f64>>> {
+        let v = self
+            .parameters_after
+            .simple
+            .get_value_mut(*idx)
+            .ok_or(SetStateError::IndexNotFound(idx))?;
+
+        if value.is_nan() {
             return Err(SetStateError::NaNValue(idx));
         }
 
@@ -880,7 +894,7 @@ impl State {
             return Err(SetStateError::NaNValue(idx));
         }
 
-        *v = Some(value);
+        *v = value;
 
         Ok(())
     }
@@ -921,7 +935,7 @@ impl State {
     pub fn set_general_parameter_index_before(
         &mut self,
         idx: GeneralParameterIndex<u64>,
-        value: Option<u64>,
+        value: u64,
     ) -> Result<(), SetStateError<GeneralParameterIndex<u64>>> {
         let v = self
             .parameters_before
@@ -937,7 +951,7 @@ impl State {
     pub fn set_general_parameter_index_after(
         &mut self,
         idx: GeneralParameterIndex<u64>,
-        value: Option<u64>,
+        value: u64,
     ) -> Result<(), SetStateError<GeneralParameterIndex<u64>>> {
         let v = self
             .parameters_after
@@ -953,7 +967,7 @@ impl State {
     pub fn set_simple_parameter_index_before(
         &mut self,
         idx: SimpleParameterIndex<u64>,
-        value: Option<u64>,
+        value: u64,
     ) -> Result<(), SetStateError<SimpleParameterIndex<u64>>> {
         let v = self
             .parameters_before
@@ -969,7 +983,7 @@ impl State {
     pub fn set_simple_parameter_index_after(
         &mut self,
         idx: SimpleParameterIndex<u64>,
-        value: Option<u64>,
+        value: u64,
     ) -> Result<(), SetStateError<SimpleParameterIndex<u64>>> {
         let v = self
             .parameters_after
@@ -992,7 +1006,7 @@ impl State {
             .get_index_mut(*idx)
             .ok_or(SetStateError::IndexNotFound(idx))?;
 
-        *v = Some(value);
+        *v = value;
 
         Ok(())
     }
@@ -1115,7 +1129,7 @@ impl State {
     pub fn set_general_multi_parameter_value_before(
         &mut self,
         idx: GeneralParameterIndex<MultiValue>,
-        value: Option<MultiValue>,
+        value: MultiValue,
     ) -> Result<(), SetStateError<GeneralParameterIndex<MultiValue>>> {
         let mv = self
             .parameters_before
@@ -1123,7 +1137,7 @@ impl State {
             .get_multi_value_mut(*idx)
             .ok_or(SetStateError::IndexNotFound(idx))?;
 
-        if value.as_ref().is_some_and(|mv| mv.has_nan()) {
+        if value.has_nan() {
             return Err(SetStateError::NaNValue(idx));
         }
 
@@ -1135,7 +1149,7 @@ impl State {
     pub fn set_general_multi_parameter_value_after(
         &mut self,
         idx: GeneralParameterIndex<MultiValue>,
-        value: Option<MultiValue>,
+        value: MultiValue,
     ) -> Result<(), SetStateError<GeneralParameterIndex<MultiValue>>> {
         let mv = self
             .parameters_after
@@ -1143,7 +1157,7 @@ impl State {
             .get_multi_value_mut(*idx)
             .ok_or(SetStateError::IndexNotFound(idx))?;
 
-        if value.as_ref().is_some_and(|mv| mv.has_nan()) {
+        if value.has_nan() {
             return Err(SetStateError::NaNValue(idx));
         }
 
@@ -1155,7 +1169,7 @@ impl State {
     pub fn set_simple_multi_parameter_value_before(
         &mut self,
         idx: SimpleParameterIndex<MultiValue>,
-        value: Option<MultiValue>,
+        value: MultiValue,
     ) -> Result<(), SetStateError<SimpleParameterIndex<MultiValue>>> {
         let mv = self
             .parameters_before
@@ -1163,7 +1177,7 @@ impl State {
             .get_multi_value_mut(*idx)
             .ok_or(SetStateError::IndexNotFound(idx))?;
 
-        if value.as_ref().is_some_and(|mv| mv.has_nan()) {
+        if value.has_nan() {
             return Err(SetStateError::NaNValue(idx));
         }
 
@@ -1175,7 +1189,7 @@ impl State {
     pub fn set_simple_multi_parameter_value_after(
         &mut self,
         idx: SimpleParameterIndex<MultiValue>,
-        value: Option<MultiValue>,
+        value: MultiValue,
     ) -> Result<(), SetStateError<SimpleParameterIndex<MultiValue>>> {
         let mv = self
             .parameters_after
@@ -1183,7 +1197,7 @@ impl State {
             .get_multi_value_mut(*idx)
             .ok_or(SetStateError::IndexNotFound(idx))?;
 
-        if value.as_ref().is_some_and(|mv| mv.has_nan()) {
+        if value.has_nan() {
             return Err(SetStateError::NaNValue(idx));
         }
 
@@ -1206,7 +1220,7 @@ impl State {
             return Err(SetStateError::NaNValue(idx));
         }
 
-        *mv = Some(value);
+        *mv = value;
 
         Ok(())
     }

--- a/pywr-core/src/state/mod.rs
+++ b/pywr-core/src/state/mod.rs
@@ -288,17 +288,11 @@ pub struct ParameterValuesCollection {
 }
 
 impl ParameterValuesCollection {
-    fn get_simple_parameter_values<'a>(
-        &'a self,
-        constant_parameter_values: ConstParameterValues<'a>,
-    ) -> SimpleParameterValues<'a> {
-        SimpleParameterValues {
-            constant: constant_parameter_values,
-            simple: ParameterValuesRef {
-                values: &self.simple.values,
-                indices: &self.simple.indices,
-                multi_values: &self.simple.multi_values,
-            },
+    fn get_simple_parameter_values(&self) -> ParameterValuesRef<'_> {
+        ParameterValuesRef {
+            values: &self.simple.values,
+            indices: &self.simple.indices,
+            multi_values: &self.simple.multi_values,
         }
     }
 }
@@ -321,35 +315,205 @@ impl ParameterValuesRef<'_> {
         self.indices.get(idx).copied()
     }
 
-    fn get_multi_value(&self, idx: usize, key: &str) -> Option<f64> {
-        self.multi_values.get(idx).and_then(|mv| mv.get_value(key).copied())
+    fn get_multi_value(&self, idx: usize) -> Option<&MultiValue> {
+        self.multi_values.get(idx)
     }
+}
 
-    fn get_multi_index(&self, idx: usize, key: &str) -> Option<u64> {
-        self.multi_values.get(idx).and_then(|mv| mv.get_index(key).copied())
-    }
+#[derive(Error, Debug)]
+pub enum SimpleParameterValuesError {
+    #[error("Simple parameter index not found: {0}")]
+    SimpleParameterIndexNotFound(SimpleParameterIndex<f64>),
+    #[error("Simple index parameter index not found: {0}")]
+    SimpleIndexParameterIndexNotFound(SimpleParameterIndex<u64>),
+    #[error("Simple parameter index not found: {0}")]
+    SimpleMultiValueParameterIndexNotFound(SimpleParameterIndex<MultiValue>),
+    #[error("Simple parameter with index {index} has no key: {key}")]
+    SimpleMultiValueParameterKeyNotFound {
+        index: SimpleParameterIndex<MultiValue>,
+        key: String,
+    },
 }
 
 pub struct SimpleParameterValues<'a> {
     constant: ConstParameterValues<'a>,
-    simple: ParameterValuesRef<'a>,
+    before: ParameterValuesRef<'a>,
+    after: ParameterValuesRef<'a>,
 }
 
 impl SimpleParameterValues<'_> {
-    pub fn get_simple_parameter_f64(&self, idx: SimpleParameterIndex<f64>) -> Option<f64> {
-        self.simple.get_value(*idx.deref())
+    pub fn get_f64(
+        &self,
+        idx: SimpleParameterIndex<f64>,
+        return_value: ParameterReturnValue,
+    ) -> Result<f64, SimpleParameterValuesError> {
+        match return_value {
+            ParameterReturnValue::Before => self.get_f64_before(idx),
+            ParameterReturnValue::After => self.get_f64_after(idx),
+            ParameterReturnValue::BeforeOrElseAfter => match self.get_f64_before(idx) {
+                Ok(v) => Ok(v),
+                Err(_) => self.get_f64_after(idx),
+            },
+            ParameterReturnValue::AfterOrElseBefore => match self.get_f64_after(idx) {
+                Ok(v) => Ok(v),
+                Err(_) => self.get_f64_before(idx),
+            },
+        }
     }
 
-    pub fn get_simple_parameter_u64(&self, idx: SimpleParameterIndex<u64>) -> Option<u64> {
-        self.simple.get_index(*idx.deref())
+    fn get_f64_before(&self, idx: SimpleParameterIndex<f64>) -> Result<f64, SimpleParameterValuesError> {
+        self.before
+            .get_value(*idx.deref())
+            .ok_or(SimpleParameterValuesError::SimpleParameterIndexNotFound(idx))
     }
 
-    pub fn get_simple_multi_parameter_f64(&self, idx: SimpleParameterIndex<MultiValue>, key: &str) -> Option<f64> {
-        self.simple.get_multi_value(*idx.deref(), key)
+    fn get_f64_after(&self, idx: SimpleParameterIndex<f64>) -> Result<f64, SimpleParameterValuesError> {
+        self.after
+            .get_value(*idx.deref())
+            .ok_or(SimpleParameterValuesError::SimpleParameterIndexNotFound(idx))
     }
 
-    pub fn get_simple_multi_parameter_u64(&self, idx: SimpleParameterIndex<MultiValue>, key: &str) -> Option<u64> {
-        self.simple.get_multi_index(*idx.deref(), key)
+    pub fn get_u64(
+        &self,
+        idx: SimpleParameterIndex<u64>,
+        return_value: ParameterReturnValue,
+    ) -> Result<u64, SimpleParameterValuesError> {
+        match return_value {
+            ParameterReturnValue::Before => self.get_u64_before(idx),
+            ParameterReturnValue::After => self.get_u64_after(idx),
+            ParameterReturnValue::BeforeOrElseAfter => match self.get_u64_before(idx) {
+                Ok(v) => Ok(v),
+                Err(_) => self.get_u64_after(idx),
+            },
+            ParameterReturnValue::AfterOrElseBefore => match self.get_u64_after(idx) {
+                Ok(v) => Ok(v),
+                Err(_) => self.get_u64_before(idx),
+            },
+        }
+    }
+
+    fn get_u64_before(&self, idx: SimpleParameterIndex<u64>) -> Result<u64, SimpleParameterValuesError> {
+        self.before
+            .get_index(*idx.deref())
+            .ok_or(SimpleParameterValuesError::SimpleIndexParameterIndexNotFound(idx))
+    }
+
+    fn get_u64_after(&self, idx: SimpleParameterIndex<u64>) -> Result<u64, SimpleParameterValuesError> {
+        self.after
+            .get_index(*idx.deref())
+            .ok_or(SimpleParameterValuesError::SimpleIndexParameterIndexNotFound(idx))
+    }
+
+    pub fn get_multi_f64(
+        &self,
+        idx: SimpleParameterIndex<MultiValue>,
+        key: &str,
+        return_value: ParameterReturnValue,
+    ) -> Result<f64, SimpleParameterValuesError> {
+        match return_value {
+            ParameterReturnValue::Before => self.get_multi_f64_before(idx, key),
+            ParameterReturnValue::After => self.get_multi_f64_after(idx, key),
+            ParameterReturnValue::BeforeOrElseAfter => match self.get_multi_f64_before(idx, key) {
+                Ok(v) => Ok(v),
+                Err(_) => self.get_multi_f64_after(idx, key),
+            },
+            ParameterReturnValue::AfterOrElseBefore => match self.get_multi_f64_after(idx, key) {
+                Ok(v) => Ok(v),
+                Err(_) => self.get_multi_f64_before(idx, key),
+            },
+        }
+    }
+
+    fn get_multi_f64_before(
+        &self,
+        idx: SimpleParameterIndex<MultiValue>,
+        key: &str,
+    ) -> Result<f64, SimpleParameterValuesError> {
+        let mv = self
+            .before
+            .get_multi_value(*idx.deref())
+            .ok_or(SimpleParameterValuesError::SimpleMultiValueParameterIndexNotFound(idx))?;
+
+        mv.get_value(key)
+            .ok_or_else(|| SimpleParameterValuesError::SimpleMultiValueParameterKeyNotFound {
+                index: idx,
+                key: key.to_string(),
+            })
+            .copied()
+    }
+
+    fn get_multi_f64_after(
+        &self,
+        idx: SimpleParameterIndex<MultiValue>,
+        key: &str,
+    ) -> Result<f64, SimpleParameterValuesError> {
+        let mv = self
+            .after
+            .get_multi_value(*idx.deref())
+            .ok_or(SimpleParameterValuesError::SimpleMultiValueParameterIndexNotFound(idx))?;
+
+        mv.get_value(key)
+            .ok_or_else(|| SimpleParameterValuesError::SimpleMultiValueParameterKeyNotFound {
+                index: idx,
+                key: key.to_string(),
+            })
+            .copied()
+    }
+
+    pub fn get_multi_u64(
+        &self,
+        idx: SimpleParameterIndex<MultiValue>,
+        key: &str,
+        return_value: ParameterReturnValue,
+    ) -> Result<u64, SimpleParameterValuesError> {
+        match return_value {
+            ParameterReturnValue::Before => self.get_multi_u64_before(idx, key),
+            ParameterReturnValue::After => self.get_multi_u64_after(idx, key),
+            ParameterReturnValue::BeforeOrElseAfter => match self.get_multi_u64_before(idx, key) {
+                Ok(v) => Ok(v),
+                Err(_) => self.get_multi_u64_after(idx, key),
+            },
+            ParameterReturnValue::AfterOrElseBefore => match self.get_multi_u64_after(idx, key) {
+                Ok(v) => Ok(v),
+                Err(_) => self.get_multi_u64_before(idx, key),
+            },
+        }
+    }
+
+    fn get_multi_u64_before(
+        &self,
+        idx: SimpleParameterIndex<MultiValue>,
+        key: &str,
+    ) -> Result<u64, SimpleParameterValuesError> {
+        let mv = self
+            .before
+            .get_multi_value(*idx.deref())
+            .ok_or(SimpleParameterValuesError::SimpleMultiValueParameterIndexNotFound(idx))?;
+
+        mv.get_index(key)
+            .ok_or_else(|| SimpleParameterValuesError::SimpleMultiValueParameterKeyNotFound {
+                index: idx,
+                key: key.to_string(),
+            })
+            .copied()
+    }
+
+    fn get_multi_u64_after(
+        &self,
+        idx: SimpleParameterIndex<MultiValue>,
+        key: &str,
+    ) -> Result<u64, SimpleParameterValuesError> {
+        let mv = self
+            .after
+            .get_multi_value(*idx.deref())
+            .ok_or(SimpleParameterValuesError::SimpleMultiValueParameterIndexNotFound(idx))?;
+
+        mv.get_index(key)
+            .ok_or_else(|| SimpleParameterValuesError::SimpleMultiValueParameterKeyNotFound {
+                index: idx,
+                key: key.to_string(),
+            })
+            .copied()
     }
 
     pub fn get_constant_values(&self) -> &ConstParameterValues<'_> {
@@ -357,26 +521,72 @@ impl SimpleParameterValues<'_> {
     }
 }
 
+#[derive(Error, Debug)]
+pub enum ConstParameterValuesError {
+    #[error("Constant parameter index not found: {0}")]
+    ConstParameterIndexNotFound(ConstParameterIndex<f64>),
+    #[error("Constant index parameter index not found: {0}")]
+    ConstIndexParameterIndexNotFound(ConstParameterIndex<u64>),
+    #[error("Constant parameter index not found: {0}")]
+    ConstMultiValueParameterIndexNotFound(ConstParameterIndex<MultiValue>),
+    #[error("Constant parameter with index {index} has no key: {key}")]
+    ConstMultiValueParameterKeyNotFound {
+        index: ConstParameterIndex<MultiValue>,
+        key: String,
+    },
+}
 #[derive(Default)]
 pub struct ConstParameterValues<'a> {
     constant: ParameterValuesRef<'a>,
 }
 
 impl ConstParameterValues<'_> {
-    pub fn get_const_parameter_f64(&self, idx: ConstParameterIndex<f64>) -> Option<f64> {
-        self.constant.get_value(*idx.deref())
+    pub fn get_f64(&self, idx: ConstParameterIndex<f64>) -> Result<f64, ConstParameterValuesError> {
+        self.constant
+            .get_value(*idx.deref())
+            .ok_or(ConstParameterValuesError::ConstParameterIndexNotFound(idx))
     }
 
-    pub fn get_const_parameter_u64(&self, idx: ConstParameterIndex<u64>) -> Option<u64> {
-        self.constant.get_index(*idx.deref())
+    pub fn get_u64(&self, idx: ConstParameterIndex<u64>) -> Result<u64, ConstParameterValuesError> {
+        self.constant
+            .get_index(*idx.deref())
+            .ok_or(ConstParameterValuesError::ConstIndexParameterIndexNotFound(idx))
     }
 
-    pub fn get_const_multi_parameter_f64(&self, idx: ConstParameterIndex<MultiValue>, key: &str) -> Option<f64> {
-        self.constant.get_multi_value(*idx.deref(), key)
+    pub fn get_multi_f64(
+        &self,
+        idx: ConstParameterIndex<MultiValue>,
+        key: &str,
+    ) -> Result<f64, ConstParameterValuesError> {
+        let mv = self
+            .constant
+            .get_multi_value(*idx.deref())
+            .ok_or(ConstParameterValuesError::ConstMultiValueParameterIndexNotFound(idx))?;
+
+        mv.get_value(key)
+            .ok_or_else(|| ConstParameterValuesError::ConstMultiValueParameterKeyNotFound {
+                index: idx,
+                key: key.to_string(),
+            })
+            .copied()
     }
 
-    pub fn get_const_multi_parameter_u64(&self, idx: ConstParameterIndex<MultiValue>, key: &str) -> Option<u64> {
-        self.constant.get_multi_index(*idx.deref(), key)
+    pub fn get_multi_u64(
+        &self,
+        idx: ConstParameterIndex<MultiValue>,
+        key: &str,
+    ) -> Result<u64, ConstParameterValuesError> {
+        let mv = self
+            .constant
+            .get_multi_value(*idx.deref())
+            .ok_or(ConstParameterValuesError::ConstMultiValueParameterIndexNotFound(idx))?;
+
+        mv.get_index(key)
+            .ok_or_else(|| ConstParameterValuesError::ConstMultiValueParameterKeyNotFound {
+                index: idx,
+                key: key.to_string(),
+            })
+            .copied()
     }
 }
 
@@ -686,28 +896,7 @@ pub enum StateError {
         index: GeneralParameterIndex<MultiValue>,
         key: String,
     },
-    #[error("Simple parameter index not found: {0}")]
-    SimpleParameterIndexNotFound(SimpleParameterIndex<f64>),
-    #[error("Simple index parameter index not found: {0}")]
-    SimpleIndexParameterIndexNotFound(SimpleParameterIndex<u64>),
-    #[error("Simple parameter index not found: {0}")]
-    SimpleMultiValueParameterIndexNotFound(SimpleParameterIndex<MultiValue>),
-    #[error("Simple parameter with index {index} has no key: {key}")]
-    SimpleMultiValueParameterKeyNotFound {
-        index: SimpleParameterIndex<MultiValue>,
-        key: String,
-    },
-    #[error("Constant parameter index not found: {0}")]
-    ConstParameterIndexNotFound(ConstParameterIndex<f64>),
-    #[error("Constant index parameter index not found: {0}")]
-    ConstIndexParameterIndexNotFound(ConstParameterIndex<u64>),
-    #[error("Constant parameter index not found: {0}")]
-    ConstMultiValueParameterIndexNotFound(ConstParameterIndex<MultiValue>),
-    #[error("Constant parameter with index {index} has no key: {key}")]
-    ConstMultiValueParameterKeyNotFound {
-        index: ConstParameterIndex<MultiValue>,
-        key: String,
-    },
+
     #[error("Multi-network transfer index not found: {0}")]
     MultiNetworkTransferIndexNotFound(MultiNetworkTransferIndex),
     #[error("Network state error: {0}")]
@@ -1226,8 +1415,11 @@ impl State {
     }
 
     pub fn get_simple_parameter_values(&self) -> SimpleParameterValues<'_> {
-        self.parameters_before
-            .get_simple_parameter_values(self.get_const_parameter_values())
+        SimpleParameterValues {
+            constant: self.get_const_parameter_values(),
+            before: self.parameters_before.get_simple_parameter_values(),
+            after: self.parameters_after.get_simple_parameter_values(),
+        }
     }
 
     pub fn get_const_parameter_values(&self) -> ConstParameterValues<'_> {


### PR DESCRIPTION
The main thing here is the separation of the before and after methods into their own traits. The individual commit messages have more detail.

Some things to add/improve after this:
- Change the internal parameter value storage to only store before or after values if the parameter is registered for that "phase". Currently all parameters have a value which would be left at default value. This is dangerous because it could be accidentally used, and inefficient in storing values that are not required; most parameters will be before or after (not both).
- Add "phase" validation to the builder. It may also allow users to specify if they want today's network value from a metric (i.e. only available in after) or yesterday's (available in before). 
- I think `AggregatedParameter` (and some others) should only register themselves for the earliest phase their dependencies make sense for. At the moment `AggregatedParameter` does the aggregation for both before and after. This will requires the above phase validation.