### PR TITLE
feat: Implement merge for NetworkSchema.

### DIFF
--- a/pywr-schema/src/data_tables/mod.rs
+++ b/pywr-schema/src/data_tables/mod.rs
@@ -144,7 +144,7 @@ impl CsvDataTable {
     }
 }
 
-/// An external table of data that can be referenced
+/// A placeholder for an external table of data that can be referenced
 #[derive(serde::Deserialize, serde::Serialize, Debug, Clone, JsonSchema)]
 pub struct PlaceholderTable {
     pub meta: TableMeta,

--- a/pywr-schema/src/data_tables/mod.rs
+++ b/pywr-schema/src/data_tables/mod.rs
@@ -57,6 +57,7 @@ pub struct TableMeta {
 #[strum_discriminants(name(DataTableType))]
 pub enum DataTable {
     CSV(CsvDataTable),
+    Placeholder(PlaceholderTable),
 }
 
 impl DataTable {
@@ -67,13 +68,21 @@ impl DataTable {
     pub fn meta(&self) -> &TableMeta {
         match self {
             DataTable::CSV(tbl) => &tbl.meta,
+            DataTable::Placeholder(tbl) => &tbl.meta,
         }
+    }
+
+    pub fn is_placeholder(&self) -> bool {
+        matches!(self, DataTable::Placeholder(_))
     }
 
     #[cfg(feature = "core")]
     pub fn load(&self, data_path: Option<&Path>) -> Result<LoadedTable, TableError> {
         match self {
             DataTable::CSV(tbl) => tbl.load_f64(data_path),
+            DataTable::Placeholder(tbl) => Err(TableError::PlaceholderTableNotAllowed {
+                name: tbl.meta.name.clone(),
+            }),
         }
     }
 }
@@ -135,6 +144,12 @@ impl CsvDataTable {
     }
 }
 
+/// An external table of data that can be referenced
+#[derive(serde::Deserialize, serde::Serialize, Debug, Clone, JsonSchema)]
+pub struct PlaceholderTable {
+    pub meta: TableMeta,
+}
+
 /// Make a finalised path for reading data from.
 ///
 /// If `table_path` is relative and `data_path` is some path then join `table_path` to `data_path`.
@@ -191,6 +206,8 @@ pub enum TableError {
     U64ConversionError,
     #[error("Checksum error: {0}")]
     ChecksumError(#[from] ChecksumError),
+    #[error("Placeholder table `{name}` cannot be loaded.")]
+    PlaceholderTableNotAllowed { name: String },
 }
 
 #[cfg(feature = "core")]

--- a/pywr-schema/src/error.rs
+++ b/pywr-schema/src/error.rs
@@ -138,6 +138,8 @@ pub enum SchemaError {
     PlaceholderNodeNotAllowed { name: String },
     #[error("Placeholder parameter `{name}` cannot be added to a model.")]
     PlaceholderParameterNotAllowed { name: String },
+    #[error("Placeholder output `{name}` cannot be added to a model.")]
+    PlaceholderOutputNotAllowed { name: String },
     #[error("Node cannot be used in a flow constraint.")]
     NodeNotAllowedInFlowConstraint,
     #[error("Node cannot be used in a storage constraint.")]

--- a/pywr-schema/src/model.rs
+++ b/pywr-schema/src/model.rs
@@ -436,7 +436,7 @@ impl From<ModelSchemaBuildError> for PyErr {
 ///
 ///
 #[skip_serializing_none]
-#[derive(serde::Deserialize, serde::Serialize, Clone, JsonSchema)]
+#[derive(serde::Deserialize, serde::Serialize, Clone, JsonSchema, Default)]
 #[cfg_attr(feature = "pyo3", pyclass(skip_from_py_object))]
 pub struct ModelSchema {
     pub metadata: Metadata,

--- a/pywr-schema/src/network.rs
+++ b/pywr-schema/src/network.rs
@@ -135,6 +135,23 @@ impl TryFrom<NetworkSchemaBuildError> for PyErr {
     }
 }
 
+#[derive(Error, Debug)]
+#[allow(clippy::enum_variant_names)] // We want to be explicit about the error types for clarity.
+pub enum NetworkMergeError {
+    #[error("Duplicate node name found when merging networks: {0}")]
+    DuplicateNodeName(String),
+    #[error("Duplicate parameter name found when merging networks: {0}")]
+    DuplicateParameterName(String),
+    #[error("Duplicate edge from `{from_node}` to `{to_node}`")]
+    DuplicateEdge { from_node: String, to_node: String },
+    #[error("Duplicate table name found when merging networks: {0}")]
+    DuplicateTableName(String),
+    #[error("Duplicate timeseries name found when merging networks: {0}")]
+    DuplicateTimeseriesName(String),
+    #[error("Duplicate metric set name found when merging networks: {0}")]
+    DuplicateOutputName(String),
+}
+
 #[cfg(feature = "core")]
 #[derive(Clone)]
 pub struct LoadArgs<'a> {
@@ -417,6 +434,10 @@ impl NetworkSchema {
         self.nodes.iter().find(|n| n.name() == name)
     }
 
+    pub fn get_node_by_name_mut(&mut self, name: &str) -> Option<&mut Node> {
+        self.nodes.iter_mut().find(|n| n.name() == name)
+    }
+
     pub fn get_node_index_by_name(&self, name: &str) -> Option<usize> {
         self.nodes
             .iter()
@@ -431,6 +452,13 @@ impl NetworkSchema {
     pub fn get_virtual_node_by_name(&self, name: &str) -> Option<&VirtualNode> {
         match &self.virtual_nodes {
             Some(virtual_nodes) => virtual_nodes.iter().find(|n| n.name() == name),
+            None => None,
+        }
+    }
+
+    pub fn get_virtual_node_by_name_mut(&mut self, name: &str) -> Option<&mut VirtualNode> {
+        match &mut self.virtual_nodes {
+            Some(virtual_nodes) => virtual_nodes.iter_mut().find(|n| n.name() == name),
             None => None,
         }
     }
@@ -452,6 +480,11 @@ impl NetworkSchema {
         }
     }
 
+    /// Returns true if any node or virtual node in the network is called `name`.
+    pub fn node_name_exists(&self, name: &str) -> bool {
+        self.get_node_by_name(name).is_some() || self.get_virtual_node_by_name(name).is_some()
+    }
+
     pub fn get_parameter_by_name(&self, name: &str) -> Option<&Parameter> {
         match &self.parameters {
             Some(parameters) => parameters.iter().find(|p| p.name() == name),
@@ -459,9 +492,87 @@ impl NetworkSchema {
         }
     }
 
-    /// Returns true if any node or virtual node in the network is called `name`.
-    pub fn node_name_exists(&self, name: &str) -> bool {
-        self.get_node_by_name(name).is_some() || self.get_virtual_node_by_name(name).is_some()
+    pub fn get_parameter_by_name_mut(&mut self, name: &str) -> Option<&mut Parameter> {
+        match &mut self.parameters {
+            Some(parameters) => parameters.iter_mut().find(|p| p.name() == name),
+            None => None,
+        }
+    }
+
+    pub fn parameter_exists(&self, name: &str) -> bool {
+        self.get_parameter_by_name(name).is_some()
+    }
+
+    pub fn get_table_by_name(&self, name: &str) -> Option<&DataTable> {
+        match &self.tables {
+            Some(tables) => tables.iter().find(|t| t.name() == name),
+            None => None,
+        }
+    }
+
+    pub fn get_table_by_name_mut(&mut self, name: &str) -> Option<&mut DataTable> {
+        match &mut self.tables {
+            Some(tables) => tables.iter_mut().find(|t| t.name() == name),
+            None => None,
+        }
+    }
+
+    pub fn table_exists(&self, name: &str) -> bool {
+        self.get_table_by_name(name).is_some()
+    }
+
+    pub fn get_timeseries_by_name(&self, name: &str) -> Option<&Timeseries> {
+        match &self.timeseries {
+            Some(timeseries) => timeseries.iter().find(|t| t.name() == name),
+            None => None,
+        }
+    }
+
+    pub fn get_timeseries_by_name_mut(&mut self, name: &str) -> Option<&mut Timeseries> {
+        match &mut self.timeseries {
+            Some(timeseries) => timeseries.iter_mut().find(|t| t.name() == name),
+            None => None,
+        }
+    }
+
+    pub fn timeseries_exists(&self, name: &str) -> bool {
+        self.get_timeseries_by_name(name).is_some()
+    }
+
+    pub fn get_metric_set_by_name(&self, name: &str) -> Option<&MetricSet> {
+        match &self.metric_sets {
+            Some(metric_sets) => metric_sets.iter().find(|ms| ms.name == name),
+            None => None,
+        }
+    }
+
+    pub fn get_metric_set_by_name_mut(&mut self, name: &str) -> Option<&mut MetricSet> {
+        match &mut self.metric_sets {
+            Some(metric_sets) => metric_sets.iter_mut().find(|ms| ms.name == name),
+            None => None,
+        }
+    }
+
+    pub fn metric_set_exists(&self, name: &str) -> bool {
+        self.get_metric_set_by_name(name).is_some()
+    }
+
+    pub fn get_output_by_name(&self, name: &str) -> Option<&Output> {
+        match &self.outputs {
+            Some(outputs) => outputs.iter().find(|o| o.name() == name),
+            None => None,
+        }
+    }
+
+    pub fn get_output_by_name_mut(&mut self, name: &str) -> Option<&mut Output> {
+        match &mut self.outputs {
+            Some(outputs) => outputs.iter_mut().find(|o| o.name() == name),
+            None => None,
+        }
+    }
+
+    pub fn output_exists(&self, name: &str) -> bool {
+        self.get_output_by_name(name).is_some()
     }
 
     /// Validate the network schema.
@@ -606,6 +717,177 @@ impl NetworkSchema {
 
         Ok((tables, timeseries))
     }
+
+    /// Merge another [`NetworkSchema`] into this one.
+    ///
+    /// This will combine the nodes, virtual nodes, edges, and parameters of both networks.
+    /// If there are any duplicate node or parameter names, an error will be returned. However,
+    /// placeholder types (e.g. [`crate::nodes::PlaceholderNode`]) are replaced.
+    ///
+    /// Metric sets are merged by name, with the metrics of any metric sets with the same name being
+    /// combined. Other information in the metric set (e.g. filters) is **not** merged.
+    pub fn merge(&mut self, other: NetworkSchema) -> Result<(), NetworkMergeError> {
+        // Merge nodes replacing placeholders at their index if they exist, otherwise appending
+        // to the end of the list, or returning an error if a duplicate name is found.
+        for node in other.nodes {
+            match self.get_node_by_name_mut(node.name()) {
+                Some(existing_node) => {
+                    if existing_node.is_placeholder() {
+                        *existing_node = node;
+                    } else {
+                        return Err(NetworkMergeError::DuplicateNodeName(node.name().to_string()));
+                    }
+                }
+                None => {
+                    // Check if the node name exists in the virtual nodes list
+                    if self.get_virtual_node_index_by_name(node.name()).is_some() {
+                        return Err(NetworkMergeError::DuplicateNodeName(node.name().to_string()));
+                    }
+                    self.nodes.push(node.clone());
+                }
+            }
+        }
+
+        // Merge virtual nodes. As per nodes, replacing placeholders at their index if they exist,
+        // otherwise appending to the end of the list, or returning an error if a duplicate name is found.
+        if let Some(other_virtual_nodes) = other.virtual_nodes {
+            for v_node in other_virtual_nodes {
+                match self.get_virtual_node_by_name_mut(v_node.name()) {
+                    Some(existing_node) => {
+                        if existing_node.is_placeholder() {
+                            *existing_node = v_node;
+                        } else {
+                            return Err(NetworkMergeError::DuplicateNodeName(v_node.name().to_string()));
+                        }
+                    }
+                    None => {
+                        // Check if the node name exists in the virtual nodes list
+                        if self.get_virtual_node_index_by_name(v_node.name()).is_some() {
+                            return Err(NetworkMergeError::DuplicateNodeName(v_node.name().to_string()));
+                        }
+
+                        self.virtual_nodes.get_or_insert_default().push(v_node);
+                    }
+                }
+            }
+        }
+
+        // Merge edges checking for duplicates
+        for edge in other.edges {
+            if self.edges.iter().any(|e| e == &edge) {
+                return Err(NetworkMergeError::DuplicateEdge {
+                    from_node: edge.from_node,
+                    to_node: edge.to_node,
+                });
+            }
+            self.edges.push(edge);
+        }
+
+        // Merge parameters
+        if let Some(other_parameters) = other.parameters {
+            for param in other_parameters {
+                match self.get_parameter_by_name_mut(param.name()) {
+                    Some(existing_param) => {
+                        if existing_param.is_placeholder() {
+                            *existing_param = param;
+                        } else {
+                            return Err(NetworkMergeError::DuplicateParameterName(param.name().to_string()));
+                        }
+                    }
+                    None => {
+                        self.parameters.get_or_insert_default().push(param);
+                    }
+                }
+            }
+        }
+
+        // Merge tables
+        if let Some(other_tables) = other.tables {
+            for table in other_tables {
+                match self.get_table_by_name_mut(table.name()) {
+                    Some(existing_table) => {
+                        if existing_table.is_placeholder() {
+                            *existing_table = table;
+                        } else {
+                            return Err(NetworkMergeError::DuplicateTableName(table.name().to_string()));
+                        }
+                    }
+                    None => {
+                        self.tables.get_or_insert_default().push(table);
+                    }
+                }
+            }
+        }
+
+        // Merge timeseries
+        if let Some(other_timeseries) = other.timeseries {
+            for ts in other_timeseries {
+                match self.get_timeseries_by_name_mut(ts.name()) {
+                    Some(existing_ts) => {
+                        if existing_ts.is_placeholder() {
+                            *existing_ts = ts;
+                        } else {
+                            return Err(NetworkMergeError::DuplicateTimeseriesName(ts.name().to_string()));
+                        }
+                    }
+                    None => {
+                        self.timeseries.get_or_insert_default().push(ts);
+                    }
+                }
+            }
+        }
+
+        // Merge metric sets. There are no placeholder metric sets. Instead, we merge the metrics
+        // of any metric sets with the same name.
+        if let Some(other_metric_sets) = other.metric_sets {
+            for ms in other_metric_sets {
+                match self.get_metric_set_by_name_mut(&ms.name) {
+                    Some(existing_ms) => {
+                        // Merge the metrics of the existing metric set with the new one.
+                        if let Some(existing_metrics) = &mut existing_ms.metrics {
+                            if let Some(new_metrics) = ms.metrics {
+                                // Check for duplicate metrics
+                                for new_metric in &new_metrics {
+                                    if existing_metrics.iter().any(|m| m == new_metric) {
+                                        return Err(NetworkMergeError::DuplicateOutputName(ms.name.clone()));
+                                    }
+                                }
+
+                                existing_metrics.extend(new_metrics);
+                            }
+                        } else {
+                            existing_ms.metrics = ms.metrics;
+                        }
+                    }
+                    None => {
+                        // No existing metric set with this name, so we can just add it.
+                        self.metric_sets.get_or_insert_default().push(ms);
+                    }
+                }
+            }
+        }
+
+        // Merge outputs. Replacing placeholders at their index if they exist, otherwise appending
+        // to the end of the list, or returning an error if a duplicate name is found.
+        if let Some(other_outputs) = other.outputs {
+            for output in other_outputs {
+                match self.get_output_by_name_mut(output.name()) {
+                    Some(existing_output) => {
+                        if existing_output.is_placeholder() {
+                            *existing_output = output;
+                        } else {
+                            return Err(NetworkMergeError::DuplicateOutputName(output.name().to_string()));
+                        }
+                    }
+                    None => {
+                        self.outputs.get_or_insert_default().push(output);
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
 }
 
 #[derive(serde::Deserialize, serde::Serialize, Clone, Display, EnumDiscriminants)]
@@ -619,7 +901,7 @@ pub enum NetworkSchemaRef {
 
 #[cfg(test)]
 mod tests {
-    use super::NetworkSchema;
+    use super::{NetworkMergeError, NetworkSchema};
     use crate::error::{DuplicateNodeName, ValidationError};
     use std::str::FromStr;
 
@@ -629,6 +911,10 @@ mod tests {
             Err(ValidationError::DuplicateNodeNames(duplicates)) => duplicates,
             Ok(()) => panic!("Expected validation to fail, but it succeeded"),
         }
+    }
+
+    fn parse_network(data: &str) -> NetworkSchema {
+        NetworkSchema::from_str(data).expect("Failed to parse test network JSON")
     }
 
     /// A network where a node and a virtual node are both called `licence`.
@@ -655,7 +941,7 @@ mod tests {
     /// is a duplicate.
     #[test]
     fn test_validate_rejects_name_shared_with_virtual_node() {
-        let network = NetworkSchema::from_str(NETWORK_WITH_SHARED_NODE_AND_VIRTUAL_NODE_NAME).unwrap();
+        let network = parse_network(NETWORK_WITH_SHARED_NODE_AND_VIRTUAL_NODE_NAME);
 
         assert_eq!(
             expect_duplicates(&network),
@@ -690,7 +976,7 @@ mod tests {
     /// Every duplicate is reported, not just the first one found.
     #[test]
     fn test_validate_reports_all_duplicates() {
-        let network = NetworkSchema::from_str(NETWORK_WITH_SEVERAL_DUPLICATES).unwrap();
+        let network = parse_network(NETWORK_WITH_SEVERAL_DUPLICATES);
 
         assert_eq!(
             expect_duplicates(&network),
@@ -707,5 +993,469 @@ mod tests {
                 },
             ]
         );
+    }
+
+    #[test]
+    fn test_merge_appends_unique_nodes_and_edges() {
+        let mut base = parse_network(
+            r#"
+            {
+                "nodes": [
+                    { "meta": { "name": "a" }, "type": "Input" },
+                    { "meta": { "name": "b" }, "type": "Output" }
+                ],
+                "edges": [
+                    { "from_node": "a", "to_node": "b" }
+                ]
+            }
+            "#,
+        );
+
+        let other = parse_network(
+            r#"
+            {
+                "nodes": [
+                    { "meta": { "name": "c" }, "type": "Output" }
+                ],
+                "edges": [
+                    { "from_node": "b", "to_node": "c" }
+                ]
+            }
+            "#,
+        );
+
+        base.merge(other).expect("Merge should succeed");
+
+        assert_eq!(base.nodes.len(), 3);
+        assert_eq!(base.edges.len(), 2);
+        assert!(base.get_node_by_name("c").is_some());
+    }
+
+    #[test]
+    fn test_merge_replaces_placeholder_node() {
+        let mut base = parse_network(
+            r#"
+            {
+                "nodes": [
+                    { "meta": { "name": "shared" }, "type": "Placeholder" }
+                ],
+                "edges": []
+            }
+            "#,
+        );
+
+        let other = parse_network(
+            r#"
+            {
+                "nodes": [
+                    { "meta": { "name": "shared" }, "type": "Input" }
+                ],
+                "edges": []
+            }
+            "#,
+        );
+
+        base.merge(other).expect("Merge should replace placeholder node");
+
+        let merged = base.get_node_by_name("shared").expect("Node should exist after merge");
+        assert!(!merged.is_placeholder());
+    }
+
+    #[test]
+    fn test_merge_rejects_duplicate_non_placeholder_node_name() {
+        let mut base = parse_network(
+            r#"
+            {
+                "nodes": [
+                    { "meta": { "name": "shared" }, "type": "Input" }
+                ],
+                "edges": []
+            }
+            "#,
+        );
+
+        let other = parse_network(
+            r#"
+            {
+                "nodes": [
+                    { "meta": { "name": "shared" }, "type": "Output" }
+                ],
+                "edges": []
+            }
+            "#,
+        );
+
+        let err = base.merge(other).expect_err("Merge should reject duplicate node names");
+        assert!(matches!(err, NetworkMergeError::DuplicateNodeName(name) if name == "shared"));
+    }
+
+    #[test]
+    fn test_merge_rejects_duplicate_edge() {
+        let mut base = parse_network(
+            r#"
+            {
+                "nodes": [
+                    { "meta": { "name": "a" }, "type": "Input" },
+                    { "meta": { "name": "b" }, "type": "Output" }
+                ],
+                "edges": [
+                    { "from_node": "a", "to_node": "b" }
+                ]
+            }
+            "#,
+        );
+
+        let other = parse_network(
+            r#"
+            {
+                "nodes": [],
+                "edges": [
+                    { "from_node": "a", "to_node": "b" }
+                ]
+            }
+            "#,
+        );
+
+        let err = base.merge(other).expect_err("Merge should reject duplicate edges");
+        assert!(matches!(
+            err,
+            NetworkMergeError::DuplicateEdge { from_node, to_node } if from_node == "a" && to_node == "b"
+        ));
+    }
+
+    #[test]
+    fn test_merge_combines_metric_set_content_for_matching_names() {
+        let mut base = parse_network(
+            r#"
+            {
+                "nodes": [],
+                "edges": [],
+                "metric_sets": [
+                    { "name": "main" }
+                ]
+            }
+            "#,
+        );
+
+        let other = parse_network(
+            r#"
+            {
+                "nodes": [],
+                "edges": [],
+                "metric_sets": [
+                    { "name": "main", "metrics": [] }
+                ]
+            }
+            "#,
+        );
+
+        base.merge(other).expect("Merge should succeed");
+
+        let metric_sets = base.metric_sets.as_ref().expect("Metric sets should exist");
+        assert_eq!(metric_sets.len(), 1);
+        assert!(
+            base.get_metric_set_by_name("main")
+                .and_then(|ms| ms.metrics.as_ref())
+                .is_some_and(|metrics| metrics.is_empty())
+        );
+    }
+
+    #[test]
+    fn test_merge_replaces_placeholder_virtual_node() {
+        let mut base = parse_network(
+            r#"
+            {
+                "nodes": [],
+                "edges": [],
+                "virtual_nodes": [
+                    { "meta": { "name": "v-shared" }, "type": "Placeholder" }
+                ]
+            }
+            "#,
+        );
+
+        let other = parse_network(
+            r#"
+            {
+                "nodes": [],
+                "edges": [],
+                "virtual_nodes": [
+                    { "meta": { "name": "v-shared" }, "type": "Aggregated", "nodes": [] }
+                ]
+            }
+            "#,
+        );
+
+        base.merge(other)
+            .expect("Merge should replace placeholder virtual node");
+
+        let merged = base
+            .get_virtual_node_by_name("v-shared")
+            .expect("Virtual node should exist after merge");
+        assert!(!merged.is_placeholder());
+    }
+
+    #[test]
+    fn test_merge_replaces_placeholder_parameter() {
+        let mut base = parse_network(
+            r#"
+            {
+                "nodes": [],
+                "edges": [],
+                "parameters": [
+                    { "type": "Placeholder", "meta": { "name": "p-shared" } }
+                ]
+            }
+            "#,
+        );
+
+        let other = parse_network(
+            r#"
+            {
+                "nodes": [],
+                "edges": [],
+                "parameters": [
+                    { "type": "Constant", "meta": { "name": "p-shared" }, "value": { "type": "Literal", "value": 1.0 } }
+                ]
+            }
+            "#,
+        );
+
+        base.merge(other).expect("Merge should replace placeholder parameter");
+
+        let merged = base
+            .get_parameter_by_name("p-shared")
+            .expect("Parameter should exist after merge");
+        assert!(!merged.is_placeholder());
+    }
+
+    #[test]
+    fn test_merge_rejects_duplicate_parameter_name() {
+        let mut base = parse_network(
+            r#"
+            {
+                "nodes": [],
+                "edges": [],
+                "parameters": [
+                    { "type": "Constant", "meta": { "name": "p-shared" }, "value": { "type": "Literal", "value": 1.0 } }
+                ]
+            }
+            "#,
+        );
+
+        let other = parse_network(
+            r#"
+            {
+                "nodes": [],
+                "edges": [],
+                "parameters": [
+                    { "type": "Constant", "meta": { "name": "p-shared" }, "value": { "type": "Literal", "value": 2.0 } }
+                ]
+            }
+            "#,
+        );
+
+        let err = base
+            .merge(other)
+            .expect_err("Merge should reject duplicate parameter names");
+        assert!(matches!(err, NetworkMergeError::DuplicateParameterName(name) if name == "p-shared"));
+    }
+
+    #[test]
+    fn test_merge_replaces_placeholder_table() {
+        let mut base = parse_network(
+            r#"
+            {
+                "nodes": [],
+                "edges": [],
+                "tables": [
+                    { "format": "Placeholder", "meta": { "name": "tbl-shared" } }
+                ]
+            }
+            "#,
+        );
+
+        let other = parse_network(
+            r#"
+            {
+                "nodes": [],
+                "edges": [],
+                "tables": [
+                    { "format": "CSV", "meta": { "name": "tbl-shared" }, "type": "Scalar", "lookup": { "type": "Row", "cols": 1 }, "url": "data.csv" }
+                ]
+            }
+            "#,
+        );
+
+        base.merge(other).expect("Merge should replace placeholder table");
+
+        let merged = base
+            .get_table_by_name("tbl-shared")
+            .expect("Table should exist after merge");
+        assert!(!merged.is_placeholder());
+    }
+
+    #[test]
+    fn test_merge_rejects_duplicate_table_name() {
+        let mut base = parse_network(
+            r#"
+            {
+                "nodes": [],
+                "edges": [],
+                "tables": [
+                    { "format": "CSV", "meta": { "name": "tbl-shared" }, "type": "Scalar", "lookup": { "type": "Row", "cols": 1 }, "url": "data.csv" }
+                ]
+            }
+            "#,
+        );
+
+        let other = parse_network(
+            r#"
+            {
+                "nodes": [],
+                "edges": [],
+                "tables": [
+                    { "format": "CSV", "meta": { "name": "tbl-shared" }, "type": "Scalar", "lookup": { "type": "Row", "cols": 1 }, "url": "other.csv" }
+                ]
+            }
+            "#,
+        );
+
+        let err = base
+            .merge(other)
+            .expect_err("Merge should reject duplicate table names");
+        assert!(matches!(err, NetworkMergeError::DuplicateTableName(name) if name == "tbl-shared"));
+    }
+
+    #[test]
+    fn test_merge_replaces_placeholder_timeseries() {
+        let mut base = parse_network(
+            r#"
+            {
+                "nodes": [],
+                "edges": [],
+                "timeseries": [
+                    { "type": "Placeholder", "meta": { "name": "ts-shared" } }
+                ]
+            }
+            "#,
+        );
+
+        let other = parse_network(
+            r#"
+            {
+                "nodes": [],
+                "edges": [],
+                "timeseries": [
+                    { "type": "Polars", "meta": { "name": "ts-shared" }, "url": "timeseries.csv" }
+                ]
+            }
+            "#,
+        );
+
+        base.merge(other).expect("Merge should replace placeholder timeseries");
+
+        let merged = base
+            .get_timeseries_by_name("ts-shared")
+            .expect("Timeseries should exist after merge");
+        assert!(!merged.is_placeholder());
+    }
+
+    #[test]
+    fn test_merge_rejects_duplicate_timeseries_name() {
+        let mut base = parse_network(
+            r#"
+            {
+                "nodes": [],
+                "edges": [],
+                "timeseries": [
+                    { "type": "Polars", "meta": { "name": "ts-shared" }, "url": "timeseries.csv" }
+                ]
+            }
+            "#,
+        );
+
+        let other = parse_network(
+            r#"
+            {
+                "nodes": [],
+                "edges": [],
+                "timeseries": [
+                    { "type": "Polars", "meta": { "name": "ts-shared" }, "url": "other.csv" }
+                ]
+            }
+            "#,
+        );
+
+        let err = base
+            .merge(other)
+            .expect_err("Merge should reject duplicate timeseries names");
+        assert!(matches!(err, NetworkMergeError::DuplicateTimeseriesName(name) if name == "ts-shared"));
+    }
+
+    #[test]
+    fn test_merge_replaces_placeholder_output() {
+        let mut base = parse_network(
+            r#"
+            {
+                "nodes": [],
+                "edges": [],
+                "outputs": [
+                    { "type": "Placeholder", "name": "out-shared" }
+                ]
+            }
+            "#,
+        );
+
+        let other = parse_network(
+            r#"
+            {
+                "nodes": [],
+                "edges": [],
+                "outputs": [
+                    { "type": "Memory", "name": "out-shared", "metric_set": "ms" }
+                ]
+            }
+            "#,
+        );
+
+        base.merge(other).expect("Merge should replace placeholder output");
+
+        let merged = base
+            .get_output_by_name("out-shared")
+            .expect("Output should exist after merge");
+        assert!(!merged.is_placeholder());
+    }
+
+    #[test]
+    fn test_merge_rejects_duplicate_output_name() {
+        let mut base = parse_network(
+            r#"
+            {
+                "nodes": [],
+                "edges": [],
+                "outputs": [
+                    { "type": "Memory", "name": "out-shared", "metric_set": "ms" }
+                ]
+            }
+            "#,
+        );
+
+        let other = parse_network(
+            r#"
+            {
+                "nodes": [],
+                "edges": [],
+                "outputs": [
+                    { "type": "Memory", "name": "out-shared", "metric_set": "ms2" }
+                ]
+            }
+            "#,
+        );
+
+        let err = base
+            .merge(other)
+            .expect_err("Merge should reject duplicate output names");
+        assert!(matches!(err, NetworkMergeError::DuplicateOutputName(name) if name == "out-shared"));
     }
 }

--- a/pywr-schema/src/network.rs
+++ b/pywr-schema/src/network.rs
@@ -728,6 +728,10 @@ impl NetworkSchema {
     ///
     /// Metric sets are merged by name, with the metrics of any metric sets with the same name being
     /// combined. Other information in the metric set (e.g. filters) is **not** merged.
+    ///
+    /// If an error occurs during the merge, the network will be left in a partially merged state.
+    /// It is recommended to clone the network before merging if you want to keep the original network
+    /// intact.
     pub fn merge(&mut self, other: NetworkSchema) -> Result<(), NetworkMergeError> {
         // Merge nodes replacing placeholders at their index if they exist, otherwise appending
         // to the end of the list, or returning an error if a duplicate name is found.
@@ -763,8 +767,8 @@ impl NetworkSchema {
                         }
                     }
                     None => {
-                        // Check if the node name exists in the virtual nodes list
-                        if self.get_virtual_node_index_by_name(v_node.name()).is_some() {
+                        // Check if the node name exists as a regular node
+                        if self.get_node_index_by_name(v_node.name()).is_some() {
                             return Err(NetworkMergeError::DuplicateNodeName(v_node.name().to_string()));
                         }
 

--- a/pywr-schema/src/network.rs
+++ b/pywr-schema/src/network.rs
@@ -148,8 +148,10 @@ pub enum NetworkMergeError {
     DuplicateTableName(String),
     #[error("Duplicate timeseries name found when merging networks: {0}")]
     DuplicateTimeseriesName(String),
-    #[error("Duplicate metric set name found when merging networks: {0}")]
+    #[error("Duplicate output name found when merging networks: {0}")]
     DuplicateOutputName(String),
+    #[error("Duplicate metric found when merging metric sets with name `{0}`")]
+    DuplicateMetric(String),
 }
 
 #[cfg(feature = "core")]
@@ -849,7 +851,7 @@ impl NetworkSchema {
                                 // Check for duplicate metrics
                                 for new_metric in &new_metrics {
                                     if existing_metrics.iter().any(|m| m == new_metric) {
-                                        return Err(NetworkMergeError::DuplicateOutputName(ms.name.clone()));
+                                        return Err(NetworkMergeError::DuplicateMetric(ms.name.clone()));
                                     }
                                 }
 

--- a/pywr-schema/src/nodes/mod.rs
+++ b/pywr-schema/src/nodes/mod.rs
@@ -277,6 +277,9 @@ impl Node {
         self.into()
     }
 
+    pub fn is_placeholder(&self) -> bool {
+        matches!(self, Self::Placeholder(_))
+    }
     pub fn meta(&self) -> &NodeMeta {
         match self {
             Node::Input(n) => &n.meta,

--- a/pywr-schema/src/nodes/virtual_nodes/mod.rs
+++ b/pywr-schema/src/nodes/virtual_nodes/mod.rs
@@ -63,6 +63,10 @@ impl VirtualNode {
         self.into()
     }
 
+    pub fn is_placeholder(&self) -> bool {
+        matches!(self, Self::Placeholder(_))
+    }
+
     pub fn meta(&self) -> &NodeMeta {
         match self {
             VirtualNode::Aggregated(n) => &n.meta,

--- a/pywr-schema/src/outputs/mod.rs
+++ b/pywr-schema/src/outputs/mod.rs
@@ -1,12 +1,14 @@
 mod csv;
 mod hdf;
 mod memory;
+mod placeholder;
 
 pub use self::csv::CsvOutput;
 #[cfg(feature = "core")]
 use crate::error::SchemaError;
 pub use hdf::Hdf5Output;
 pub use memory::MemoryOutput;
+pub use placeholder::PlaceholderOutput;
 use pywr_schema_macros::PywrVisitPaths;
 use schemars::JsonSchema;
 #[cfg(feature = "core")]
@@ -23,6 +25,21 @@ pub enum Output {
     CSV(CsvOutput),
     HDF5(Hdf5Output),
     Memory(Box<MemoryOutput>),
+    Placeholder(PlaceholderOutput),
+}
+
+impl Output {
+    pub fn name(&self) -> &str {
+        match self {
+            Self::CSV(o) => &o.name,
+            Self::HDF5(o) => &o.name,
+            Self::Memory(o) => &o.name,
+            Self::Placeholder(o) => &o.name,
+        }
+    }
+    pub fn is_placeholder(&self) -> bool {
+        matches!(self, Self::Placeholder(_))
+    }
 }
 
 #[cfg(feature = "core")]
@@ -37,14 +54,7 @@ impl Output {
             Self::CSV(o) => o.add_to_network(network, output_path),
             Self::HDF5(o) => o.add_to_network(network, output_path),
             Self::Memory(o) => o.add_to_network(network, data_path),
-        }
-    }
-
-    pub fn name(&self) -> &str {
-        match self {
-            Self::CSV(o) => &o.name,
-            Self::HDF5(o) => &o.name,
-            Self::Memory(o) => &o.name,
+            Self::Placeholder(o) => o.add_to_network(),
         }
     }
 }

--- a/pywr-schema/src/outputs/placeholder.rs
+++ b/pywr-schema/src/outputs/placeholder.rs
@@ -1,0 +1,19 @@
+#[cfg(feature = "core")]
+use crate::SchemaError;
+use pywr_schema_macros::{PywrVisitPaths, skip_serializing_none};
+use schemars::JsonSchema;
+
+#[skip_serializing_none]
+#[derive(serde::Deserialize, serde::Serialize, Debug, Clone, JsonSchema, PywrVisitPaths)]
+pub struct PlaceholderOutput {
+    pub name: String,
+}
+
+#[cfg(feature = "core")]
+impl PlaceholderOutput {
+    pub fn add_to_network(&self) -> Result<(), SchemaError> {
+        Err(SchemaError::PlaceholderOutputNotAllowed {
+            name: self.name.clone(),
+        })
+    }
+}

--- a/pywr-schema/src/parameters/mod.rs
+++ b/pywr-schema/src/parameters/mod.rs
@@ -140,6 +140,10 @@ impl Parameter {
         self.meta().name.as_str()
     }
 
+    pub fn is_placeholder(&self) -> bool {
+        matches!(self, Self::Placeholder(_))
+    }
+
     pub fn meta(&self) -> &ParameterMeta {
         match self {
             Self::Constant(p) => &p.meta,

--- a/pywr-schema/src/timeseries/mod.rs
+++ b/pywr-schema/src/timeseries/mod.rs
@@ -1,6 +1,7 @@
 #[cfg(feature = "core")]
 mod align_and_resample;
 mod pandas;
+mod placeholder;
 mod polars_dataset;
 
 use crate::ConversionError;
@@ -12,6 +13,7 @@ use crate::visit::VisitPaths;
 #[cfg(feature = "core")]
 use ndarray::{Array2, ShapeError};
 pub use pandas::PandasTimeseries;
+pub use placeholder::PlaceholderTimeseries;
 #[cfg(feature = "core")]
 use polars::error::PolarsError;
 #[cfg(feature = "core")]
@@ -80,6 +82,8 @@ pub enum TimeseriesError {
     #[error("Checksum error: {0}")]
     #[cfg(feature = "core")]
     ChecksumError(#[from] crate::digest::ChecksumError),
+    #[error("Placeholder timeseries `{name}` cannot be loaded.")]
+    PlaceholderTimeseriesNotAllowed { name: String },
 }
 
 #[cfg(feature = "pyo3")]
@@ -100,6 +104,7 @@ impl TryFrom<TimeseriesError> for PyErr {
 pub enum Timeseries {
     Pandas(PandasTimeseries),
     Polars(PolarsTimeseries),
+    Placeholder(PlaceholderTimeseries),
 }
 
 impl Timeseries {
@@ -108,6 +113,7 @@ impl Timeseries {
         match &self {
             Timeseries::Polars(dataset) => dataset.load(data_path, domain),
             Timeseries::Pandas(dataset) => dataset.load(data_path, domain),
+            Timeseries::Placeholder(dataset) => dataset.load(),
         }
     }
 
@@ -115,7 +121,20 @@ impl Timeseries {
         match &self {
             Timeseries::Polars(dataset) => dataset.meta.name.as_str(),
             Timeseries::Pandas(dataset) => dataset.meta.name.as_str(),
+            Timeseries::Placeholder(dataset) => dataset.meta.name.as_str(),
         }
+    }
+
+    pub fn meta(&self) -> &ParameterMeta {
+        match &self {
+            Timeseries::Polars(dataset) => &dataset.meta,
+            Timeseries::Pandas(dataset) => &dataset.meta,
+            Timeseries::Placeholder(dataset) => &dataset.meta,
+        }
+    }
+
+    pub fn is_placeholder(&self) -> bool {
+        matches!(self, Timeseries::Placeholder(_))
     }
 }
 
@@ -124,6 +143,7 @@ impl VisitPaths for Timeseries {
         match &self {
             Timeseries::Polars(dataset) => dataset.visit_paths(visitor),
             Timeseries::Pandas(dataset) => dataset.visit_paths(visitor),
+            Timeseries::Placeholder(dataset) => dataset.visit_paths(visitor),
         }
     }
 
@@ -131,6 +151,7 @@ impl VisitPaths for Timeseries {
         match self {
             Timeseries::Polars(dataset) => dataset.visit_paths_mut(visitor),
             Timeseries::Pandas(dataset) => dataset.visit_paths_mut(visitor),
+            Timeseries::Placeholder(dataset) => dataset.visit_paths_mut(visitor),
         }
     }
 }

--- a/pywr-schema/src/timeseries/placeholder.rs
+++ b/pywr-schema/src/timeseries/placeholder.rs
@@ -1,0 +1,28 @@
+use crate::VisitPaths;
+use crate::parameters::ParameterMeta;
+use pywr_schema_macros::skip_serializing_none;
+use schemars::JsonSchema;
+
+#[skip_serializing_none]
+#[derive(serde::Deserialize, serde::Serialize, Debug, Clone, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct PlaceholderTimeseries {
+    pub meta: ParameterMeta,
+}
+
+impl VisitPaths for PlaceholderTimeseries {}
+
+#[cfg(feature = "core")]
+mod core {
+    use super::PlaceholderTimeseries;
+    use crate::timeseries::TimeseriesError;
+    use polars::frame::DataFrame;
+
+    impl PlaceholderTimeseries {
+        pub fn load(&self) -> Result<DataFrame, TimeseriesError> {
+            Err(TimeseriesError::PlaceholderTimeseriesNotAllowed {
+                name: self.meta.name.clone(),
+            })
+        }
+    }
+}


### PR DESCRIPTION
Initial commit of a basic merge function. It modifies a base network schema in-place by consuming another one. Merge errors on duplicates unless they are a placeholder type. Placeholders are replaced in-place.

Metric sets are treated different with the metric entries merged if the names match.

Added additional placeholder types for tables, outputs and timeseries.

Added additional API for finding other components on the schema.