### PR TITLE
feat: Slot validation API

### DIFF
--- a/pywr-schema/src/nodes/abstraction.rs
+++ b/pywr-schema/src/nodes/abstraction.rs
@@ -30,6 +30,7 @@ node_component_subset_enum! {
     }
 }
 
+#[derive(PartialEq)]
 pub enum AbstractionOutputNodeSlot {
     River,
     Abstraction,
@@ -94,13 +95,28 @@ pub struct AbstractionNode {
 impl AbstractionNode {
     const DEFAULT_ATTRIBUTE: AbstractionNodeAttribute = AbstractionNodeAttribute::Abstraction;
     const DEFAULT_COMPONENT: AbstractionNodeComponent = AbstractionNodeComponent::Abstraction;
+    const DEFAULT_OUTPUT_SLOT: AbstractionOutputNodeSlot = AbstractionOutputNodeSlot::River;
 
-    pub fn iter_output_slots(&self) -> impl Iterator<Item = NodeSlot> + '_ {
-        [
-            AbstractionOutputNodeSlot::River.into(),
-            AbstractionOutputNodeSlot::Abstraction.into(),
-        ]
-        .into_iter()
+    pub fn iter_output_slots(&self) -> impl Iterator<Item = AbstractionOutputNodeSlot> + '_ {
+        [AbstractionOutputNodeSlot::River, AbstractionOutputNodeSlot::Abstraction].into_iter()
+    }
+
+    /// Validate the output slot and return the corresponding `ReservoirOutputNodeSlot`.
+    pub fn output_slot(&self, slot: Option<&NodeSlot>) -> Result<AbstractionOutputNodeSlot, SchemaError> {
+        let slot = match slot {
+            Some(s) => {
+                let slot = s.clone().try_into()?;
+                // Check if the slot is valid for this node
+                if !self.iter_output_slots().any(|s| s == slot) {
+                    return Err(SchemaError::OutputNodeSlotNotSupported { slot: s.clone() });
+                }
+
+                slot
+            }
+            None => Self::DEFAULT_OUTPUT_SLOT,
+        };
+
+        Ok(slot)
     }
 
     pub fn default_attribute(&self) -> AbstractionNodeAttribute {
@@ -114,7 +130,6 @@ impl AbstractionNode {
 
 #[cfg(feature = "core")]
 impl AbstractionNode {
-    const DEFAULT_OUTPUT_SLOT: AbstractionOutputNodeSlot = AbstractionOutputNodeSlot::River;
     fn mrf_sub_name(&self) -> UnresolvedNode {
         UnresolvedNode::new(&self.meta.name, Some("mrf"))
     }

--- a/pywr-schema/src/nodes/mod.rs
+++ b/pywr-schema/src/nodes/mod.rs
@@ -55,14 +55,14 @@ mod water_treatment_works;
 // `virtual` is a reserved keyword in Rust, so we use `virtual_nodes` as the module name
 mod virtual_nodes;
 
-use crate::error::{ComponentConversionError, ConversionError};
+use crate::error::{ComponentConversionError, ConversionError, SchemaError};
 use crate::metric::Metric;
+#[cfg(feature = "core")]
+use crate::network::LoadArgs;
 use crate::network::NetworkSchema;
 use crate::parameters::Parameter;
 use crate::v1::{ConversionData, TryFromV1, TryIntoV2};
 use crate::visit::{VisitMetrics, VisitNodeReferences, VisitPaths};
-#[cfg(feature = "core")]
-use crate::{error::SchemaError, network::LoadArgs};
 pub use abstraction::AbstractionNode;
 pub use attributes::NodeAttribute;
 pub use components::NodeComponent;
@@ -345,6 +345,38 @@ impl Node {
         }
     }
 
+    /// Validate the provided input slot converting it into a [`NodeSlot`] if a default is available.
+    ///
+    /// [`None`] is returned if the node does not support slots and the provided slot is [`None`].
+    /// If the node does support slots, then the provided slot is validated and returned as a [`NodeSlot`].
+    /// If the provided slot is [`None`] and the node has a default slot, then the default slot is returned.
+    ///
+    /// [`Node::Placeholder`] nodes will accept any slot and return it as a [`NodeSlot`].
+    pub fn validate_input_slot(&self, slot: Option<&NodeSlot>) -> Result<Option<NodeSlot>, SchemaError> {
+        match self {
+            Node::Input(_)
+            | Node::Link(_)
+            | Node::Output(_)
+            | Node::Storage(_)
+            | Node::Catchment(_)
+            | Node::RiverGauge(_)
+            | Node::LossLink(_)
+            | Node::Delay(_)
+            | Node::PiecewiseLink(_)
+            | Node::PiecewiseStorage(_)
+            | Node::River(_)
+            | Node::RiverSplitWithGauge(_)
+            | Node::WaterTreatmentWorks(_)
+            | Node::Turbine(_)
+            | Node::Reservoir(_)
+            | Node::Abstraction(_) => match slot {
+                Some(s) => Err(SchemaError::InputNodeSlotNotSupported { slot: s.clone() }),
+                None => Ok(None),
+            },
+            Node::Placeholder(_) => Ok(slot.cloned()),
+        }
+    }
+
     /// Get any output (or "from") slots that this node has.
     pub fn iter_output_slots(&self) -> Option<Box<dyn Iterator<Item = NodeSlot> + '_>> {
         match self {
@@ -359,12 +391,44 @@ impl Node {
             Node::PiecewiseLink(_) => None,
             Node::PiecewiseStorage(_) => None,
             Node::River(_) => None,
-            Node::RiverSplitWithGauge(n) => Some(Box::new(n.iter_output_slots())),
+            Node::RiverSplitWithGauge(n) => Some(Box::new(n.iter_output_slots().map(|s| s.into()))),
             Node::WaterTreatmentWorks(_) => None,
             Node::Turbine(_) => None,
-            Node::Reservoir(n) => Some(Box::new(n.iter_output_slots())),
+            Node::Reservoir(n) => Some(Box::new(n.iter_output_slots().map(|s| s.into()))),
             Node::Placeholder(_) => None,
-            Node::Abstraction(n) => Some(Box::new(n.iter_output_slots())),
+            Node::Abstraction(n) => Some(Box::new(n.iter_output_slots().map(|s| s.into()))),
+        }
+    }
+
+    /// Validate the provided output slot converting it into a [`NodeSlot`] if a default is available.
+    ///
+    /// [`None`] is returned if the node does not support slots and the provided slot is [`None`].
+    /// If the node does support slots, then the provided slot is validated and returned as a [`NodeSlot`].
+    /// If the provided slot is [`None`] and the node has a default slot, then the default slot is returned.
+    ///
+    /// [`Node::Placeholder`] nodes will accept any slot and return it as a [`NodeSlot`].
+    pub fn validate_output_slot(&self, slot: Option<&NodeSlot>) -> Result<Option<NodeSlot>, SchemaError> {
+        match self {
+            Node::Input(_)
+            | Node::Link(_)
+            | Node::Output(_)
+            | Node::Storage(_)
+            | Node::Catchment(_)
+            | Node::RiverGauge(_)
+            | Node::LossLink(_)
+            | Node::Delay(_)
+            | Node::PiecewiseLink(_)
+            | Node::PiecewiseStorage(_)
+            | Node::River(_)
+            | Node::WaterTreatmentWorks(_)
+            | Node::Turbine(_) => match slot {
+                Some(s) => Err(SchemaError::OutputNodeSlotNotSupported { slot: s.clone() }),
+                None => Ok(None),
+            },
+            Node::Placeholder(_) => Ok(slot.cloned()),
+            Node::RiverSplitWithGauge(n) => n.output_slot(slot).map(|s| Some(s.into())),
+            Node::Reservoir(n) => n.output_slot(slot).map(|s| Some(s.into())),
+            Node::Abstraction(n) => n.output_slot(slot).map(|s| Some(s.into())),
         }
     }
 

--- a/pywr-schema/src/nodes/reservoir.rs
+++ b/pywr-schema/src/nodes/reservoir.rs
@@ -110,6 +110,7 @@ node_component_subset_enum! {
     }
 }
 
+#[derive(PartialEq)]
 pub enum ReservoirOutputNodeSlot {
     Storage,
     Compensation,
@@ -240,6 +241,7 @@ pub struct ReservoirNode {
 
 impl ReservoirNode {
     pub const DEFAULT_COMPONENT: ReservoirNodeComponent = ReservoirNodeComponent::Compensation;
+    const DEFAULT_OUTPUT_SLOT: ReservoirOutputNodeSlot = ReservoirOutputNodeSlot::Storage;
 
     /// Get the node's metadata.
     pub(crate) fn meta(&self) -> &NodeMeta {
@@ -251,13 +253,33 @@ impl ReservoirNode {
         &mut self.storage.meta
     }
 
-    pub fn iter_output_slots(&self) -> impl Iterator<Item = NodeSlot> + '_ {
-        [
-            ReservoirOutputNodeSlot::Storage.into(),
-            ReservoirOutputNodeSlot::Compensation.into(),
-            ReservoirOutputNodeSlot::Spill.into(),
-        ]
-        .into_iter()
+    pub fn iter_output_slots(&self) -> impl Iterator<Item = ReservoirOutputNodeSlot> + '_ {
+        let mut slots = vec![ReservoirOutputNodeSlot::Storage, ReservoirOutputNodeSlot::Compensation];
+
+        // There is only a Spill slot if the spill node is a LinkNode.
+        if matches!(self.spill, Some(SpillNodeType::LinkNode)) {
+            slots.push(ReservoirOutputNodeSlot::Spill);
+        }
+
+        slots.into_iter()
+    }
+
+    /// Validate the output slot and return the corresponding `ReservoirOutputNodeSlot`.
+    pub fn output_slot(&self, slot: Option<&NodeSlot>) -> Result<ReservoirOutputNodeSlot, SchemaError> {
+        let slot = match slot {
+            Some(s) => {
+                let slot = s.clone().try_into()?;
+                // Check if the slot is valid for this node
+                if !self.iter_output_slots().any(|s| s == slot) {
+                    return Err(SchemaError::OutputNodeSlotNotSupported { slot: s.clone() });
+                }
+
+                slot
+            }
+            None => Self::DEFAULT_OUTPUT_SLOT,
+        };
+
+        Ok(slot)
     }
 
     pub fn default_attribute(&self) -> ReservoirNodeAttribute {
@@ -271,7 +293,6 @@ impl ReservoirNode {
 
 #[cfg(feature = "core")]
 impl ReservoirNode {
-    const DEFAULT_OUTPUT_SLOT: ReservoirOutputNodeSlot = ReservoirOutputNodeSlot::Storage;
     /// The sub-name of the compensation link node.
     fn compensation_node_sub_name(&self) -> UnresolvedNode {
         UnresolvedNode::new(&self.storage.meta.name, Some("compensation"))
@@ -292,10 +313,7 @@ impl ReservoirNode {
 
     pub fn output_connectors(&self, slot: Option<&NodeSlot>) -> Result<Vec<UnresolvedNode>, SchemaError> {
         // Use the default slot if none is specified
-        let slot = match slot {
-            Some(c) => c.clone().try_into()?,
-            None => Self::DEFAULT_OUTPUT_SLOT,
-        };
+        let slot = self.output_slot(slot)?;
 
         let indices = match slot {
             ReservoirOutputNodeSlot::Storage => {
@@ -309,6 +327,8 @@ impl ReservoirNode {
                     vec![self.spill_node_sub_name()]
                 }
                 _ => {
+                    // This should not happen because we already validated the slot in `output_slot`,
+                    // but we include this for completeness.
                     return Err(SchemaError::OutputNodeSlotNotSupported { slot: slot.into() });
                 }
             },

--- a/pywr-schema/src/nodes/reservoir.rs
+++ b/pywr-schema/src/nodes/reservoir.rs
@@ -254,7 +254,11 @@ impl ReservoirNode {
     }
 
     pub fn iter_output_slots(&self) -> impl Iterator<Item = ReservoirOutputNodeSlot> + '_ {
-        let mut slots = vec![ReservoirOutputNodeSlot::Storage, ReservoirOutputNodeSlot::Compensation];
+        let mut slots = vec![ReservoirOutputNodeSlot::Storage];
+
+        if self.compensation.is_some() {
+            slots.push(ReservoirOutputNodeSlot::Compensation);
+        }
 
         // There is only a Spill slot if the spill node is a LinkNode.
         if matches!(self.spill, Some(SpillNodeType::LinkNode)) {

--- a/pywr-schema/src/nodes/river_split_with_gauge.rs
+++ b/pywr-schema/src/nodes/river_split_with_gauge.rs
@@ -183,16 +183,25 @@ impl RiverSplitWithGaugeNode {
 
         let indices = match &slot {
             RiverSplitWithGaugeOutputNodeSlot::River => self.default_connectors(),
-            RiverSplitWithGaugeOutputNodeSlot::Split { position } => {
-                if *position < self.splits.len() {
+            RiverSplitWithGaugeOutputNodeSlot::Split { position } => match self.splits.get(*position) {
+                Some(split) => {
+                    // If the split has a slot name, then it should be accessed via the user slot, not the index.
+                    if split.slot_name.is_some() {
+                        return Err(SchemaError::NodeConnectionSlotNotFound {
+                            node: self.meta.name.clone(),
+                            slot: slot.into(),
+                        });
+                    }
+
                     vec![self.split_sub_name(*position)]
-                } else {
+                }
+                None => {
                     return Err(SchemaError::NodeConnectionSlotNotFound {
                         node: self.meta.name.clone(),
                         slot: slot.into(),
                     });
                 }
-            }
+            },
             RiverSplitWithGaugeOutputNodeSlot::User { name } => {
                 match self
                     .splits

--- a/pywr-schema/src/nodes/river_split_with_gauge.rs
+++ b/pywr-schema/src/nodes/river_split_with_gauge.rs
@@ -3,7 +3,6 @@ use crate::error::SchemaError;
 use crate::metric::Metric;
 #[cfg(feature = "core")]
 use crate::network::LoadArgs;
-use crate::nodes::abstraction::AbstractionOutputNodeSlot;
 #[cfg(feature = "core")]
 use crate::nodes::{NodeAttribute, NodeComponent};
 use crate::nodes::{NodeMeta, NodeSlot};
@@ -42,6 +41,7 @@ node_component_subset_enum! {
     }
 }
 
+#[derive(PartialEq)]
 pub enum RiverSplitWithGaugeOutputNodeSlot {
     River,
     Split { position: usize },
@@ -102,14 +102,33 @@ pub struct RiverSplitWithGaugeNode {
 impl RiverSplitWithGaugeNode {
     const DEFAULT_ATTRIBUTE: RiverSplitWithGaugeNodeAttribute = RiverSplitWithGaugeNodeAttribute::Outflow;
     const DEFAULT_COMPONENT: RiverSplitWithGaugeNodeComponent = RiverSplitWithGaugeNodeComponent::Outflow;
+    const DEFAULT_OUTPUT_SLOT: RiverSplitWithGaugeOutputNodeSlot = RiverSplitWithGaugeOutputNodeSlot::River;
 
-    pub fn iter_output_slots(&self) -> impl Iterator<Item = NodeSlot> + '_ {
-        [AbstractionOutputNodeSlot::River.into()]
+    pub fn iter_output_slots(&self) -> impl Iterator<Item = RiverSplitWithGaugeOutputNodeSlot> + '_ {
+        [RiverSplitWithGaugeOutputNodeSlot::River]
             .into_iter()
             .chain(self.splits.iter().enumerate().map(|(i, split)| match &split.slot_name {
-                Some(name) => NodeSlot::User { name: name.clone() },
-                None => NodeSlot::Split { position: i },
+                Some(name) => RiverSplitWithGaugeOutputNodeSlot::User { name: name.clone() },
+                None => RiverSplitWithGaugeOutputNodeSlot::Split { position: i },
             }))
+    }
+
+    /// Validate the output slot and return the corresponding `ReservoirOutputNodeSlot`.
+    pub fn output_slot(&self, slot: Option<&NodeSlot>) -> Result<RiverSplitWithGaugeOutputNodeSlot, SchemaError> {
+        let slot = match slot {
+            Some(s) => {
+                let slot = s.clone().try_into()?;
+                // Check if the slot is valid for this node
+                if !self.iter_output_slots().any(|s| s == slot) {
+                    return Err(SchemaError::OutputNodeSlotNotSupported { slot: s.clone() });
+                }
+
+                slot
+            }
+            None => Self::DEFAULT_OUTPUT_SLOT,
+        };
+
+        Ok(slot)
     }
 
     pub fn default_attribute(&self) -> RiverSplitWithGaugeNodeAttribute {
@@ -123,7 +142,6 @@ impl RiverSplitWithGaugeNode {
 
 #[cfg(feature = "core")]
 impl RiverSplitWithGaugeNode {
-    const DEFAULT_OUTPUT_SLOT: RiverSplitWithGaugeOutputNodeSlot = RiverSplitWithGaugeOutputNodeSlot::River;
     fn mrf_sub_name(&self) -> UnresolvedNode {
         UnresolvedNode::new(&self.meta.name, Some("mrf"))
     }


### PR DESCRIPTION
Add a new API for validating slots against a node's schema.

Also correct the logic in the availability of the Spill slot
in the `ReservoirNode`. It is only available if "spill" is
set to the `Spill` variant.