### PR TITLE
feat: Support metrics providing a value aligned to the current phase.

### DIFF
--- a/pywr-book/src/custom_parameters.md
+++ b/pywr-book/src/custom_parameters.md
@@ -69,7 +69,7 @@ from pywr import ParameterInfo
 
 
 def current_timestep(
-        info: ParameterInfo, a: float, b: float, some_condition: str = "foo"
+    info: ParameterInfo, a: float, b: float, some_condition: str = "foo"
 ) -> float:
     """Return the current time step."""
     match some_condition:

--- a/pywr-book/src/custom_parameters.md
+++ b/pywr-book/src/custom_parameters.md
@@ -1,22 +1,19 @@
 # Extending functionality with custom parameters
 
-Parameters are a core part of Pywr, allowing you to define how your model behaves.
-While Pywr comes with a wide range of built-in parameters, you may find that you need to create custom parameters to
-suit your specific modelling needs.
-This guide will walk you through the process of creating custom parameters in Pywr.
+Parameters are a core part of Pywr, allowing you to define how your model behaves. While Pywr comes with a wide range of
+built-in parameters, you may find that you need to create custom parameters to suit your specific modelling needs. This
+guide will walk you through the process of creating custom parameters in Pywr.
 
-Currently, Pywr supports custom parameters that are defined in Python.
-If your parameter is general enough, you may want to consider contributing it to the Pywr project.
-If you do, please see the [Developers Guide](./developers-guide/adding-a-parameter.md) for more information on how to do
-this.
+Currently, Pywr supports custom parameters that are defined in Python. If your parameter is general enough, you may want
+to consider contributing it to the Pywr project. If you do, please see
+the [Developers Guide](./developers-guide/adding-a-parameter.md) for more information on how to do this.
 
 ## Python functions
 
-The simplest way to create a custom parameter is to define a Python function.
-This function should accept at least one argument, which is a `ParameterInfo` object.
-This object contains information from the model, such as the current time step, scenario index,
-and any metric values that have been requested.
-Additional arguments can also be passed to the function.
+The simplest way to create a custom parameter is to define a Python function. This function should accept at least one
+argument, which is a `ParameterInfo` object. This object contains information from the model, such as the current time
+step, scenario index, and any metric values that have been requested. Additional arguments can also be passed to the
+function.
 
 Here is an example of a simple custom parameter that returns the current time step:
 
@@ -30,10 +27,9 @@ def current_time_step(info: ParameterInfo) -> float:
     return info.timestep.index
 ```
 
-To use this custom parameter in your model it must be defined as a `Parameter` in your model's JSON file.
-Below is an example of how to define the `current_time_step` parameter in your model's JSON file.
-The `source` field specifies the path to the Python file containing the function,
-and the `object` field specifies the name of the function to call.
+To use this custom parameter in your model it must be defined as a `Parameter` in your model's JSON file. Below is an
+example of how to define the `current_time_step` parameter in your model's JSON file. The `source` field specifies the
+path to the Python file containing the function, and the `object` field specifies the name of the function to call.
 
 ```json
 {
@@ -60,13 +56,12 @@ and the `object` field specifies the name of the function to call.
 
 ### Constant arguments
 
-In reality, your function will likely need to accept additional arguments.
-These arguments might be constants that change the behaviour of the function, but do *not* change over time
-or are a result of the model's simulation state.
-In this case they can be defined as `args` or `kwargs` in the parameter definition.
-Only simple types that are supported by JSON can be used as arguments, such as strings, numbers, and booleans.
-However, by parameterising these values, you can easily change them without modifying the Python code or reuse
-the same function with different values in different parts of the model.
+In reality, your function will likely need to accept additional arguments. These arguments might be constants that
+change the behaviour of the function, but do *not* change over time or are a result of the model's simulation state. In
+this case they can be defined as `args` or `kwargs` in the parameter definition. Only simple types that are supported by
+JSON can be used as arguments, such as strings, numbers, and booleans. However, by parameterising these values, you can
+easily change them without modifying the Python code or reuse the same function with different values in different parts
+of the model.
 
 ```python
 # custom_parameters.py
@@ -118,10 +113,9 @@ To pass these arguments to the function, you can define them in the model's JSON
 
 ### Metrics from the model
 
-More complex parameters will need information from the model, such as the current volume of a reservoir, or
-the value of another parameter, etc.
-These values need to be requested in the JSON definition of parameter, and then they can be accessed in the function
-using the `ParameterInfo` object.
+More complex parameters will need information from the model, such as the current volume of a reservoir, or the value of
+another parameter, etc. These values need to be requested in the JSON definition of parameter, and then they can be
+accessed in the function using the `ParameterInfo` object.
 
 ```python
 # custom_parameters.py
@@ -136,8 +130,8 @@ def factor_volume(info: ParameterInfo, factor: float) -> float:
 
 The JSON definition of the parameter needs to include a `metrics` and/or `indices` field that specifies which model
 metrics to request. Both fields are a dictionary where the keys are the keys used to retrieve the values from the
-`ParameterInfo` object, and the values specify the metric to retrieve. Metrics are accessed using `get_metric(key)`,
-and indices are accessed using `get_index(key)`.
+`ParameterInfo` object, and the values specify the metric to retrieve. Metrics are accessed using `get_metric(key)`, and
+indices are accessed using `get_index(key)`.
 
 ```json
 {
@@ -173,23 +167,22 @@ and indices are accessed using `get_index(key)`.
 
 ## Python classes & stateful parameters
 
-If your parameter needs to maintain state between calls, you can define it as a Python class.
-This class should implement an `__init__` method that setups up the parameter, including any
-initial state.
-The `__init__` method is passed the `args` and `kwargs` defined in the JSON file.
-Pywr will create an instance of the class for every scenario in a simulation.
-These instances will be reused for each time step in the scenario, allowing you to maintain state across time steps.
+If your parameter needs to maintain state between calls, you can define it as a Python class. This class should
+implement an `__init__` method that setups up the parameter, including any initial state. The `__init__` method is
+passed the `args` and `kwargs` defined in the JSON file. Pywr will create an instance of the class for every scenario in
+a simulation. These instances will be reused for each time step in the scenario, allowing you to maintain state across
+time steps.
 
 > **Note**: Unlike Pywr v1.x a separate instance of the class is created for each scenario.
 > This means you do not have to worry about state being shared between scenarios, and do *not* need to implement
 > state for each scenario yourself.
 
-The class should also implement `before` method, which is called for each time step in the scenario.
-This method should accept a `ParameterInfo` object as its only argument.
+The class should also implement `before` method, which is called for each time step in the scenario. This method should
+accept a `ParameterInfo` object as its only argument.
 
-Finally, the class may also implement an `after` method, which is called after the resource allocation
-has been completed for the time step.
-This method can be used to perform any final calculations or updates to the parameter state.
+Finally, the class may also implement an `after` method, which is called after the resource allocation has been
+completed for the time step. This method can be used to perform any final calculations or updates to the parameter
+state.
 
 Here is an example of a simple stateful parameter that counts the number of time steps:
 
@@ -240,9 +233,9 @@ To use this custom parameter in your model, you can define it in the JSON file a
 
 ## Using modules instead of files
 
-It might be more convenient to define your custom parameters in a Python module instead of a file. This
-allows you to integrate your custom parameters with other Python code, such as unit tests or other utility functions.
-To do this, you can use the `source` field to specify the module name instead of a file path.
+It might be more convenient to define your custom parameters in a Python module instead of a file. This allows you to
+integrate your custom parameters with other Python code, such as unit tests or other utility functions. To do this, you
+can use the `source` field to specify the module name instead of a file path.
 
 Here is an example of how to define a custom parameter in a module (in this case `my_model.parameters`):
 
@@ -271,13 +264,11 @@ Here is an example of how to define a custom parameter in a module (in this case
 
 ## Returning integers or multiple values
 
-In the examples above the custom parameter functions return a single floating point value.
-However, you can also return integers or multiple values.
-In the JSON definition of the parameter, you can specify the `return_type` field to indicate the type of value
-the function will return.
-To return an integer, you can set the `return_type` to `"Int"`.
-To return multiple values, you can set the `return_type` to `"Dict"` and the function should return a dictionary
-where the keys are the names of the values and the values are the values themselves.
+In the examples above the custom parameter functions return a single floating point value. However, you can also return
+integers or multiple values. In the JSON definition of the parameter, you can specify the `return_type` field to
+indicate the type of value the function will return. To return an integer, you can set the `return_type` to `"Int"`. To
+return multiple values, you can set the `return_type` to `"Dict"` and the function should return a dictionary where the
+keys are the names of the values and the values are the values themselves.
 
 An example of a custom parameter that returns multiple values is shown below:
 
@@ -344,9 +335,9 @@ calculations after the resource allocation has been completed. Typically, this i
 access the results of the resource allocation, such as the allocated flow or the new volume of a reservoir after the
 allocation. In this case, the parameter can implement an `after` method.
 
-The example below lists a custom parameter that implements both `before` and `after` methods. It is a simple crop
-water requirement parameter that calculates the water requirement for a crop based on the current month in `before`,
-and then computes a crop yield in `after` based on the allocated water and the water requirement.
+The example below lists a custom parameter that implements both `before` and `after` methods. It is a simple crop water
+requirement parameter that calculates the water requirement for a crop based on the current month in `before`, and then
+computes a crop yield in `after` based on the allocated water and the water requirement.
 
 [//]: # (@formatter:off)
 
@@ -354,9 +345,9 @@ and then computes a crop yield in `after` based on the allocated water and the w
 {{ #include ../py-listings/agri-parameter/agri_parameter.py}}
 ```
 
-When referring to the parameter in the model, the `return_value` field can be used to specify whether to use the value 
+When referring to the parameter in the model, the `source` field can be used to specify whether to use the value 
 returned by the `before` or `after` method. By default, the value returned by the `before` method is used, but if you 
-want to use the value from the `after` method you can set `return_value` to `"After"`. The example below shows how to 
+want to use the value from the `after` method you can set `source` to `"After"`. The example below shows how to 
 use the `CropParameter` above parameter in a metric set, and specify that the value from the `after` method should be used.
 
 [//]: # (@formatter:off)

--- a/pywr-book/src/custom_parameters.md
+++ b/pywr-book/src/custom_parameters.md
@@ -69,7 +69,7 @@ from pywr import ParameterInfo
 
 
 def current_timestep(
-    info: ParameterInfo, a: float, b: float, some_condition: str = "foo"
+        info: ParameterInfo, a: float, b: float, some_condition: str = "foo"
 ) -> float:
     """Return the current time step."""
     match some_condition:
@@ -345,9 +345,9 @@ computes a crop yield in `after` based on the allocated water and the water requ
 {{ #include ../py-listings/agri-parameter/agri_parameter.py}}
 ```
 
-When referring to the parameter in the model, the `source` field can be used to specify whether to use the value 
+When referring to the parameter in the model, the `return_value` field can be used to specify whether to use the value 
 returned by the `before` or `after` method. By default, the value returned by the `before` method is used, but if you 
-want to use the value from the `after` method you can set `source` to `"After"`. The example below shows how to 
+want to use the value from the `after` method you can set `return_value` to `"After"`. The example below shows how to 
 use the `CropParameter` above parameter in a metric set, and specify that the value from the `after` method should be used.
 
 [//]: # (@formatter:off)

--- a/pywr-core/src/aggregated_node.rs
+++ b/pywr-core/src/aggregated_node.rs
@@ -1092,7 +1092,7 @@ mod tests {
     use crate::models::ModelBuilder;
     use crate::network::NetworkBuilder;
     use crate::node::{NodeBuilder, UnresolvedNode};
-    use crate::parameters::{MonthlyProfileParameterBuilder, ParameterName, ParameterReturnValue};
+    use crate::parameters::{MonthlyProfileParameterBuilder, ParameterName, UnresolvedParameterReturnValue};
     use crate::recorders::AssertionF64RecorderBuilder;
     use crate::test_utils::{default_domain, run_all_solvers};
     use ndarray::Array2;
@@ -1221,7 +1221,7 @@ mod tests {
         relationship
             .factor(UnresolvedMetricF64::ParameterValue {
                 name: factor_profile_name,
-                return_value: ParameterReturnValue::Before,
+                return_value: UnresolvedParameterReturnValue::Before,
             })
             .factor(1.0.into());
 

--- a/pywr-core/src/metric.rs
+++ b/pywr-core/src/metric.rs
@@ -7,7 +7,7 @@ use crate::network::{
 use crate::node::{NodeError, UnresolvedNode};
 use crate::parameters::{
     ConstParameterIndex, GeneralAfterValueIndex, GeneralBeforeValueIndex, ParameterIndex, ParameterName,
-    ParameterReturnValue, SimpleParameterIndex,
+    SimpleParameterIndex, UnresolvedParameterReturnValue,
 };
 use crate::state::{
     ConstParameterValues, ConstParameterValuesError, MultiValue, NetworkStateError, SimpleParameterValues,
@@ -109,6 +109,16 @@ impl SimpleMetricF64 {
     }
 }
 
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum ParameterReturnValue<T> {
+    Before(GeneralBeforeValueIndex<T>),
+    After(GeneralAfterValueIndex<T>),
+    // Returns the value corresponding to the requested phase.
+    Requested {
+        before: GeneralBeforeValueIndex<T>,
+        after: GeneralAfterValueIndex<T>,
+    },
+}
 #[derive(Debug, Error)]
 pub enum MetricF64Error {
     #[error("Node index not found: {0}")]
@@ -150,16 +160,14 @@ pub enum MetricF64 {
         indices: Vec<EdgeIndex>,
         name: String,
     },
-    ParameterBeforeF64(GeneralBeforeValueIndex<f64>),
-    ParameterAfterF64(GeneralAfterValueIndex<f64>),
-    ParameterBeforeU64(GeneralBeforeValueIndex<u64>),
-    ParameterAfterU64(GeneralAfterValueIndex<u64>),
-    ParameterBeforeMulti {
-        index: GeneralBeforeValueIndex<MultiValue>,
-        key: String,
+    ParameterF64 {
+        indices: ParameterReturnValue<f64>,
     },
-    ParameterAfterMulti {
-        index: GeneralAfterValueIndex<MultiValue>,
+    ParameterU64 {
+        indices: ParameterReturnValue<u64>,
+    },
+    ParameterMulti {
+        indices: ParameterReturnValue<MultiValue>,
         key: String,
     },
     VirtualStorageVolume(VirtualStorageIndex),
@@ -176,6 +184,12 @@ pub enum MetricF64 {
     // TODO implement other MultiNodeXXX variants
     InterNetworkTransfer(MultiNetworkTransferIndex),
     Simple(SimpleMetricF64),
+}
+
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum CalculationPhase {
+    Before,
+    After,
 }
 
 impl MetricF64 {
@@ -236,19 +250,31 @@ impl MetricF64 {
                     .sum::<Result<_, _>>()?;
                 Ok(flow)
             }
-            MetricF64::ParameterBeforeF64(idx) => Ok(state.get_general_parameter_f64_before(*idx)?),
-            MetricF64::ParameterAfterF64(idx) => Ok(state.get_general_parameter_f64_after(*idx)?),
-            MetricF64::ParameterBeforeU64(idx) => Ok(state.get_general_parameter_u64_before(*idx)? as f64),
-            MetricF64::ParameterAfterU64(idx) => Ok(state.get_general_parameter_u64_after(*idx)? as f64),
-            MetricF64::ParameterBeforeMulti { index, key } => {
-                let mv = state.get_general_parameter_multi_before(*index)?;
-                let value = mv
-                    .get_value(key)
-                    .ok_or_else(|| MetricF64Error::GeneralMultiValueParameterKeyNotFound { key: key.clone() })?;
-                Ok(*value)
-            }
-            MetricF64::ParameterAfterMulti { index, key } => {
-                let mv = state.get_general_parameter_multi_after(*index)?;
+            MetricF64::ParameterF64 { indices } => match indices {
+                ParameterReturnValue::Before(index) => Ok(state.get_general_parameter_f64_before(*index)?),
+                ParameterReturnValue::After(index) => Ok(state.get_general_parameter_f64_after(*index)?),
+                ParameterReturnValue::Requested { before, after } => match state.get_calculation_phase() {
+                    CalculationPhase::Before => Ok(state.get_general_parameter_f64_before(*before)?),
+                    CalculationPhase::After => Ok(state.get_general_parameter_f64_after(*after)?),
+                },
+            },
+            MetricF64::ParameterU64 { indices } => match indices {
+                ParameterReturnValue::Before(index) => Ok(state.get_general_parameter_u64_before(*index)? as f64),
+                ParameterReturnValue::After(index) => Ok(state.get_general_parameter_u64_after(*index)? as f64),
+                ParameterReturnValue::Requested { before, after } => match state.get_calculation_phase() {
+                    CalculationPhase::Before => Ok(state.get_general_parameter_u64_before(*before)? as f64),
+                    CalculationPhase::After => Ok(state.get_general_parameter_u64_after(*after)? as f64),
+                },
+            },
+            MetricF64::ParameterMulti { indices, key } => {
+                let mv = match indices {
+                    ParameterReturnValue::Before(index) => state.get_general_parameter_multi_before(*index)?,
+                    ParameterReturnValue::After(index) => state.get_general_parameter_multi_after(*index)?,
+                    ParameterReturnValue::Requested { before, after } => match state.get_calculation_phase() {
+                        CalculationPhase::Before => state.get_general_parameter_multi_before(*before)?,
+                        CalculationPhase::After => state.get_general_parameter_multi_after(*after)?,
+                    },
+                };
                 let value = mv
                     .get_value(key)
                     .ok_or_else(|| MetricF64Error::GeneralMultiValueParameterKeyNotFound { key: key.clone() })?;
@@ -450,7 +476,7 @@ pub enum MetricF64ResolutionError {
     ParameterNotRegisteredInCorrectPhase {
         parameter: ParameterName,
         consumer_phase: MetricConsumerPhase,
-        return_value: ParameterReturnValue,
+        return_value: UnresolvedParameterReturnValue,
     },
 }
 
@@ -473,12 +499,12 @@ pub enum UnresolvedMetricF64 {
     },
     ParameterValue {
         name: ParameterName,
-        return_value: ParameterReturnValue,
+        return_value: UnresolvedParameterReturnValue,
     },
     MultiParameterValue {
         name: ParameterName,
         key: String,
-        return_value: ParameterReturnValue,
+        return_value: UnresolvedParameterReturnValue,
     },
     VirtualStorageVolume(UnresolvedNode),
     VirtualStorageProportionalVolume(UnresolvedNode),
@@ -497,49 +523,49 @@ pub enum UnresolvedMetricF64 {
 
 impl UnresolvedMetricF64 {
     /// Create a new [`Self::ParameterValue`] variant with the given parameter name and a return
-    /// value of [`ParameterReturnValue::Before`].
+    /// value of [`UnresolvedParameterReturnValue::Before`].
     pub fn new_parameter_before<N: Into<ParameterName>>(name: N) -> Self {
         Self::ParameterValue {
             name: name.into(),
-            return_value: ParameterReturnValue::Before,
+            return_value: UnresolvedParameterReturnValue::Before,
         }
     }
 
     /// Create a new [`Self::MultiParameterValue`] variant with the given parameter name and a return
-    /// value of [`ParameterReturnValue::Before`].
+    /// value of [`UnresolvedParameterReturnValue::Before`].
     pub fn new_parameter_before_key<N: Into<ParameterName>>(name: N, key: &str) -> Self {
         Self::MultiParameterValue {
             name: name.into(),
             key: key.to_string(),
-            return_value: ParameterReturnValue::Before,
+            return_value: UnresolvedParameterReturnValue::Before,
         }
     }
 
     /// Create a new [`Self::ParameterValue`] variant with the given parameter name and a return
-    /// value of [`ParameterReturnValue::After`].
+    /// value of [`UnresolvedParameterReturnValue::After`].
     pub fn new_parameter_after<N: Into<ParameterName>>(name: N) -> Self {
         Self::ParameterValue {
             name: name.into(),
-            return_value: ParameterReturnValue::After,
+            return_value: UnresolvedParameterReturnValue::After,
         }
     }
 
     /// Create a new [`Self::ParameterValue`] variant with the given parameter name and a return
-    /// value of [`ParameterReturnValue::AfterOrElseInitial`].
+    /// value of [`UnresolvedParameterReturnValue::AfterOrElseInitial`].
     pub fn new_parameter_after_else_initial<N: Into<ParameterName>>(name: N) -> Self {
         Self::ParameterValue {
             name: name.into(),
-            return_value: ParameterReturnValue::AfterOrElseInitial,
+            return_value: UnresolvedParameterReturnValue::AfterOrElseInitial,
         }
     }
 
     /// Create a new [`Self::MultiParameterValue`] variant with the given parameter name and a return
-    /// value of [`ParameterReturnValue::After`].
+    /// value of [`UnresolvedParameterReturnValue::After`].
     pub fn new_parameter_after_key<N: Into<ParameterName>>(name: N, key: &str) -> Self {
         Self::MultiParameterValue {
             name: name.into(),
             key: key.to_string(),
-            return_value: ParameterReturnValue::After,
+            return_value: UnresolvedParameterReturnValue::After,
         }
     }
 
@@ -789,7 +815,7 @@ impl From<f64> for UnresolvedMetricF64 {
     }
 }
 
-/// Resolve a [`ParameterIndex<f64>`] to a [`MetricF64`] using the provided [`ParameterReturnValue`]
+/// Resolve a [`ParameterIndex<f64>`] to a [`MetricF64`] using the provided [`UnresolvedParameterReturnValue`]
 /// and [`MetricConsumerPhase`]. This function is used to determine if a parameter can be resolved to a metric
 /// based on the phase in which the consumer is using the metric and the return value of the parameter.
 ///
@@ -797,15 +823,17 @@ impl From<f64> for UnresolvedMetricF64 {
 fn resolve_parameter_index_f64_to_metric_f64(
     name: &ParameterName,
     idx: ParameterIndex<f64>,
-    parameter_return_value: ParameterReturnValue,
+    parameter_return_value: UnresolvedParameterReturnValue,
     consumer_phase: MetricConsumerPhase,
 ) -> Result<MetricF64, MetricF64ResolutionError> {
     match idx {
         // Constant and simple can always be resolved to a metric, regardless of the consumer phase
         // as long as the parameter return value is "before".
         ParameterIndex::Const(idx) => match parameter_return_value {
-            ParameterReturnValue::Before => Ok(ConstantMetricF64::ParameterValue(idx).into()),
-            ParameterReturnValue::After | ParameterReturnValue::AfterOrElseInitial => {
+            UnresolvedParameterReturnValue::Before => Ok(ConstantMetricF64::ParameterValue(idx).into()),
+            UnresolvedParameterReturnValue::After
+            | UnresolvedParameterReturnValue::AfterOrElseInitial
+            | UnresolvedParameterReturnValue::Both => {
                 Err(MetricF64ResolutionError::ParameterNotRegisteredInCorrectPhase {
                     parameter: name.clone(),
                     consumer_phase,
@@ -814,8 +842,10 @@ fn resolve_parameter_index_f64_to_metric_f64(
             }
         },
         ParameterIndex::Simple(idx) => match parameter_return_value {
-            ParameterReturnValue::Before => Ok(SimpleMetricF64::ParameterValue { index: idx }.into()),
-            ParameterReturnValue::After | ParameterReturnValue::AfterOrElseInitial => {
+            UnresolvedParameterReturnValue::Before => Ok(SimpleMetricF64::ParameterValue { index: idx }.into()),
+            UnresolvedParameterReturnValue::After
+            | UnresolvedParameterReturnValue::AfterOrElseInitial
+            | UnresolvedParameterReturnValue::Both => {
                 Err(MetricF64ResolutionError::ParameterNotRegisteredInCorrectPhase {
                     parameter: name.clone(),
                     consumer_phase,
@@ -826,12 +856,14 @@ fn resolve_parameter_index_f64_to_metric_f64(
         // General parameters must be validated against the consumer phase to determine if they can be resolved to a metric.
         ParameterIndex::General(idx) => {
             match (parameter_return_value, consumer_phase) {
-                (ParameterReturnValue::Before, MetricConsumerPhase::Before) => {
+                (UnresolvedParameterReturnValue::Before, MetricConsumerPhase::Before) => {
                     // The consumer is using the metric in the "before" phase, and the parameter is
                     // providing a "before" value, so we can resolve it to a metric provided the
                     // parameter index contains a "before" index.
                     match idx.before {
-                        Some(before_idx) => Ok(MetricF64::ParameterBeforeF64(before_idx)),
+                        Some(before_idx) => Ok(MetricF64::ParameterF64 {
+                            indices: ParameterReturnValue::Before(before_idx),
+                        }),
                         None => Err(MetricF64ResolutionError::ParameterNotRegisteredInCorrectPhase {
                             parameter: name.clone(),
                             consumer_phase,
@@ -839,13 +871,15 @@ fn resolve_parameter_index_f64_to_metric_f64(
                         }),
                     }
                 }
-                (ParameterReturnValue::Before, MetricConsumerPhase::After) => {
+                (UnresolvedParameterReturnValue::Before, MetricConsumerPhase::After) => {
                     // The consumer is using the metric in the "after" phase, but the parameter is
                     // providing a "before" value. This is fine because the "before" value is still
                     // valid in the "after" phase, so we can resolve it to a metric provided the
                     // parameter index contains a "before" index.
                     match idx.before {
-                        Some(before_idx) => Ok(MetricF64::ParameterBeforeF64(before_idx)),
+                        Some(before_idx) => Ok(MetricF64::ParameterF64 {
+                            indices: ParameterReturnValue::Before(before_idx),
+                        }),
                         None => Err(MetricF64ResolutionError::ParameterNotRegisteredInCorrectPhase {
                             parameter: name.clone(),
                             consumer_phase,
@@ -853,13 +887,15 @@ fn resolve_parameter_index_f64_to_metric_f64(
                         }),
                     }
                 }
-                (ParameterReturnValue::Before, MetricConsumerPhase::Both) => {
+                (UnresolvedParameterReturnValue::Before, MetricConsumerPhase::Both) => {
                     // The consumer is using the metric in both "before" and "after" phases, and the
                     // parameter is providing a "before" value. This is fine because the "before"
                     // value is valid in both phases, so we can resolve it to a metric provided the
                     // parameter index contains a "before" index.
                     match idx.before {
-                        Some(before_idx) => Ok(MetricF64::ParameterBeforeF64(before_idx)),
+                        Some(before_idx) => Ok(MetricF64::ParameterF64 {
+                            indices: ParameterReturnValue::Before(before_idx),
+                        }),
                         None => Err(MetricF64ResolutionError::ParameterNotRegisteredInCorrectPhase {
                             parameter: name.clone(),
                             consumer_phase,
@@ -867,8 +903,8 @@ fn resolve_parameter_index_f64_to_metric_f64(
                         }),
                     }
                 }
-                (ParameterReturnValue::After, MetricConsumerPhase::Before)
-                | (ParameterReturnValue::After, MetricConsumerPhase::Both) => {
+                (UnresolvedParameterReturnValue::After, MetricConsumerPhase::Before)
+                | (UnresolvedParameterReturnValue::After, MetricConsumerPhase::Both) => {
                     // The consumer is using the metric in the "before" phase, but the parameter is
                     // providing an "after" value. This is not valid because the "after" value is not
                     // valid in the "before" phase, so we cannot resolve it to a metric.
@@ -878,12 +914,14 @@ fn resolve_parameter_index_f64_to_metric_f64(
                         return_value: parameter_return_value,
                     })
                 }
-                (ParameterReturnValue::After, MetricConsumerPhase::After) => {
+                (UnresolvedParameterReturnValue::After, MetricConsumerPhase::After) => {
                     // The consumer is using the metric in the "after" phase, and the parameter is
                     // providing an "after" value, so we can resolve it to a metric provided the
                     // parameter index contains an "after" index.
                     match idx.after {
-                        Some(after_idx) => Ok(MetricF64::ParameterAfterF64(after_idx)),
+                        Some(after_idx) => Ok(MetricF64::ParameterF64 {
+                            indices: ParameterReturnValue::After(after_idx),
+                        }),
                         None => Err(MetricF64ResolutionError::ParameterNotRegisteredInCorrectPhase {
                             parameter: name.clone(),
                             consumer_phase,
@@ -891,13 +929,15 @@ fn resolve_parameter_index_f64_to_metric_f64(
                         }),
                     }
                 }
-                (ParameterReturnValue::AfterOrElseInitial, MetricConsumerPhase::Before) => {
+                (UnresolvedParameterReturnValue::AfterOrElseInitial, MetricConsumerPhase::Before) => {
                     // The consumer is using the metric in the "before" phase, but the parameter is
                     // providing an "after" value. However, they have specified that using any
                     // initial value is acceptable, so we can resolve it to a metric provided the
                     // parameter index contains an "after" index.
                     match idx.after {
-                        Some(after_idx) => Ok(MetricF64::ParameterAfterF64(after_idx)),
+                        Some(after_idx) => Ok(MetricF64::ParameterF64 {
+                            indices: ParameterReturnValue::After(after_idx),
+                        }),
                         None => Err(MetricF64ResolutionError::ParameterNotRegisteredInCorrectPhase {
                             parameter: name.clone(),
                             consumer_phase,
@@ -905,12 +945,14 @@ fn resolve_parameter_index_f64_to_metric_f64(
                         }),
                     }
                 }
-                (ParameterReturnValue::AfterOrElseInitial, MetricConsumerPhase::After) => {
+                (UnresolvedParameterReturnValue::AfterOrElseInitial, MetricConsumerPhase::After) => {
                     // The consumer is using the metric in the "after" phase, and the parameter is
                     // providing an "after" value, so we can resolve it to a metric provided the
                     // parameter index contains an "after" index.
                     match idx.after {
-                        Some(after_idx) => Ok(MetricF64::ParameterAfterF64(after_idx)),
+                        Some(after_idx) => Ok(MetricF64::ParameterF64 {
+                            indices: ParameterReturnValue::After(after_idx),
+                        }),
                         None => Err(MetricF64ResolutionError::ParameterNotRegisteredInCorrectPhase {
                             parameter: name.clone(),
                             consumer_phase,
@@ -918,14 +960,64 @@ fn resolve_parameter_index_f64_to_metric_f64(
                         }),
                     }
                 }
-                (ParameterReturnValue::AfterOrElseInitial, MetricConsumerPhase::Both) => {
+                (UnresolvedParameterReturnValue::AfterOrElseInitial, MetricConsumerPhase::Both) => {
                     // The consumer is using the metric in both "before" and "after" phases, and the
                     // parameter is providing an "after" value. However, they have specified that using any
                     // initial value is acceptable in the "before" phase, so we can resolve it to a metric provided the
                     // parameter index contains an "after" index.
                     match idx.after {
-                        Some(after_idx) => Ok(MetricF64::ParameterAfterF64(after_idx)),
+                        Some(after_idx) => Ok(MetricF64::ParameterF64 {
+                            indices: ParameterReturnValue::After(after_idx),
+                        }),
                         None => Err(MetricF64ResolutionError::ParameterNotRegisteredInCorrectPhase {
+                            parameter: name.clone(),
+                            consumer_phase,
+                            return_value: parameter_return_value,
+                        }),
+                    }
+                }
+                (UnresolvedParameterReturnValue::Both, MetricConsumerPhase::Before) => {
+                    // The consumer is using the metric in the "before" phase, and the parameter is
+                    // providing both "before" and "after" values. We can resolve it to a metric provided the
+                    // parameter index contains a "before" index.
+                    match idx.before {
+                        Some(before_idx) => Ok(MetricF64::ParameterF64 {
+                            indices: ParameterReturnValue::Before(before_idx),
+                        }),
+                        None => Err(MetricF64ResolutionError::ParameterNotRegisteredInCorrectPhase {
+                            parameter: name.clone(),
+                            consumer_phase,
+                            return_value: parameter_return_value,
+                        }),
+                    }
+                }
+                (UnresolvedParameterReturnValue::Both, MetricConsumerPhase::After) => {
+                    // The consumer is using the metric in the "after" phase, and the parameter is
+                    // providing both "before" and "after" values. We can resolve it to a metric provided the
+                    // parameter index contains an "after" index.
+                    match idx.after {
+                        Some(after_idx) => Ok(MetricF64::ParameterF64 {
+                            indices: ParameterReturnValue::After(after_idx),
+                        }),
+                        None => Err(MetricF64ResolutionError::ParameterNotRegisteredInCorrectPhase {
+                            parameter: name.clone(),
+                            consumer_phase,
+                            return_value: parameter_return_value,
+                        }),
+                    }
+                }
+                (UnresolvedParameterReturnValue::Both, MetricConsumerPhase::Both) => {
+                    // The consumer is using the metric in both "before" and "after" phases, and the
+                    // parameter is providing both "before" and "after" values. We can resolve it to a metric provided the
+                    // parameter index contains both a "before" and an "after" index.
+                    match (idx.before, idx.after) {
+                        (Some(before_idx), Some(after_idx)) => Ok(MetricF64::ParameterF64 {
+                            indices: ParameterReturnValue::Requested {
+                                before: before_idx,
+                                after: after_idx,
+                            },
+                        }),
+                        _ => Err(MetricF64ResolutionError::ParameterNotRegisteredInCorrectPhase {
                             parameter: name.clone(),
                             consumer_phase,
                             return_value: parameter_return_value,
@@ -937,7 +1029,7 @@ fn resolve_parameter_index_f64_to_metric_f64(
     }
 }
 
-/// Resolve a [`ParameterIndex<u64>`] to a [`MetricF64`] using the provided [`ParameterReturnValue`]
+/// Resolve a [`ParameterIndex<u64>`] to a [`MetricF64`] using the provided [`UnresolvedParameterReturnValue`]
 /// and [`MetricConsumerPhase`]. This function is used to determine if a parameter can be resolved to a metric
 /// based on the phase in which the consumer is using the metric and the return value of the parameter.
 ///
@@ -945,15 +1037,17 @@ fn resolve_parameter_index_f64_to_metric_f64(
 fn resolve_parameter_index_u64_to_metric_f64(
     name: &ParameterName,
     idx: ParameterIndex<u64>,
-    parameter_return_value: ParameterReturnValue,
+    parameter_return_value: UnresolvedParameterReturnValue,
     consumer_phase: MetricConsumerPhase,
 ) -> Result<MetricF64, MetricF64ResolutionError> {
     match idx {
         // Constant and simple can always be resolved to a metric, regardless of the consumer phase
         // as long as the parameter return value is "before".
         ParameterIndex::Const(idx) => match parameter_return_value {
-            ParameterReturnValue::Before => Ok(ConstantMetricF64::IndexParameterValue(idx).into()),
-            ParameterReturnValue::After | ParameterReturnValue::AfterOrElseInitial => {
+            UnresolvedParameterReturnValue::Before => Ok(ConstantMetricF64::IndexParameterValue(idx).into()),
+            UnresolvedParameterReturnValue::After
+            | UnresolvedParameterReturnValue::AfterOrElseInitial
+            | UnresolvedParameterReturnValue::Both => {
                 Err(MetricF64ResolutionError::ParameterNotRegisteredInCorrectPhase {
                     parameter: name.clone(),
                     consumer_phase,
@@ -962,8 +1056,10 @@ fn resolve_parameter_index_u64_to_metric_f64(
             }
         },
         ParameterIndex::Simple(idx) => match parameter_return_value {
-            ParameterReturnValue::Before => Ok(SimpleMetricF64::IndexParameterValue { index: idx }.into()),
-            ParameterReturnValue::After | ParameterReturnValue::AfterOrElseInitial => {
+            UnresolvedParameterReturnValue::Before => Ok(SimpleMetricF64::IndexParameterValue { index: idx }.into()),
+            UnresolvedParameterReturnValue::After
+            | UnresolvedParameterReturnValue::AfterOrElseInitial
+            | UnresolvedParameterReturnValue::Both => {
                 Err(MetricF64ResolutionError::ParameterNotRegisteredInCorrectPhase {
                     parameter: name.clone(),
                     consumer_phase,
@@ -974,12 +1070,14 @@ fn resolve_parameter_index_u64_to_metric_f64(
         // General parameters must be validated against the consumer phase to determine if they can be resolved to a metric.
         ParameterIndex::General(idx) => {
             match (parameter_return_value, consumer_phase) {
-                (ParameterReturnValue::Before, MetricConsumerPhase::Before) => {
+                (UnresolvedParameterReturnValue::Before, MetricConsumerPhase::Before) => {
                     // The consumer is using the metric in the "before" phase, and the parameter is
                     // providing a "before" value, so we can resolve it to a metric provided the
                     // parameter index contains a "before" index.
                     match idx.before {
-                        Some(before_idx) => Ok(MetricF64::ParameterBeforeU64(before_idx)),
+                        Some(before_idx) => Ok(MetricF64::ParameterU64 {
+                            indices: ParameterReturnValue::Before(before_idx),
+                        }),
                         None => Err(MetricF64ResolutionError::ParameterNotRegisteredInCorrectPhase {
                             parameter: name.clone(),
                             consumer_phase,
@@ -987,13 +1085,15 @@ fn resolve_parameter_index_u64_to_metric_f64(
                         }),
                     }
                 }
-                (ParameterReturnValue::Before, MetricConsumerPhase::After) => {
+                (UnresolvedParameterReturnValue::Before, MetricConsumerPhase::After) => {
                     // The consumer is using the metric in the "after" phase, but the parameter is
                     // providing a "before" value. This is fine because the "before" value is still
                     // valid in the "after" phase, so we can resolve it to a metric provided the
                     // parameter index contains a "before" index.
                     match idx.before {
-                        Some(before_idx) => Ok(MetricF64::ParameterBeforeU64(before_idx)),
+                        Some(before_idx) => Ok(MetricF64::ParameterU64 {
+                            indices: ParameterReturnValue::Before(before_idx),
+                        }),
                         None => Err(MetricF64ResolutionError::ParameterNotRegisteredInCorrectPhase {
                             parameter: name.clone(),
                             consumer_phase,
@@ -1001,13 +1101,15 @@ fn resolve_parameter_index_u64_to_metric_f64(
                         }),
                     }
                 }
-                (ParameterReturnValue::Before, MetricConsumerPhase::Both) => {
+                (UnresolvedParameterReturnValue::Before, MetricConsumerPhase::Both) => {
                     // The consumer is using the metric in both "before" and "after" phases, and the
                     // parameter is providing a "before" value. This is fine because the "before"
                     // value is valid in both phases, so we can resolve it to a metric provided the
                     // parameter index contains a "before" index.
                     match idx.before {
-                        Some(before_idx) => Ok(MetricF64::ParameterBeforeU64(before_idx)),
+                        Some(before_idx) => Ok(MetricF64::ParameterU64 {
+                            indices: ParameterReturnValue::Before(before_idx),
+                        }),
                         None => Err(MetricF64ResolutionError::ParameterNotRegisteredInCorrectPhase {
                             parameter: name.clone(),
                             consumer_phase,
@@ -1015,8 +1117,8 @@ fn resolve_parameter_index_u64_to_metric_f64(
                         }),
                     }
                 }
-                (ParameterReturnValue::After, MetricConsumerPhase::Before)
-                | (ParameterReturnValue::After, MetricConsumerPhase::Both) => {
+                (UnresolvedParameterReturnValue::After, MetricConsumerPhase::Before)
+                | (UnresolvedParameterReturnValue::After, MetricConsumerPhase::Both) => {
                     // The consumer is using the metric in the "before" phase, but the parameter is
                     // providing an "after" value. This is not valid because the "after" value is not
                     // valid in the "before" phase, so we cannot resolve it to a metric.
@@ -1026,12 +1128,14 @@ fn resolve_parameter_index_u64_to_metric_f64(
                         return_value: parameter_return_value,
                     })
                 }
-                (ParameterReturnValue::After, MetricConsumerPhase::After) => {
+                (UnresolvedParameterReturnValue::After, MetricConsumerPhase::After) => {
                     // The consumer is using the metric in the "after" phase, and the parameter is
                     // providing an "after" value, so we can resolve it to a metric provided the
                     // parameter index contains an "after" index.
                     match idx.after {
-                        Some(after_idx) => Ok(MetricF64::ParameterAfterU64(after_idx)),
+                        Some(after_idx) => Ok(MetricF64::ParameterU64 {
+                            indices: ParameterReturnValue::After(after_idx),
+                        }),
                         None => Err(MetricF64ResolutionError::ParameterNotRegisteredInCorrectPhase {
                             parameter: name.clone(),
                             consumer_phase,
@@ -1039,13 +1143,15 @@ fn resolve_parameter_index_u64_to_metric_f64(
                         }),
                     }
                 }
-                (ParameterReturnValue::AfterOrElseInitial, MetricConsumerPhase::Before) => {
+                (UnresolvedParameterReturnValue::AfterOrElseInitial, MetricConsumerPhase::Before) => {
                     // The consumer is using the metric in the "before" phase, but the parameter is
                     // providing an "after" value. However, they have specified that using any
                     // initial value is acceptable, so we can resolve it to a metric provided the
                     // parameter index contains an "after" index.
                     match idx.after {
-                        Some(after_idx) => Ok(MetricF64::ParameterAfterU64(after_idx)),
+                        Some(after_idx) => Ok(MetricF64::ParameterU64 {
+                            indices: ParameterReturnValue::After(after_idx),
+                        }),
                         None => Err(MetricF64ResolutionError::ParameterNotRegisteredInCorrectPhase {
                             parameter: name.clone(),
                             consumer_phase,
@@ -1053,12 +1159,14 @@ fn resolve_parameter_index_u64_to_metric_f64(
                         }),
                     }
                 }
-                (ParameterReturnValue::AfterOrElseInitial, MetricConsumerPhase::After) => {
+                (UnresolvedParameterReturnValue::AfterOrElseInitial, MetricConsumerPhase::After) => {
                     // The consumer is using the metric in the "after" phase, and the parameter is
                     // providing an "after" value, so we can resolve it to a metric provided the
                     // parameter index contains an "after" index.
                     match idx.after {
-                        Some(after_idx) => Ok(MetricF64::ParameterAfterU64(after_idx)),
+                        Some(after_idx) => Ok(MetricF64::ParameterU64 {
+                            indices: ParameterReturnValue::After(after_idx),
+                        }),
                         None => Err(MetricF64ResolutionError::ParameterNotRegisteredInCorrectPhase {
                             parameter: name.clone(),
                             consumer_phase,
@@ -1066,14 +1174,64 @@ fn resolve_parameter_index_u64_to_metric_f64(
                         }),
                     }
                 }
-                (ParameterReturnValue::AfterOrElseInitial, MetricConsumerPhase::Both) => {
+                (UnresolvedParameterReturnValue::AfterOrElseInitial, MetricConsumerPhase::Both) => {
                     // The consumer is using the metric in both "before" and "after" phases, and the
                     // parameter is providing an "after" value. However, they have specified that using any
                     // initial value is acceptable in the "before" phase, so we can resolve it to a metric provided the
                     // parameter index contains an "after" index.
                     match idx.after {
-                        Some(after_idx) => Ok(MetricF64::ParameterAfterU64(after_idx)),
+                        Some(after_idx) => Ok(MetricF64::ParameterU64 {
+                            indices: ParameterReturnValue::After(after_idx),
+                        }),
                         None => Err(MetricF64ResolutionError::ParameterNotRegisteredInCorrectPhase {
+                            parameter: name.clone(),
+                            consumer_phase,
+                            return_value: parameter_return_value,
+                        }),
+                    }
+                }
+                (UnresolvedParameterReturnValue::Both, MetricConsumerPhase::Before) => {
+                    // The consumer is using the metric in the "before" phase, and the parameter is
+                    // providing both "before" and "after" values. We can resolve it to a metric provided the
+                    // parameter index contains a "before" index.
+                    match idx.before {
+                        Some(before_idx) => Ok(MetricF64::ParameterU64 {
+                            indices: ParameterReturnValue::Before(before_idx),
+                        }),
+                        None => Err(MetricF64ResolutionError::ParameterNotRegisteredInCorrectPhase {
+                            parameter: name.clone(),
+                            consumer_phase,
+                            return_value: parameter_return_value,
+                        }),
+                    }
+                }
+                (UnresolvedParameterReturnValue::Both, MetricConsumerPhase::After) => {
+                    // The consumer is using the metric in the "after" phase, and the parameter is
+                    // providing both "before" and "after" values. We can resolve it to a metric provided the
+                    // parameter index contains an "after" index.
+                    match idx.after {
+                        Some(after_idx) => Ok(MetricF64::ParameterU64 {
+                            indices: ParameterReturnValue::After(after_idx),
+                        }),
+                        None => Err(MetricF64ResolutionError::ParameterNotRegisteredInCorrectPhase {
+                            parameter: name.clone(),
+                            consumer_phase,
+                            return_value: parameter_return_value,
+                        }),
+                    }
+                }
+                (UnresolvedParameterReturnValue::Both, MetricConsumerPhase::Both) => {
+                    // The consumer is using the metric in both "before" and "after" phases, and the
+                    // parameter is providing both "before" and "after" values. We can resolve it to a metric provided the
+                    // parameter index contains both a "before" and an "after" index.
+                    match (idx.before, idx.after) {
+                        (Some(before_idx), Some(after_idx)) => Ok(MetricF64::ParameterU64 {
+                            indices: ParameterReturnValue::Requested {
+                                before: before_idx,
+                                after: after_idx,
+                            },
+                        }),
+                        _ => Err(MetricF64ResolutionError::ParameterNotRegisteredInCorrectPhase {
                             parameter: name.clone(),
                             consumer_phase,
                             return_value: parameter_return_value,
@@ -1085,7 +1243,7 @@ fn resolve_parameter_index_u64_to_metric_f64(
     }
 }
 
-/// Resolve a [`ParameterIndex<MultiValue>`] to a [`MetricF64`] using the provided [`ParameterReturnValue`]
+/// Resolve a [`ParameterIndex<MultiValue>`] to a [`MetricF64`] using the provided [`UnresolvedParameterReturnValue`]
 /// and [`MetricConsumerPhase`]. This function is used to determine if a parameter can be resolved to a metric
 /// based on the phase in which the consumer is using the metric and the return value of the parameter.
 ///
@@ -1094,19 +1252,21 @@ fn resolve_parameter_index_multi_to_metric_f64(
     name: &ParameterName,
     idx: ParameterIndex<MultiValue>,
     key: &str,
-    parameter_return_value: ParameterReturnValue,
+    parameter_return_value: UnresolvedParameterReturnValue,
     consumer_phase: MetricConsumerPhase,
 ) -> Result<MetricF64, MetricF64ResolutionError> {
     match idx {
         // Constant and simple can always be resolved to a metric, regardless of the consumer phase
         // as long as the parameter return value is "before".
         ParameterIndex::Const(index) => match parameter_return_value {
-            ParameterReturnValue::Before => Ok(ConstantMetricF64::MultiParameterValue {
+            UnresolvedParameterReturnValue::Before => Ok(ConstantMetricF64::MultiParameterValue {
                 index,
                 key: key.to_string(),
             }
             .into()),
-            ParameterReturnValue::After | ParameterReturnValue::AfterOrElseInitial => {
+            UnresolvedParameterReturnValue::After
+            | UnresolvedParameterReturnValue::AfterOrElseInitial
+            | UnresolvedParameterReturnValue::Both => {
                 Err(MetricF64ResolutionError::ParameterNotRegisteredInCorrectPhase {
                     parameter: name.clone(),
                     consumer_phase,
@@ -1115,12 +1275,14 @@ fn resolve_parameter_index_multi_to_metric_f64(
             }
         },
         ParameterIndex::Simple(index) => match parameter_return_value {
-            ParameterReturnValue::Before => Ok(SimpleMetricF64::MultiParameterValue {
+            UnresolvedParameterReturnValue::Before => Ok(SimpleMetricF64::MultiParameterValue {
                 index,
                 key: key.to_string(),
             }
             .into()),
-            ParameterReturnValue::After | ParameterReturnValue::AfterOrElseInitial => {
+            UnresolvedParameterReturnValue::After
+            | UnresolvedParameterReturnValue::AfterOrElseInitial
+            | UnresolvedParameterReturnValue::Both => {
                 Err(MetricF64ResolutionError::ParameterNotRegisteredInCorrectPhase {
                     parameter: name.clone(),
                     consumer_phase,
@@ -1131,13 +1293,13 @@ fn resolve_parameter_index_multi_to_metric_f64(
         // General parameters must be validated against the consumer phase to determine if they can be resolved to a metric.
         ParameterIndex::General(idx) => {
             match (parameter_return_value, consumer_phase) {
-                (ParameterReturnValue::Before, MetricConsumerPhase::Before) => {
+                (UnresolvedParameterReturnValue::Before, MetricConsumerPhase::Before) => {
                     // The consumer is using the metric in the "before" phase, and the parameter is
                     // providing a "before" value, so we can resolve it to a metric provided the
                     // parameter index contains a "before" index.
                     match idx.before {
-                        Some(before_idx) => Ok(MetricF64::ParameterBeforeMulti {
-                            index: before_idx,
+                        Some(before_idx) => Ok(MetricF64::ParameterMulti {
+                            indices: ParameterReturnValue::Before(before_idx),
                             key: key.to_string(),
                         }),
                         None => Err(MetricF64ResolutionError::ParameterNotRegisteredInCorrectPhase {
@@ -1147,14 +1309,14 @@ fn resolve_parameter_index_multi_to_metric_f64(
                         }),
                     }
                 }
-                (ParameterReturnValue::Before, MetricConsumerPhase::After) => {
+                (UnresolvedParameterReturnValue::Before, MetricConsumerPhase::After) => {
                     // The consumer is using the metric in the "after" phase, but the parameter is
                     // providing a "before" value. This is fine because the "before" value is still
                     // valid in the "after" phase, so we can resolve it to a metric provided the
                     // parameter index contains a "before" index.
                     match idx.before {
-                        Some(before_idx) => Ok(MetricF64::ParameterBeforeMulti {
-                            index: before_idx,
+                        Some(before_idx) => Ok(MetricF64::ParameterMulti {
+                            indices: ParameterReturnValue::Before(before_idx),
                             key: key.to_string(),
                         }),
                         None => Err(MetricF64ResolutionError::ParameterNotRegisteredInCorrectPhase {
@@ -1164,14 +1326,14 @@ fn resolve_parameter_index_multi_to_metric_f64(
                         }),
                     }
                 }
-                (ParameterReturnValue::Before, MetricConsumerPhase::Both) => {
+                (UnresolvedParameterReturnValue::Before, MetricConsumerPhase::Both) => {
                     // The consumer is using the metric in both "before" and "after" phases, and the
                     // parameter is providing a "before" value. This is fine because the "before"
                     // value is valid in both phases, so we can resolve it to a metric provided the
                     // parameter index contains a "before" index.
                     match idx.before {
-                        Some(before_idx) => Ok(MetricF64::ParameterBeforeMulti {
-                            index: before_idx,
+                        Some(before_idx) => Ok(MetricF64::ParameterMulti {
+                            indices: ParameterReturnValue::Before(before_idx),
                             key: key.to_string(),
                         }),
                         None => Err(MetricF64ResolutionError::ParameterNotRegisteredInCorrectPhase {
@@ -1181,8 +1343,8 @@ fn resolve_parameter_index_multi_to_metric_f64(
                         }),
                     }
                 }
-                (ParameterReturnValue::After, MetricConsumerPhase::Before)
-                | (ParameterReturnValue::After, MetricConsumerPhase::Both) => {
+                (UnresolvedParameterReturnValue::After, MetricConsumerPhase::Before)
+                | (UnresolvedParameterReturnValue::After, MetricConsumerPhase::Both) => {
                     // The consumer is using the metric in the "before" phase, but the parameter is
                     // providing an "after" value. This is not valid because the "after" value is not
                     // valid in the "before" phase, so we cannot resolve it to a metric.
@@ -1192,13 +1354,13 @@ fn resolve_parameter_index_multi_to_metric_f64(
                         return_value: parameter_return_value,
                     })
                 }
-                (ParameterReturnValue::After, MetricConsumerPhase::After) => {
+                (UnresolvedParameterReturnValue::After, MetricConsumerPhase::After) => {
                     // The consumer is using the metric in the "after" phase, and the parameter is
                     // providing an "after" value, so we can resolve it to a metric provided the
                     // parameter index contains an "after" index.
                     match idx.after {
-                        Some(after_idx) => Ok(MetricF64::ParameterAfterMulti {
-                            index: after_idx,
+                        Some(after_idx) => Ok(MetricF64::ParameterMulti {
+                            indices: ParameterReturnValue::After(after_idx),
                             key: key.to_string(),
                         }),
                         None => Err(MetricF64ResolutionError::ParameterNotRegisteredInCorrectPhase {
@@ -1208,14 +1370,14 @@ fn resolve_parameter_index_multi_to_metric_f64(
                         }),
                     }
                 }
-                (ParameterReturnValue::AfterOrElseInitial, MetricConsumerPhase::Before) => {
+                (UnresolvedParameterReturnValue::AfterOrElseInitial, MetricConsumerPhase::Before) => {
                     // The consumer is using the metric in the "before" phase, but the parameter is
                     // providing an "after" value. However, they have specified that using any
                     // initial value is acceptable, so we can resolve it to a metric provided the
                     // parameter index contains an "after" index.
                     match idx.after {
-                        Some(after_idx) => Ok(MetricF64::ParameterAfterMulti {
-                            index: after_idx,
+                        Some(after_idx) => Ok(MetricF64::ParameterMulti {
+                            indices: ParameterReturnValue::After(after_idx),
                             key: key.to_string(),
                         }),
                         None => Err(MetricF64ResolutionError::ParameterNotRegisteredInCorrectPhase {
@@ -1225,13 +1387,13 @@ fn resolve_parameter_index_multi_to_metric_f64(
                         }),
                     }
                 }
-                (ParameterReturnValue::AfterOrElseInitial, MetricConsumerPhase::After) => {
+                (UnresolvedParameterReturnValue::AfterOrElseInitial, MetricConsumerPhase::After) => {
                     // The consumer is using the metric in the "after" phase, and the parameter is
                     // providing an "after" value, so we can resolve it to a metric provided the
                     // parameter index contains an "after" index.
                     match idx.after {
-                        Some(after_idx) => Ok(MetricF64::ParameterAfterMulti {
-                            index: after_idx,
+                        Some(after_idx) => Ok(MetricF64::ParameterMulti {
+                            indices: ParameterReturnValue::After(after_idx),
                             key: key.to_string(),
                         }),
                         None => Err(MetricF64ResolutionError::ParameterNotRegisteredInCorrectPhase {
@@ -1241,17 +1403,68 @@ fn resolve_parameter_index_multi_to_metric_f64(
                         }),
                     }
                 }
-                (ParameterReturnValue::AfterOrElseInitial, MetricConsumerPhase::Both) => {
+                (UnresolvedParameterReturnValue::AfterOrElseInitial, MetricConsumerPhase::Both) => {
                     // The consumer is using the metric in both "before" and "after" phases, and the
                     // parameter is providing an "after" value. However, they have specified that using any
                     // initial value is acceptable in the "before" phase, so we can resolve it to a metric provided the
                     // parameter index contains an "after" index.
                     match idx.after {
-                        Some(after_idx) => Ok(MetricF64::ParameterAfterMulti {
-                            index: after_idx,
+                        Some(after_idx) => Ok(MetricF64::ParameterMulti {
+                            indices: ParameterReturnValue::After(after_idx),
                             key: key.to_string(),
                         }),
                         None => Err(MetricF64ResolutionError::ParameterNotRegisteredInCorrectPhase {
+                            parameter: name.clone(),
+                            consumer_phase,
+                            return_value: parameter_return_value,
+                        }),
+                    }
+                }
+                (UnresolvedParameterReturnValue::Both, MetricConsumerPhase::Before) => {
+                    // The consumer is using the metric in the "before" phase, and the parameter is
+                    // providing both "before" and "after" values. We can resolve it to a metric provided the
+                    // parameter index contains a "before" index.
+                    match idx.before {
+                        Some(before_idx) => Ok(MetricF64::ParameterMulti {
+                            indices: ParameterReturnValue::Before(before_idx),
+                            key: key.to_string(),
+                        }),
+                        None => Err(MetricF64ResolutionError::ParameterNotRegisteredInCorrectPhase {
+                            parameter: name.clone(),
+                            consumer_phase,
+                            return_value: parameter_return_value,
+                        }),
+                    }
+                }
+                (UnresolvedParameterReturnValue::Both, MetricConsumerPhase::After) => {
+                    // The consumer is using the metric in the "after" phase, and the parameter is
+                    // providing both "before" and "after" values. We can resolve it to a metric provided the
+                    // parameter index contains an "after" index.
+                    match idx.after {
+                        Some(after_idx) => Ok(MetricF64::ParameterMulti {
+                            indices: ParameterReturnValue::After(after_idx),
+                            key: key.to_string(),
+                        }),
+                        None => Err(MetricF64ResolutionError::ParameterNotRegisteredInCorrectPhase {
+                            parameter: name.clone(),
+                            consumer_phase,
+                            return_value: parameter_return_value,
+                        }),
+                    }
+                }
+                (UnresolvedParameterReturnValue::Both, MetricConsumerPhase::Both) => {
+                    // The consumer is using the metric in both "before" and "after" phases, and the
+                    // parameter is providing both "before" and "after" values. We can resolve it to a metric provided the
+                    // parameter index contains both a "before" and an "after" index.
+                    match (idx.before, idx.after) {
+                        (Some(before_idx), Some(after_idx)) => Ok(MetricF64::ParameterMulti {
+                            indices: ParameterReturnValue::Requested {
+                                before: before_idx,
+                                after: after_idx,
+                            },
+                            key: key.to_string(),
+                        }),
+                        _ => Err(MetricF64ResolutionError::ParameterNotRegisteredInCorrectPhase {
                             parameter: name.clone(),
                             consumer_phase,
                             return_value: parameter_return_value,
@@ -1342,14 +1555,11 @@ pub enum MetricU64Error {
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum MetricU64 {
-    ParameterBeforeU64(GeneralBeforeValueIndex<u64>),
-    ParameterAfterU64(GeneralAfterValueIndex<u64>),
-    ParameterBeforeMulti {
-        index: GeneralBeforeValueIndex<MultiValue>,
-        key: String,
+    ParameterU64 {
+        indices: ParameterReturnValue<u64>,
     },
-    ParameterAfterMulti {
-        index: GeneralAfterValueIndex<MultiValue>,
+    ParameterMulti {
+        indices: ParameterReturnValue<MultiValue>,
         key: String,
     },
     Simple(SimpleMetricU64),
@@ -1359,17 +1569,23 @@ pub enum MetricU64 {
 impl MetricU64 {
     pub fn get_value(&self, _network: &Network, state: &State) -> Result<u64, MetricU64Error> {
         match self {
-            Self::ParameterBeforeU64(idx) => Ok(state.get_general_parameter_u64_before(*idx)?),
-            Self::ParameterAfterU64(idx) => Ok(state.get_general_parameter_u64_after(*idx)?),
-            Self::ParameterBeforeMulti { index, key } => {
-                let mv = state.get_general_parameter_multi_before(*index)?;
-                let value = mv
-                    .get_index(key)
-                    .ok_or_else(|| MetricU64Error::GeneralMultiValueParameterKeyNotFound { key: key.clone() })?;
-                Ok(*value)
-            }
-            Self::ParameterAfterMulti { index, key } => {
-                let mv = state.get_general_parameter_multi_after(*index)?;
+            Self::ParameterU64 { indices } => match indices {
+                ParameterReturnValue::Before(index) => Ok(state.get_general_parameter_u64_before(*index)?),
+                ParameterReturnValue::After(index) => Ok(state.get_general_parameter_u64_after(*index)?),
+                ParameterReturnValue::Requested { before, after } => match state.get_calculation_phase() {
+                    CalculationPhase::Before => Ok(state.get_general_parameter_u64_before(*before)?),
+                    CalculationPhase::After => Ok(state.get_general_parameter_u64_after(*after)?),
+                },
+            },
+            Self::ParameterMulti { indices, key } => {
+                let mv = match indices {
+                    ParameterReturnValue::Before(index) => state.get_general_parameter_multi_before(*index)?,
+                    ParameterReturnValue::After(index) => state.get_general_parameter_multi_after(*index)?,
+                    ParameterReturnValue::Requested { before, after } => match state.get_calculation_phase() {
+                        CalculationPhase::Before => state.get_general_parameter_multi_before(*before)?,
+                        CalculationPhase::After => state.get_general_parameter_multi_after(*after)?,
+                    },
+                };
                 let value = mv
                     .get_index(key)
                     .ok_or_else(|| MetricU64Error::GeneralMultiValueParameterKeyNotFound { key: key.clone() })?;
@@ -1471,7 +1687,7 @@ pub enum MetricU64ResolutionError {
     ParameterNotRegisteredInCorrectPhase {
         parameter: ParameterName,
         consumer_phase: MetricConsumerPhase,
-        return_value: ParameterReturnValue,
+        return_value: UnresolvedParameterReturnValue,
     },
 }
 
@@ -1479,12 +1695,12 @@ pub enum MetricU64ResolutionError {
 pub enum UnresolvedMetricU64 {
     ParameterValue {
         name: ParameterName,
-        return_value: ParameterReturnValue,
+        return_value: UnresolvedParameterReturnValue,
     },
     MultiParameterValue {
         name: ParameterName,
         key: String,
-        return_value: ParameterReturnValue,
+        return_value: UnresolvedParameterReturnValue,
     },
     InterNetworkTransfer(String),
     Constant(u64),
@@ -1494,7 +1710,7 @@ impl UnresolvedMetricU64 {
     pub fn new_parameter_before<N: Into<ParameterName>>(name: N) -> Self {
         Self::ParameterValue {
             name: name.into(),
-            return_value: ParameterReturnValue::Before,
+            return_value: UnresolvedParameterReturnValue::Before,
         }
     }
     pub fn resolve(
@@ -1547,7 +1763,7 @@ impl From<u64> for UnresolvedMetricU64 {
     }
 }
 
-/// Resolve a [`ParameterIndex<u64>`] to a [`MetricU64`] using the provided [`ParameterReturnValue`]
+/// Resolve a [`ParameterIndex<u64>`] to a [`MetricU64`] using the provided [`UnresolvedParameterReturnValue`]
 /// and [`MetricConsumerPhase`]. This function is used to determine if a parameter can be resolved to a metric
 /// based on the phase in which the consumer is using the metric and the return value of the parameter.
 ///
@@ -1555,7 +1771,7 @@ impl From<u64> for UnresolvedMetricU64 {
 fn resolve_parameter_index_u64_to_metric_u64(
     name: &ParameterName,
     idx: ParameterIndex<u64>,
-    parameter_return_value: ParameterReturnValue,
+    parameter_return_value: UnresolvedParameterReturnValue,
     consumer_phase: MetricConsumerPhase,
 ) -> Result<MetricU64, MetricU64ResolutionError> {
     match idx {
@@ -1565,12 +1781,14 @@ fn resolve_parameter_index_u64_to_metric_u64(
         // General parameters must be validated against the consumer phase to determine if they can be resolved to a metric.
         ParameterIndex::General(idx) => {
             match (parameter_return_value, consumer_phase) {
-                (ParameterReturnValue::Before, MetricConsumerPhase::Before) => {
+                (UnresolvedParameterReturnValue::Before, MetricConsumerPhase::Before) => {
                     // The consumer is using the metric in the "before" phase, and the parameter is
                     // providing a "before" value, so we can resolve it to a metric provided the
                     // parameter index contains a "before" index.
                     match idx.before {
-                        Some(before_idx) => Ok(MetricU64::ParameterBeforeU64(before_idx)),
+                        Some(before_idx) => Ok(MetricU64::ParameterU64 {
+                            indices: ParameterReturnValue::Before(before_idx),
+                        }),
                         None => Err(MetricU64ResolutionError::ParameterNotRegisteredInCorrectPhase {
                             parameter: name.clone(),
                             consumer_phase,
@@ -1578,13 +1796,15 @@ fn resolve_parameter_index_u64_to_metric_u64(
                         }),
                     }
                 }
-                (ParameterReturnValue::Before, MetricConsumerPhase::After) => {
+                (UnresolvedParameterReturnValue::Before, MetricConsumerPhase::After) => {
                     // The consumer is using the metric in the "after" phase, but the parameter is
                     // providing a "before" value. This is fine because the "before" value is still
                     // valid in the "after" phase, so we can resolve it to a metric provided the
                     // parameter index contains a "before" index.
                     match idx.before {
-                        Some(before_idx) => Ok(MetricU64::ParameterBeforeU64(before_idx)),
+                        Some(before_idx) => Ok(MetricU64::ParameterU64 {
+                            indices: ParameterReturnValue::Before(before_idx),
+                        }),
                         None => Err(MetricU64ResolutionError::ParameterNotRegisteredInCorrectPhase {
                             parameter: name.clone(),
                             consumer_phase,
@@ -1592,13 +1812,15 @@ fn resolve_parameter_index_u64_to_metric_u64(
                         }),
                     }
                 }
-                (ParameterReturnValue::Before, MetricConsumerPhase::Both) => {
+                (UnresolvedParameterReturnValue::Before, MetricConsumerPhase::Both) => {
                     // The consumer is using the metric in both "before" and "after" phases, and the
                     // parameter is providing a "before" value. This is fine because the "before"
                     // value is valid in both phases, so we can resolve it to a metric provided the
                     // parameter index contains a "before" index.
                     match idx.before {
-                        Some(before_idx) => Ok(MetricU64::ParameterBeforeU64(before_idx)),
+                        Some(before_idx) => Ok(MetricU64::ParameterU64 {
+                            indices: ParameterReturnValue::Before(before_idx),
+                        }),
                         None => Err(MetricU64ResolutionError::ParameterNotRegisteredInCorrectPhase {
                             parameter: name.clone(),
                             consumer_phase,
@@ -1606,8 +1828,8 @@ fn resolve_parameter_index_u64_to_metric_u64(
                         }),
                     }
                 }
-                (ParameterReturnValue::After, MetricConsumerPhase::Before)
-                | (ParameterReturnValue::After, MetricConsumerPhase::Both) => {
+                (UnresolvedParameterReturnValue::After, MetricConsumerPhase::Before)
+                | (UnresolvedParameterReturnValue::After, MetricConsumerPhase::Both) => {
                     // The consumer is using the metric in the "before" phase, but the parameter is
                     // providing an "after" value. This is not valid because the "after" value is not
                     // valid in the "before" phase, so we cannot resolve it to a metric.
@@ -1617,12 +1839,14 @@ fn resolve_parameter_index_u64_to_metric_u64(
                         return_value: parameter_return_value,
                     })
                 }
-                (ParameterReturnValue::After, MetricConsumerPhase::After) => {
+                (UnresolvedParameterReturnValue::After, MetricConsumerPhase::After) => {
                     // The consumer is using the metric in the "after" phase, and the parameter is
                     // providing an "after" value, so we can resolve it to a metric provided the
                     // parameter index contains an "after" index.
                     match idx.after {
-                        Some(after_idx) => Ok(MetricU64::ParameterAfterU64(after_idx)),
+                        Some(after_idx) => Ok(MetricU64::ParameterU64 {
+                            indices: ParameterReturnValue::After(after_idx),
+                        }),
                         None => Err(MetricU64ResolutionError::ParameterNotRegisteredInCorrectPhase {
                             parameter: name.clone(),
                             consumer_phase,
@@ -1630,13 +1854,15 @@ fn resolve_parameter_index_u64_to_metric_u64(
                         }),
                     }
                 }
-                (ParameterReturnValue::AfterOrElseInitial, MetricConsumerPhase::Before) => {
+                (UnresolvedParameterReturnValue::AfterOrElseInitial, MetricConsumerPhase::Before) => {
                     // The consumer is using the metric in the "before" phase, but the parameter is
                     // providing an "after" value. However, they have specified that using any
                     // initial value is acceptable, so we can resolve it to a metric provided the
                     // parameter index contains an "after" index.
                     match idx.after {
-                        Some(after_idx) => Ok(MetricU64::ParameterAfterU64(after_idx)),
+                        Some(after_idx) => Ok(MetricU64::ParameterU64 {
+                            indices: ParameterReturnValue::After(after_idx),
+                        }),
                         None => Err(MetricU64ResolutionError::ParameterNotRegisteredInCorrectPhase {
                             parameter: name.clone(),
                             consumer_phase,
@@ -1644,12 +1870,14 @@ fn resolve_parameter_index_u64_to_metric_u64(
                         }),
                     }
                 }
-                (ParameterReturnValue::AfterOrElseInitial, MetricConsumerPhase::After) => {
+                (UnresolvedParameterReturnValue::AfterOrElseInitial, MetricConsumerPhase::After) => {
                     // The consumer is using the metric in the "after" phase, and the parameter is
                     // providing an "after" value, so we can resolve it to a metric provided the
                     // parameter index contains an "after" index.
                     match idx.after {
-                        Some(after_idx) => Ok(MetricU64::ParameterAfterU64(after_idx)),
+                        Some(after_idx) => Ok(MetricU64::ParameterU64 {
+                            indices: ParameterReturnValue::After(after_idx),
+                        }),
                         None => Err(MetricU64ResolutionError::ParameterNotRegisteredInCorrectPhase {
                             parameter: name.clone(),
                             consumer_phase,
@@ -1657,14 +1885,64 @@ fn resolve_parameter_index_u64_to_metric_u64(
                         }),
                     }
                 }
-                (ParameterReturnValue::AfterOrElseInitial, MetricConsumerPhase::Both) => {
+                (UnresolvedParameterReturnValue::AfterOrElseInitial, MetricConsumerPhase::Both) => {
                     // The consumer is using the metric in both "before" and "after" phases, and the
                     // parameter is providing an "after" value. However, they have specified that using any
                     // initial value is acceptable in the "before" phase, so we can resolve it to a metric provided the
                     // parameter index contains an "after" index.
                     match idx.after {
-                        Some(after_idx) => Ok(MetricU64::ParameterAfterU64(after_idx)),
+                        Some(after_idx) => Ok(MetricU64::ParameterU64 {
+                            indices: ParameterReturnValue::After(after_idx),
+                        }),
                         None => Err(MetricU64ResolutionError::ParameterNotRegisteredInCorrectPhase {
+                            parameter: name.clone(),
+                            consumer_phase,
+                            return_value: parameter_return_value,
+                        }),
+                    }
+                }
+                (UnresolvedParameterReturnValue::Both, MetricConsumerPhase::Before) => {
+                    // The consumer is using the metric in the "before" phase, and the parameter is
+                    // providing both "before" and "after" values. We can resolve it to a metric provided the
+                    // parameter index contains a "before" index.
+                    match idx.before {
+                        Some(before_idx) => Ok(MetricU64::ParameterU64 {
+                            indices: ParameterReturnValue::Before(before_idx),
+                        }),
+                        None => Err(MetricU64ResolutionError::ParameterNotRegisteredInCorrectPhase {
+                            parameter: name.clone(),
+                            consumer_phase,
+                            return_value: parameter_return_value,
+                        }),
+                    }
+                }
+                (UnresolvedParameterReturnValue::Both, MetricConsumerPhase::After) => {
+                    // The consumer is using the metric in the "after" phase, and the parameter is
+                    // providing both "before" and "after" values. We can resolve it to a metric provided the
+                    // parameter index contains an "after" index.
+                    match idx.after {
+                        Some(after_idx) => Ok(MetricU64::ParameterU64 {
+                            indices: ParameterReturnValue::After(after_idx),
+                        }),
+                        None => Err(MetricU64ResolutionError::ParameterNotRegisteredInCorrectPhase {
+                            parameter: name.clone(),
+                            consumer_phase,
+                            return_value: parameter_return_value,
+                        }),
+                    }
+                }
+                (UnresolvedParameterReturnValue::Both, MetricConsumerPhase::Both) => {
+                    // The consumer is using the metric in both "before" and "after" phases, and the
+                    // parameter is providing both "before" and "after" values. We can resolve it to a metric provided the
+                    // parameter index contains both a "before" and an "after" index.
+                    match (idx.before, idx.after) {
+                        (Some(before_idx), Some(after_idx)) => Ok(MetricU64::ParameterU64 {
+                            indices: ParameterReturnValue::Requested {
+                                before: before_idx,
+                                after: after_idx,
+                            },
+                        }),
+                        _ => Err(MetricU64ResolutionError::ParameterNotRegisteredInCorrectPhase {
                             parameter: name.clone(),
                             consumer_phase,
                             return_value: parameter_return_value,
@@ -1676,7 +1954,7 @@ fn resolve_parameter_index_u64_to_metric_u64(
     }
 }
 
-/// Resolve a [`ParameterIndex<MultiValue>`] to a [`MetricU64`] using the provided [`ParameterReturnValue`]
+/// Resolve a [`ParameterIndex<MultiValue>`] to a [`MetricU64`] using the provided [`UnresolvedParameterReturnValue`]
 /// and [`MetricConsumerPhase`]. This function is used to determine if a parameter can be resolved to a metric
 /// based on the phase in which the consumer is using the metric and the return value of the parameter.
 ///
@@ -1685,7 +1963,7 @@ fn resolve_parameter_index_multi_to_metric_u64(
     name: &ParameterName,
     idx: ParameterIndex<MultiValue>,
     key: &str,
-    parameter_return_value: ParameterReturnValue,
+    parameter_return_value: UnresolvedParameterReturnValue,
     consumer_phase: MetricConsumerPhase,
 ) -> Result<MetricU64, MetricU64ResolutionError> {
     match idx {
@@ -1703,13 +1981,13 @@ fn resolve_parameter_index_multi_to_metric_u64(
         // General parameters must be validated against the consumer phase to determine if they can be resolved to a metric.
         ParameterIndex::General(idx) => {
             match (parameter_return_value, consumer_phase) {
-                (ParameterReturnValue::Before, MetricConsumerPhase::Before) => {
+                (UnresolvedParameterReturnValue::Before, MetricConsumerPhase::Before) => {
                     // The consumer is using the metric in the "before" phase, and the parameter is
                     // providing a "before" value, so we can resolve it to a metric provided the
                     // parameter index contains a "before" index.
                     match idx.before {
-                        Some(before_idx) => Ok(MetricU64::ParameterBeforeMulti {
-                            index: before_idx,
+                        Some(before_idx) => Ok(MetricU64::ParameterMulti {
+                            indices: ParameterReturnValue::Before(before_idx),
                             key: key.to_string(),
                         }),
                         None => Err(MetricU64ResolutionError::ParameterNotRegisteredInCorrectPhase {
@@ -1719,14 +1997,14 @@ fn resolve_parameter_index_multi_to_metric_u64(
                         }),
                     }
                 }
-                (ParameterReturnValue::Before, MetricConsumerPhase::After) => {
+                (UnresolvedParameterReturnValue::Before, MetricConsumerPhase::After) => {
                     // The consumer is using the metric in the "after" phase, but the parameter is
                     // providing a "before" value. This is fine because the "before" value is still
                     // valid in the "after" phase, so we can resolve it to a metric provided the
                     // parameter index contains a "before" index.
                     match idx.before {
-                        Some(before_idx) => Ok(MetricU64::ParameterBeforeMulti {
-                            index: before_idx,
+                        Some(before_idx) => Ok(MetricU64::ParameterMulti {
+                            indices: ParameterReturnValue::Before(before_idx),
                             key: key.to_string(),
                         }),
                         None => Err(MetricU64ResolutionError::ParameterNotRegisteredInCorrectPhase {
@@ -1736,14 +2014,14 @@ fn resolve_parameter_index_multi_to_metric_u64(
                         }),
                     }
                 }
-                (ParameterReturnValue::Before, MetricConsumerPhase::Both) => {
+                (UnresolvedParameterReturnValue::Before, MetricConsumerPhase::Both) => {
                     // The consumer is using the metric in both "before" and "after" phases, and the
                     // parameter is providing a "before" value. This is fine because the "before"
                     // value is valid in both phases, so we can resolve it to a metric provided the
                     // parameter index contains a "before" index.
                     match idx.before {
-                        Some(before_idx) => Ok(MetricU64::ParameterBeforeMulti {
-                            index: before_idx,
+                        Some(before_idx) => Ok(MetricU64::ParameterMulti {
+                            indices: ParameterReturnValue::Before(before_idx),
                             key: key.to_string(),
                         }),
                         None => Err(MetricU64ResolutionError::ParameterNotRegisteredInCorrectPhase {
@@ -1753,8 +2031,8 @@ fn resolve_parameter_index_multi_to_metric_u64(
                         }),
                     }
                 }
-                (ParameterReturnValue::After, MetricConsumerPhase::Before)
-                | (ParameterReturnValue::After, MetricConsumerPhase::Both) => {
+                (UnresolvedParameterReturnValue::After, MetricConsumerPhase::Before)
+                | (UnresolvedParameterReturnValue::After, MetricConsumerPhase::Both) => {
                     // The consumer is using the metric in the "before" phase, but the parameter is
                     // providing an "after" value. This is not valid because the "after" value is not
                     // valid in the "before" phase, so we cannot resolve it to a metric.
@@ -1764,13 +2042,13 @@ fn resolve_parameter_index_multi_to_metric_u64(
                         return_value: parameter_return_value,
                     })
                 }
-                (ParameterReturnValue::After, MetricConsumerPhase::After) => {
+                (UnresolvedParameterReturnValue::After, MetricConsumerPhase::After) => {
                     // The consumer is using the metric in the "after" phase, and the parameter is
                     // providing an "after" value, so we can resolve it to a metric provided the
                     // parameter index contains an "after" index.
                     match idx.after {
-                        Some(after_idx) => Ok(MetricU64::ParameterAfterMulti {
-                            index: after_idx,
+                        Some(after_idx) => Ok(MetricU64::ParameterMulti {
+                            indices: ParameterReturnValue::After(after_idx),
                             key: key.to_string(),
                         }),
                         None => Err(MetricU64ResolutionError::ParameterNotRegisteredInCorrectPhase {
@@ -1780,14 +2058,14 @@ fn resolve_parameter_index_multi_to_metric_u64(
                         }),
                     }
                 }
-                (ParameterReturnValue::AfterOrElseInitial, MetricConsumerPhase::Before) => {
+                (UnresolvedParameterReturnValue::AfterOrElseInitial, MetricConsumerPhase::Before) => {
                     // The consumer is using the metric in the "before" phase, but the parameter is
                     // providing an "after" value. However, they have specified that using any
                     // initial value is acceptable, so we can resolve it to a metric provided the
                     // parameter index contains an "after" index.
                     match idx.after {
-                        Some(after_idx) => Ok(MetricU64::ParameterAfterMulti {
-                            index: after_idx,
+                        Some(after_idx) => Ok(MetricU64::ParameterMulti {
+                            indices: ParameterReturnValue::After(after_idx),
                             key: key.to_string(),
                         }),
                         None => Err(MetricU64ResolutionError::ParameterNotRegisteredInCorrectPhase {
@@ -1797,13 +2075,13 @@ fn resolve_parameter_index_multi_to_metric_u64(
                         }),
                     }
                 }
-                (ParameterReturnValue::AfterOrElseInitial, MetricConsumerPhase::After) => {
+                (UnresolvedParameterReturnValue::AfterOrElseInitial, MetricConsumerPhase::After) => {
                     // The consumer is using the metric in the "after" phase, and the parameter is
                     // providing an "after" value, so we can resolve it to a metric provided the
                     // parameter index contains an "after" index.
                     match idx.after {
-                        Some(after_idx) => Ok(MetricU64::ParameterAfterMulti {
-                            index: after_idx,
+                        Some(after_idx) => Ok(MetricU64::ParameterMulti {
+                            indices: ParameterReturnValue::After(after_idx),
                             key: key.to_string(),
                         }),
                         None => Err(MetricU64ResolutionError::ParameterNotRegisteredInCorrectPhase {
@@ -1813,17 +2091,68 @@ fn resolve_parameter_index_multi_to_metric_u64(
                         }),
                     }
                 }
-                (ParameterReturnValue::AfterOrElseInitial, MetricConsumerPhase::Both) => {
+                (UnresolvedParameterReturnValue::AfterOrElseInitial, MetricConsumerPhase::Both) => {
                     // The consumer is using the metric in both "before" and "after" phases, and the
                     // parameter is providing an "after" value. However, they have specified that using any
                     // initial value is acceptable in the "before" phase, so we can resolve it to a metric provided the
                     // parameter index contains an "after" index.
                     match idx.after {
-                        Some(after_idx) => Ok(MetricU64::ParameterAfterMulti {
-                            index: after_idx,
+                        Some(after_idx) => Ok(MetricU64::ParameterMulti {
+                            indices: ParameterReturnValue::After(after_idx),
                             key: key.to_string(),
                         }),
                         None => Err(MetricU64ResolutionError::ParameterNotRegisteredInCorrectPhase {
+                            parameter: name.clone(),
+                            consumer_phase,
+                            return_value: parameter_return_value,
+                        }),
+                    }
+                }
+                (UnresolvedParameterReturnValue::Both, MetricConsumerPhase::Before) => {
+                    // The consumer is using the metric in the "before" phase, and the parameter is
+                    // providing both "before" and "after" values. We can resolve it to a metric provided the
+                    // parameter index contains a "before" index.
+                    match idx.before {
+                        Some(before_idx) => Ok(MetricU64::ParameterMulti {
+                            indices: ParameterReturnValue::Before(before_idx),
+                            key: key.to_string(),
+                        }),
+                        None => Err(MetricU64ResolutionError::ParameterNotRegisteredInCorrectPhase {
+                            parameter: name.clone(),
+                            consumer_phase,
+                            return_value: parameter_return_value,
+                        }),
+                    }
+                }
+                (UnresolvedParameterReturnValue::Both, MetricConsumerPhase::After) => {
+                    // The consumer is using the metric in the "after" phase, and the parameter is
+                    // providing both "before" and "after" values. We can resolve it to a metric provided the
+                    // parameter index contains an "after" index.
+                    match idx.after {
+                        Some(after_idx) => Ok(MetricU64::ParameterMulti {
+                            indices: ParameterReturnValue::After(after_idx),
+                            key: key.to_string(),
+                        }),
+                        None => Err(MetricU64ResolutionError::ParameterNotRegisteredInCorrectPhase {
+                            parameter: name.clone(),
+                            consumer_phase,
+                            return_value: parameter_return_value,
+                        }),
+                    }
+                }
+                (UnresolvedParameterReturnValue::Both, MetricConsumerPhase::Both) => {
+                    // The consumer is using the metric in both "before" and "after" phases, and the
+                    // parameter is providing both "before" and "after" values. We can resolve it to a metric provided the
+                    // parameter index contains both a "before" and an "after" index.
+                    match (idx.before, idx.after) {
+                        (Some(before_idx), Some(after_idx)) => Ok(MetricU64::ParameterMulti {
+                            indices: ParameterReturnValue::Requested {
+                                before: before_idx,
+                                after: after_idx,
+                            },
+                            key: key.to_string(),
+                        }),
+                        _ => Err(MetricU64ResolutionError::ParameterNotRegisteredInCorrectPhase {
                             parameter: name.clone(),
                             consumer_phase,
                             return_value: parameter_return_value,

--- a/pywr-core/src/metric.rs
+++ b/pywr-core/src/metric.rs
@@ -110,7 +110,7 @@ impl SimpleMetricF64 {
 }
 
 #[derive(Copy, Clone, Debug, PartialEq)]
-pub enum ParameterReturnValue<T> {
+pub enum ParameterValueSource<T> {
     Before(GeneralBeforeValueIndex<T>),
     After(GeneralAfterValueIndex<T>),
     // Returns the value corresponding to the requested phase.
@@ -161,13 +161,13 @@ pub enum MetricF64 {
         name: String,
     },
     ParameterF64 {
-        indices: ParameterReturnValue<f64>,
+        source: ParameterValueSource<f64>,
     },
     ParameterU64 {
-        indices: ParameterReturnValue<u64>,
+        source: ParameterValueSource<u64>,
     },
     ParameterMulti {
-        indices: ParameterReturnValue<MultiValue>,
+        source: ParameterValueSource<MultiValue>,
         key: String,
     },
     VirtualStorageVolume(VirtualStorageIndex),
@@ -250,27 +250,27 @@ impl MetricF64 {
                     .sum::<Result<_, _>>()?;
                 Ok(flow)
             }
-            MetricF64::ParameterF64 { indices } => match indices {
-                ParameterReturnValue::Before(index) => Ok(state.get_general_parameter_f64_before(*index)?),
-                ParameterReturnValue::After(index) => Ok(state.get_general_parameter_f64_after(*index)?),
-                ParameterReturnValue::Requested { before, after } => match state.get_calculation_phase() {
+            MetricF64::ParameterF64 { source } => match source {
+                ParameterValueSource::Before(index) => Ok(state.get_general_parameter_f64_before(*index)?),
+                ParameterValueSource::After(index) => Ok(state.get_general_parameter_f64_after(*index)?),
+                ParameterValueSource::Requested { before, after } => match state.get_calculation_phase() {
                     CalculationPhase::Before => Ok(state.get_general_parameter_f64_before(*before)?),
                     CalculationPhase::After => Ok(state.get_general_parameter_f64_after(*after)?),
                 },
             },
-            MetricF64::ParameterU64 { indices } => match indices {
-                ParameterReturnValue::Before(index) => Ok(state.get_general_parameter_u64_before(*index)? as f64),
-                ParameterReturnValue::After(index) => Ok(state.get_general_parameter_u64_after(*index)? as f64),
-                ParameterReturnValue::Requested { before, after } => match state.get_calculation_phase() {
+            MetricF64::ParameterU64 { source } => match source {
+                ParameterValueSource::Before(index) => Ok(state.get_general_parameter_u64_before(*index)? as f64),
+                ParameterValueSource::After(index) => Ok(state.get_general_parameter_u64_after(*index)? as f64),
+                ParameterValueSource::Requested { before, after } => match state.get_calculation_phase() {
                     CalculationPhase::Before => Ok(state.get_general_parameter_u64_before(*before)? as f64),
                     CalculationPhase::After => Ok(state.get_general_parameter_u64_after(*after)? as f64),
                 },
             },
-            MetricF64::ParameterMulti { indices, key } => {
-                let mv = match indices {
-                    ParameterReturnValue::Before(index) => state.get_general_parameter_multi_before(*index)?,
-                    ParameterReturnValue::After(index) => state.get_general_parameter_multi_after(*index)?,
-                    ParameterReturnValue::Requested { before, after } => match state.get_calculation_phase() {
+            MetricF64::ParameterMulti { source, key } => {
+                let mv = match source {
+                    ParameterValueSource::Before(index) => state.get_general_parameter_multi_before(*index)?,
+                    ParameterValueSource::After(index) => state.get_general_parameter_multi_after(*index)?,
+                    ParameterValueSource::Requested { before, after } => match state.get_calculation_phase() {
                         CalculationPhase::Before => state.get_general_parameter_multi_before(*before)?,
                         CalculationPhase::After => state.get_general_parameter_multi_after(*after)?,
                     },
@@ -855,176 +855,14 @@ fn resolve_parameter_index_f64_to_metric_f64(
         },
         // General parameters must be validated against the consumer phase to determine if they can be resolved to a metric.
         ParameterIndex::General(idx) => {
-            match (parameter_return_value, consumer_phase) {
-                (UnresolvedParameterReturnValue::Before, MetricConsumerPhase::Before) => {
-                    // The consumer is using the metric in the "before" phase, and the parameter is
-                    // providing a "before" value, so we can resolve it to a metric provided the
-                    // parameter index contains a "before" index.
-                    match idx.before {
-                        Some(before_idx) => Ok(MetricF64::ParameterF64 {
-                            indices: ParameterReturnValue::Before(before_idx),
-                        }),
-                        None => Err(MetricF64ResolutionError::ParameterNotRegisteredInCorrectPhase {
-                            parameter: name.clone(),
-                            consumer_phase,
-                            return_value: parameter_return_value,
-                        }),
-                    }
-                }
-                (UnresolvedParameterReturnValue::Before, MetricConsumerPhase::After) => {
-                    // The consumer is using the metric in the "after" phase, but the parameter is
-                    // providing a "before" value. This is fine because the "before" value is still
-                    // valid in the "after" phase, so we can resolve it to a metric provided the
-                    // parameter index contains a "before" index.
-                    match idx.before {
-                        Some(before_idx) => Ok(MetricF64::ParameterF64 {
-                            indices: ParameterReturnValue::Before(before_idx),
-                        }),
-                        None => Err(MetricF64ResolutionError::ParameterNotRegisteredInCorrectPhase {
-                            parameter: name.clone(),
-                            consumer_phase,
-                            return_value: parameter_return_value,
-                        }),
-                    }
-                }
-                (UnresolvedParameterReturnValue::Before, MetricConsumerPhase::Both) => {
-                    // The consumer is using the metric in both "before" and "after" phases, and the
-                    // parameter is providing a "before" value. This is fine because the "before"
-                    // value is valid in both phases, so we can resolve it to a metric provided the
-                    // parameter index contains a "before" index.
-                    match idx.before {
-                        Some(before_idx) => Ok(MetricF64::ParameterF64 {
-                            indices: ParameterReturnValue::Before(before_idx),
-                        }),
-                        None => Err(MetricF64ResolutionError::ParameterNotRegisteredInCorrectPhase {
-                            parameter: name.clone(),
-                            consumer_phase,
-                            return_value: parameter_return_value,
-                        }),
-                    }
-                }
-                (UnresolvedParameterReturnValue::After, MetricConsumerPhase::Before)
-                | (UnresolvedParameterReturnValue::After, MetricConsumerPhase::Both) => {
-                    // The consumer is using the metric in the "before" phase, but the parameter is
-                    // providing an "after" value. This is not valid because the "after" value is not
-                    // valid in the "before" phase, so we cannot resolve it to a metric.
-                    Err(MetricF64ResolutionError::ParameterNotRegisteredInCorrectPhase {
-                        parameter: name.clone(),
-                        consumer_phase,
-                        return_value: parameter_return_value,
-                    })
-                }
-                (UnresolvedParameterReturnValue::After, MetricConsumerPhase::After) => {
-                    // The consumer is using the metric in the "after" phase, and the parameter is
-                    // providing an "after" value, so we can resolve it to a metric provided the
-                    // parameter index contains an "after" index.
-                    match idx.after {
-                        Some(after_idx) => Ok(MetricF64::ParameterF64 {
-                            indices: ParameterReturnValue::After(after_idx),
-                        }),
-                        None => Err(MetricF64ResolutionError::ParameterNotRegisteredInCorrectPhase {
-                            parameter: name.clone(),
-                            consumer_phase,
-                            return_value: parameter_return_value,
-                        }),
-                    }
-                }
-                (UnresolvedParameterReturnValue::AfterOrElseInitial, MetricConsumerPhase::Before) => {
-                    // The consumer is using the metric in the "before" phase, but the parameter is
-                    // providing an "after" value. However, they have specified that using any
-                    // initial value is acceptable, so we can resolve it to a metric provided the
-                    // parameter index contains an "after" index.
-                    match idx.after {
-                        Some(after_idx) => Ok(MetricF64::ParameterF64 {
-                            indices: ParameterReturnValue::After(after_idx),
-                        }),
-                        None => Err(MetricF64ResolutionError::ParameterNotRegisteredInCorrectPhase {
-                            parameter: name.clone(),
-                            consumer_phase,
-                            return_value: parameter_return_value,
-                        }),
-                    }
-                }
-                (UnresolvedParameterReturnValue::AfterOrElseInitial, MetricConsumerPhase::After) => {
-                    // The consumer is using the metric in the "after" phase, and the parameter is
-                    // providing an "after" value, so we can resolve it to a metric provided the
-                    // parameter index contains an "after" index.
-                    match idx.after {
-                        Some(after_idx) => Ok(MetricF64::ParameterF64 {
-                            indices: ParameterReturnValue::After(after_idx),
-                        }),
-                        None => Err(MetricF64ResolutionError::ParameterNotRegisteredInCorrectPhase {
-                            parameter: name.clone(),
-                            consumer_phase,
-                            return_value: parameter_return_value,
-                        }),
-                    }
-                }
-                (UnresolvedParameterReturnValue::AfterOrElseInitial, MetricConsumerPhase::Both) => {
-                    // The consumer is using the metric in both "before" and "after" phases, and the
-                    // parameter is providing an "after" value. However, they have specified that using any
-                    // initial value is acceptable in the "before" phase, so we can resolve it to a metric provided the
-                    // parameter index contains an "after" index.
-                    match idx.after {
-                        Some(after_idx) => Ok(MetricF64::ParameterF64 {
-                            indices: ParameterReturnValue::After(after_idx),
-                        }),
-                        None => Err(MetricF64ResolutionError::ParameterNotRegisteredInCorrectPhase {
-                            parameter: name.clone(),
-                            consumer_phase,
-                            return_value: parameter_return_value,
-                        }),
-                    }
-                }
-                (UnresolvedParameterReturnValue::Both, MetricConsumerPhase::Before) => {
-                    // The consumer is using the metric in the "before" phase, and the parameter is
-                    // providing both "before" and "after" values. We can resolve it to a metric provided the
-                    // parameter index contains a "before" index.
-                    match idx.before {
-                        Some(before_idx) => Ok(MetricF64::ParameterF64 {
-                            indices: ParameterReturnValue::Before(before_idx),
-                        }),
-                        None => Err(MetricF64ResolutionError::ParameterNotRegisteredInCorrectPhase {
-                            parameter: name.clone(),
-                            consumer_phase,
-                            return_value: parameter_return_value,
-                        }),
-                    }
-                }
-                (UnresolvedParameterReturnValue::Both, MetricConsumerPhase::After) => {
-                    // The consumer is using the metric in the "after" phase, and the parameter is
-                    // providing both "before" and "after" values. We can resolve it to a metric provided the
-                    // parameter index contains an "after" index.
-                    match idx.after {
-                        Some(after_idx) => Ok(MetricF64::ParameterF64 {
-                            indices: ParameterReturnValue::After(after_idx),
-                        }),
-                        None => Err(MetricF64ResolutionError::ParameterNotRegisteredInCorrectPhase {
-                            parameter: name.clone(),
-                            consumer_phase,
-                            return_value: parameter_return_value,
-                        }),
-                    }
-                }
-                (UnresolvedParameterReturnValue::Both, MetricConsumerPhase::Both) => {
-                    // The consumer is using the metric in both "before" and "after" phases, and the
-                    // parameter is providing both "before" and "after" values. We can resolve it to a metric provided the
-                    // parameter index contains both a "before" and an "after" index.
-                    match (idx.before, idx.after) {
-                        (Some(before_idx), Some(after_idx)) => Ok(MetricF64::ParameterF64 {
-                            indices: ParameterReturnValue::Requested {
-                                before: before_idx,
-                                after: after_idx,
-                            },
-                        }),
-                        _ => Err(MetricF64ResolutionError::ParameterNotRegisteredInCorrectPhase {
-                            parameter: name.clone(),
-                            consumer_phase,
-                            return_value: parameter_return_value,
-                        }),
-                    }
-                }
-            }
+            let source = resolve_parameter_return_value(idx.before, idx.after, parameter_return_value, consumer_phase)
+                .ok_or_else(|| MetricF64ResolutionError::ParameterNotRegisteredInCorrectPhase {
+                    parameter: name.clone(),
+                    consumer_phase,
+                    return_value: parameter_return_value,
+                })?;
+
+            Ok(MetricF64::ParameterF64 { source })
         }
     }
 }
@@ -1069,176 +907,14 @@ fn resolve_parameter_index_u64_to_metric_f64(
         },
         // General parameters must be validated against the consumer phase to determine if they can be resolved to a metric.
         ParameterIndex::General(idx) => {
-            match (parameter_return_value, consumer_phase) {
-                (UnresolvedParameterReturnValue::Before, MetricConsumerPhase::Before) => {
-                    // The consumer is using the metric in the "before" phase, and the parameter is
-                    // providing a "before" value, so we can resolve it to a metric provided the
-                    // parameter index contains a "before" index.
-                    match idx.before {
-                        Some(before_idx) => Ok(MetricF64::ParameterU64 {
-                            indices: ParameterReturnValue::Before(before_idx),
-                        }),
-                        None => Err(MetricF64ResolutionError::ParameterNotRegisteredInCorrectPhase {
-                            parameter: name.clone(),
-                            consumer_phase,
-                            return_value: parameter_return_value,
-                        }),
-                    }
-                }
-                (UnresolvedParameterReturnValue::Before, MetricConsumerPhase::After) => {
-                    // The consumer is using the metric in the "after" phase, but the parameter is
-                    // providing a "before" value. This is fine because the "before" value is still
-                    // valid in the "after" phase, so we can resolve it to a metric provided the
-                    // parameter index contains a "before" index.
-                    match idx.before {
-                        Some(before_idx) => Ok(MetricF64::ParameterU64 {
-                            indices: ParameterReturnValue::Before(before_idx),
-                        }),
-                        None => Err(MetricF64ResolutionError::ParameterNotRegisteredInCorrectPhase {
-                            parameter: name.clone(),
-                            consumer_phase,
-                            return_value: parameter_return_value,
-                        }),
-                    }
-                }
-                (UnresolvedParameterReturnValue::Before, MetricConsumerPhase::Both) => {
-                    // The consumer is using the metric in both "before" and "after" phases, and the
-                    // parameter is providing a "before" value. This is fine because the "before"
-                    // value is valid in both phases, so we can resolve it to a metric provided the
-                    // parameter index contains a "before" index.
-                    match idx.before {
-                        Some(before_idx) => Ok(MetricF64::ParameterU64 {
-                            indices: ParameterReturnValue::Before(before_idx),
-                        }),
-                        None => Err(MetricF64ResolutionError::ParameterNotRegisteredInCorrectPhase {
-                            parameter: name.clone(),
-                            consumer_phase,
-                            return_value: parameter_return_value,
-                        }),
-                    }
-                }
-                (UnresolvedParameterReturnValue::After, MetricConsumerPhase::Before)
-                | (UnresolvedParameterReturnValue::After, MetricConsumerPhase::Both) => {
-                    // The consumer is using the metric in the "before" phase, but the parameter is
-                    // providing an "after" value. This is not valid because the "after" value is not
-                    // valid in the "before" phase, so we cannot resolve it to a metric.
-                    Err(MetricF64ResolutionError::ParameterNotRegisteredInCorrectPhase {
-                        parameter: name.clone(),
-                        consumer_phase,
-                        return_value: parameter_return_value,
-                    })
-                }
-                (UnresolvedParameterReturnValue::After, MetricConsumerPhase::After) => {
-                    // The consumer is using the metric in the "after" phase, and the parameter is
-                    // providing an "after" value, so we can resolve it to a metric provided the
-                    // parameter index contains an "after" index.
-                    match idx.after {
-                        Some(after_idx) => Ok(MetricF64::ParameterU64 {
-                            indices: ParameterReturnValue::After(after_idx),
-                        }),
-                        None => Err(MetricF64ResolutionError::ParameterNotRegisteredInCorrectPhase {
-                            parameter: name.clone(),
-                            consumer_phase,
-                            return_value: parameter_return_value,
-                        }),
-                    }
-                }
-                (UnresolvedParameterReturnValue::AfterOrElseInitial, MetricConsumerPhase::Before) => {
-                    // The consumer is using the metric in the "before" phase, but the parameter is
-                    // providing an "after" value. However, they have specified that using any
-                    // initial value is acceptable, so we can resolve it to a metric provided the
-                    // parameter index contains an "after" index.
-                    match idx.after {
-                        Some(after_idx) => Ok(MetricF64::ParameterU64 {
-                            indices: ParameterReturnValue::After(after_idx),
-                        }),
-                        None => Err(MetricF64ResolutionError::ParameterNotRegisteredInCorrectPhase {
-                            parameter: name.clone(),
-                            consumer_phase,
-                            return_value: parameter_return_value,
-                        }),
-                    }
-                }
-                (UnresolvedParameterReturnValue::AfterOrElseInitial, MetricConsumerPhase::After) => {
-                    // The consumer is using the metric in the "after" phase, and the parameter is
-                    // providing an "after" value, so we can resolve it to a metric provided the
-                    // parameter index contains an "after" index.
-                    match idx.after {
-                        Some(after_idx) => Ok(MetricF64::ParameterU64 {
-                            indices: ParameterReturnValue::After(after_idx),
-                        }),
-                        None => Err(MetricF64ResolutionError::ParameterNotRegisteredInCorrectPhase {
-                            parameter: name.clone(),
-                            consumer_phase,
-                            return_value: parameter_return_value,
-                        }),
-                    }
-                }
-                (UnresolvedParameterReturnValue::AfterOrElseInitial, MetricConsumerPhase::Both) => {
-                    // The consumer is using the metric in both "before" and "after" phases, and the
-                    // parameter is providing an "after" value. However, they have specified that using any
-                    // initial value is acceptable in the "before" phase, so we can resolve it to a metric provided the
-                    // parameter index contains an "after" index.
-                    match idx.after {
-                        Some(after_idx) => Ok(MetricF64::ParameterU64 {
-                            indices: ParameterReturnValue::After(after_idx),
-                        }),
-                        None => Err(MetricF64ResolutionError::ParameterNotRegisteredInCorrectPhase {
-                            parameter: name.clone(),
-                            consumer_phase,
-                            return_value: parameter_return_value,
-                        }),
-                    }
-                }
-                (UnresolvedParameterReturnValue::Both, MetricConsumerPhase::Before) => {
-                    // The consumer is using the metric in the "before" phase, and the parameter is
-                    // providing both "before" and "after" values. We can resolve it to a metric provided the
-                    // parameter index contains a "before" index.
-                    match idx.before {
-                        Some(before_idx) => Ok(MetricF64::ParameterU64 {
-                            indices: ParameterReturnValue::Before(before_idx),
-                        }),
-                        None => Err(MetricF64ResolutionError::ParameterNotRegisteredInCorrectPhase {
-                            parameter: name.clone(),
-                            consumer_phase,
-                            return_value: parameter_return_value,
-                        }),
-                    }
-                }
-                (UnresolvedParameterReturnValue::Both, MetricConsumerPhase::After) => {
-                    // The consumer is using the metric in the "after" phase, and the parameter is
-                    // providing both "before" and "after" values. We can resolve it to a metric provided the
-                    // parameter index contains an "after" index.
-                    match idx.after {
-                        Some(after_idx) => Ok(MetricF64::ParameterU64 {
-                            indices: ParameterReturnValue::After(after_idx),
-                        }),
-                        None => Err(MetricF64ResolutionError::ParameterNotRegisteredInCorrectPhase {
-                            parameter: name.clone(),
-                            consumer_phase,
-                            return_value: parameter_return_value,
-                        }),
-                    }
-                }
-                (UnresolvedParameterReturnValue::Both, MetricConsumerPhase::Both) => {
-                    // The consumer is using the metric in both "before" and "after" phases, and the
-                    // parameter is providing both "before" and "after" values. We can resolve it to a metric provided the
-                    // parameter index contains both a "before" and an "after" index.
-                    match (idx.before, idx.after) {
-                        (Some(before_idx), Some(after_idx)) => Ok(MetricF64::ParameterU64 {
-                            indices: ParameterReturnValue::Requested {
-                                before: before_idx,
-                                after: after_idx,
-                            },
-                        }),
-                        _ => Err(MetricF64ResolutionError::ParameterNotRegisteredInCorrectPhase {
-                            parameter: name.clone(),
-                            consumer_phase,
-                            return_value: parameter_return_value,
-                        }),
-                    }
-                }
-            }
+            let source = resolve_parameter_return_value(idx.before, idx.after, parameter_return_value, consumer_phase)
+                .ok_or_else(|| MetricF64ResolutionError::ParameterNotRegisteredInCorrectPhase {
+                    parameter: name.clone(),
+                    consumer_phase,
+                    return_value: parameter_return_value,
+                })?;
+
+            Ok(MetricF64::ParameterU64 { source })
         }
     }
 }
@@ -1292,187 +968,42 @@ fn resolve_parameter_index_multi_to_metric_f64(
         },
         // General parameters must be validated against the consumer phase to determine if they can be resolved to a metric.
         ParameterIndex::General(idx) => {
-            match (parameter_return_value, consumer_phase) {
-                (UnresolvedParameterReturnValue::Before, MetricConsumerPhase::Before) => {
-                    // The consumer is using the metric in the "before" phase, and the parameter is
-                    // providing a "before" value, so we can resolve it to a metric provided the
-                    // parameter index contains a "before" index.
-                    match idx.before {
-                        Some(before_idx) => Ok(MetricF64::ParameterMulti {
-                            indices: ParameterReturnValue::Before(before_idx),
-                            key: key.to_string(),
-                        }),
-                        None => Err(MetricF64ResolutionError::ParameterNotRegisteredInCorrectPhase {
-                            parameter: name.clone(),
-                            consumer_phase,
-                            return_value: parameter_return_value,
-                        }),
-                    }
-                }
-                (UnresolvedParameterReturnValue::Before, MetricConsumerPhase::After) => {
-                    // The consumer is using the metric in the "after" phase, but the parameter is
-                    // providing a "before" value. This is fine because the "before" value is still
-                    // valid in the "after" phase, so we can resolve it to a metric provided the
-                    // parameter index contains a "before" index.
-                    match idx.before {
-                        Some(before_idx) => Ok(MetricF64::ParameterMulti {
-                            indices: ParameterReturnValue::Before(before_idx),
-                            key: key.to_string(),
-                        }),
-                        None => Err(MetricF64ResolutionError::ParameterNotRegisteredInCorrectPhase {
-                            parameter: name.clone(),
-                            consumer_phase,
-                            return_value: parameter_return_value,
-                        }),
-                    }
-                }
-                (UnresolvedParameterReturnValue::Before, MetricConsumerPhase::Both) => {
-                    // The consumer is using the metric in both "before" and "after" phases, and the
-                    // parameter is providing a "before" value. This is fine because the "before"
-                    // value is valid in both phases, so we can resolve it to a metric provided the
-                    // parameter index contains a "before" index.
-                    match idx.before {
-                        Some(before_idx) => Ok(MetricF64::ParameterMulti {
-                            indices: ParameterReturnValue::Before(before_idx),
-                            key: key.to_string(),
-                        }),
-                        None => Err(MetricF64ResolutionError::ParameterNotRegisteredInCorrectPhase {
-                            parameter: name.clone(),
-                            consumer_phase,
-                            return_value: parameter_return_value,
-                        }),
-                    }
-                }
-                (UnresolvedParameterReturnValue::After, MetricConsumerPhase::Before)
-                | (UnresolvedParameterReturnValue::After, MetricConsumerPhase::Both) => {
-                    // The consumer is using the metric in the "before" phase, but the parameter is
-                    // providing an "after" value. This is not valid because the "after" value is not
-                    // valid in the "before" phase, so we cannot resolve it to a metric.
-                    Err(MetricF64ResolutionError::ParameterNotRegisteredInCorrectPhase {
-                        parameter: name.clone(),
-                        consumer_phase,
-                        return_value: parameter_return_value,
-                    })
-                }
-                (UnresolvedParameterReturnValue::After, MetricConsumerPhase::After) => {
-                    // The consumer is using the metric in the "after" phase, and the parameter is
-                    // providing an "after" value, so we can resolve it to a metric provided the
-                    // parameter index contains an "after" index.
-                    match idx.after {
-                        Some(after_idx) => Ok(MetricF64::ParameterMulti {
-                            indices: ParameterReturnValue::After(after_idx),
-                            key: key.to_string(),
-                        }),
-                        None => Err(MetricF64ResolutionError::ParameterNotRegisteredInCorrectPhase {
-                            parameter: name.clone(),
-                            consumer_phase,
-                            return_value: parameter_return_value,
-                        }),
-                    }
-                }
-                (UnresolvedParameterReturnValue::AfterOrElseInitial, MetricConsumerPhase::Before) => {
-                    // The consumer is using the metric in the "before" phase, but the parameter is
-                    // providing an "after" value. However, they have specified that using any
-                    // initial value is acceptable, so we can resolve it to a metric provided the
-                    // parameter index contains an "after" index.
-                    match idx.after {
-                        Some(after_idx) => Ok(MetricF64::ParameterMulti {
-                            indices: ParameterReturnValue::After(after_idx),
-                            key: key.to_string(),
-                        }),
-                        None => Err(MetricF64ResolutionError::ParameterNotRegisteredInCorrectPhase {
-                            parameter: name.clone(),
-                            consumer_phase,
-                            return_value: parameter_return_value,
-                        }),
-                    }
-                }
-                (UnresolvedParameterReturnValue::AfterOrElseInitial, MetricConsumerPhase::After) => {
-                    // The consumer is using the metric in the "after" phase, and the parameter is
-                    // providing an "after" value, so we can resolve it to a metric provided the
-                    // parameter index contains an "after" index.
-                    match idx.after {
-                        Some(after_idx) => Ok(MetricF64::ParameterMulti {
-                            indices: ParameterReturnValue::After(after_idx),
-                            key: key.to_string(),
-                        }),
-                        None => Err(MetricF64ResolutionError::ParameterNotRegisteredInCorrectPhase {
-                            parameter: name.clone(),
-                            consumer_phase,
-                            return_value: parameter_return_value,
-                        }),
-                    }
-                }
-                (UnresolvedParameterReturnValue::AfterOrElseInitial, MetricConsumerPhase::Both) => {
-                    // The consumer is using the metric in both "before" and "after" phases, and the
-                    // parameter is providing an "after" value. However, they have specified that using any
-                    // initial value is acceptable in the "before" phase, so we can resolve it to a metric provided the
-                    // parameter index contains an "after" index.
-                    match idx.after {
-                        Some(after_idx) => Ok(MetricF64::ParameterMulti {
-                            indices: ParameterReturnValue::After(after_idx),
-                            key: key.to_string(),
-                        }),
-                        None => Err(MetricF64ResolutionError::ParameterNotRegisteredInCorrectPhase {
-                            parameter: name.clone(),
-                            consumer_phase,
-                            return_value: parameter_return_value,
-                        }),
-                    }
-                }
-                (UnresolvedParameterReturnValue::Both, MetricConsumerPhase::Before) => {
-                    // The consumer is using the metric in the "before" phase, and the parameter is
-                    // providing both "before" and "after" values. We can resolve it to a metric provided the
-                    // parameter index contains a "before" index.
-                    match idx.before {
-                        Some(before_idx) => Ok(MetricF64::ParameterMulti {
-                            indices: ParameterReturnValue::Before(before_idx),
-                            key: key.to_string(),
-                        }),
-                        None => Err(MetricF64ResolutionError::ParameterNotRegisteredInCorrectPhase {
-                            parameter: name.clone(),
-                            consumer_phase,
-                            return_value: parameter_return_value,
-                        }),
-                    }
-                }
-                (UnresolvedParameterReturnValue::Both, MetricConsumerPhase::After) => {
-                    // The consumer is using the metric in the "after" phase, and the parameter is
-                    // providing both "before" and "after" values. We can resolve it to a metric provided the
-                    // parameter index contains an "after" index.
-                    match idx.after {
-                        Some(after_idx) => Ok(MetricF64::ParameterMulti {
-                            indices: ParameterReturnValue::After(after_idx),
-                            key: key.to_string(),
-                        }),
-                        None => Err(MetricF64ResolutionError::ParameterNotRegisteredInCorrectPhase {
-                            parameter: name.clone(),
-                            consumer_phase,
-                            return_value: parameter_return_value,
-                        }),
-                    }
-                }
-                (UnresolvedParameterReturnValue::Both, MetricConsumerPhase::Both) => {
-                    // The consumer is using the metric in both "before" and "after" phases, and the
-                    // parameter is providing both "before" and "after" values. We can resolve it to a metric provided the
-                    // parameter index contains both a "before" and an "after" index.
-                    match (idx.before, idx.after) {
-                        (Some(before_idx), Some(after_idx)) => Ok(MetricF64::ParameterMulti {
-                            indices: ParameterReturnValue::Requested {
-                                before: before_idx,
-                                after: after_idx,
-                            },
-                            key: key.to_string(),
-                        }),
-                        _ => Err(MetricF64ResolutionError::ParameterNotRegisteredInCorrectPhase {
-                            parameter: name.clone(),
-                            consumer_phase,
-                            return_value: parameter_return_value,
-                        }),
-                    }
-                }
-            }
+            let source = resolve_parameter_return_value(idx.before, idx.after, parameter_return_value, consumer_phase)
+                .ok_or_else(|| MetricF64ResolutionError::ParameterNotRegisteredInCorrectPhase {
+                    parameter: name.clone(),
+                    consumer_phase,
+                    return_value: parameter_return_value,
+                })?;
+
+            Ok(MetricF64::ParameterMulti {
+                source,
+                key: key.to_string(),
+            })
         }
+    }
+}
+
+fn resolve_parameter_return_value<T>(
+    before: Option<GeneralBeforeValueIndex<T>>,
+    after: Option<GeneralAfterValueIndex<T>>,
+    requested: UnresolvedParameterReturnValue,
+    consumer: MetricConsumerPhase,
+) -> Option<ParameterValueSource<T>> {
+    match (requested, consumer) {
+        (UnresolvedParameterReturnValue::Before, _) => before.map(ParameterValueSource::Before),
+
+        (UnresolvedParameterReturnValue::After, MetricConsumerPhase::After)
+        | (UnresolvedParameterReturnValue::AfterOrElseInitial, _) => after.map(ParameterValueSource::After),
+
+        (UnresolvedParameterReturnValue::Both, MetricConsumerPhase::Before) => before.map(ParameterValueSource::Before),
+
+        (UnresolvedParameterReturnValue::Both, MetricConsumerPhase::After) => after.map(ParameterValueSource::After),
+
+        (UnresolvedParameterReturnValue::Both, MetricConsumerPhase::Both) => before
+            .zip(after)
+            .map(|(before, after)| ParameterValueSource::Requested { before, after }),
+
+        _ => None,
     }
 }
 
@@ -1556,10 +1087,10 @@ pub enum MetricU64Error {
 #[derive(Clone, Debug, PartialEq)]
 pub enum MetricU64 {
     ParameterU64 {
-        indices: ParameterReturnValue<u64>,
+        source: ParameterValueSource<u64>,
     },
     ParameterMulti {
-        indices: ParameterReturnValue<MultiValue>,
+        source: ParameterValueSource<MultiValue>,
         key: String,
     },
     Simple(SimpleMetricU64),
@@ -1569,19 +1100,19 @@ pub enum MetricU64 {
 impl MetricU64 {
     pub fn get_value(&self, _network: &Network, state: &State) -> Result<u64, MetricU64Error> {
         match self {
-            Self::ParameterU64 { indices } => match indices {
-                ParameterReturnValue::Before(index) => Ok(state.get_general_parameter_u64_before(*index)?),
-                ParameterReturnValue::After(index) => Ok(state.get_general_parameter_u64_after(*index)?),
-                ParameterReturnValue::Requested { before, after } => match state.get_calculation_phase() {
+            Self::ParameterU64 { source } => match source {
+                ParameterValueSource::Before(index) => Ok(state.get_general_parameter_u64_before(*index)?),
+                ParameterValueSource::After(index) => Ok(state.get_general_parameter_u64_after(*index)?),
+                ParameterValueSource::Requested { before, after } => match state.get_calculation_phase() {
                     CalculationPhase::Before => Ok(state.get_general_parameter_u64_before(*before)?),
                     CalculationPhase::After => Ok(state.get_general_parameter_u64_after(*after)?),
                 },
             },
-            Self::ParameterMulti { indices, key } => {
-                let mv = match indices {
-                    ParameterReturnValue::Before(index) => state.get_general_parameter_multi_before(*index)?,
-                    ParameterReturnValue::After(index) => state.get_general_parameter_multi_after(*index)?,
-                    ParameterReturnValue::Requested { before, after } => match state.get_calculation_phase() {
+            Self::ParameterMulti { source, key } => {
+                let mv = match source {
+                    ParameterValueSource::Before(index) => state.get_general_parameter_multi_before(*index)?,
+                    ParameterValueSource::After(index) => state.get_general_parameter_multi_after(*index)?,
+                    ParameterValueSource::Requested { before, after } => match state.get_calculation_phase() {
                         CalculationPhase::Before => state.get_general_parameter_multi_before(*before)?,
                         CalculationPhase::After => state.get_general_parameter_multi_after(*after)?,
                     },
@@ -1775,181 +1306,42 @@ fn resolve_parameter_index_u64_to_metric_u64(
     consumer_phase: MetricConsumerPhase,
 ) -> Result<MetricU64, MetricU64ResolutionError> {
     match idx {
-        // Constant and simple can always be resolved to a metric.
-        ParameterIndex::Const(idx) => Ok(ConstantMetricU64::IndexParameterValue(idx).into()),
-        ParameterIndex::Simple(idx) => Ok(SimpleMetricU64::IndexParameterValue { index: idx }.into()),
+        // Constant and simple can always be resolved to a metric, regardless of the consumer phase
+        // as long as the parameter return value is "before".
+        ParameterIndex::Const(idx) => match parameter_return_value {
+            UnresolvedParameterReturnValue::Before => Ok(ConstantMetricU64::IndexParameterValue(idx).into()),
+            UnresolvedParameterReturnValue::After
+            | UnresolvedParameterReturnValue::AfterOrElseInitial
+            | UnresolvedParameterReturnValue::Both => {
+                Err(MetricU64ResolutionError::ParameterNotRegisteredInCorrectPhase {
+                    parameter: name.clone(),
+                    consumer_phase,
+                    return_value: parameter_return_value,
+                })
+            }
+        },
+        ParameterIndex::Simple(idx) => match parameter_return_value {
+            UnresolvedParameterReturnValue::Before => Ok(SimpleMetricU64::IndexParameterValue { index: idx }.into()),
+            UnresolvedParameterReturnValue::After
+            | UnresolvedParameterReturnValue::AfterOrElseInitial
+            | UnresolvedParameterReturnValue::Both => {
+                Err(MetricU64ResolutionError::ParameterNotRegisteredInCorrectPhase {
+                    parameter: name.clone(),
+                    consumer_phase,
+                    return_value: parameter_return_value,
+                })
+            }
+        },
         // General parameters must be validated against the consumer phase to determine if they can be resolved to a metric.
         ParameterIndex::General(idx) => {
-            match (parameter_return_value, consumer_phase) {
-                (UnresolvedParameterReturnValue::Before, MetricConsumerPhase::Before) => {
-                    // The consumer is using the metric in the "before" phase, and the parameter is
-                    // providing a "before" value, so we can resolve it to a metric provided the
-                    // parameter index contains a "before" index.
-                    match idx.before {
-                        Some(before_idx) => Ok(MetricU64::ParameterU64 {
-                            indices: ParameterReturnValue::Before(before_idx),
-                        }),
-                        None => Err(MetricU64ResolutionError::ParameterNotRegisteredInCorrectPhase {
-                            parameter: name.clone(),
-                            consumer_phase,
-                            return_value: parameter_return_value,
-                        }),
-                    }
-                }
-                (UnresolvedParameterReturnValue::Before, MetricConsumerPhase::After) => {
-                    // The consumer is using the metric in the "after" phase, but the parameter is
-                    // providing a "before" value. This is fine because the "before" value is still
-                    // valid in the "after" phase, so we can resolve it to a metric provided the
-                    // parameter index contains a "before" index.
-                    match idx.before {
-                        Some(before_idx) => Ok(MetricU64::ParameterU64 {
-                            indices: ParameterReturnValue::Before(before_idx),
-                        }),
-                        None => Err(MetricU64ResolutionError::ParameterNotRegisteredInCorrectPhase {
-                            parameter: name.clone(),
-                            consumer_phase,
-                            return_value: parameter_return_value,
-                        }),
-                    }
-                }
-                (UnresolvedParameterReturnValue::Before, MetricConsumerPhase::Both) => {
-                    // The consumer is using the metric in both "before" and "after" phases, and the
-                    // parameter is providing a "before" value. This is fine because the "before"
-                    // value is valid in both phases, so we can resolve it to a metric provided the
-                    // parameter index contains a "before" index.
-                    match idx.before {
-                        Some(before_idx) => Ok(MetricU64::ParameterU64 {
-                            indices: ParameterReturnValue::Before(before_idx),
-                        }),
-                        None => Err(MetricU64ResolutionError::ParameterNotRegisteredInCorrectPhase {
-                            parameter: name.clone(),
-                            consumer_phase,
-                            return_value: parameter_return_value,
-                        }),
-                    }
-                }
-                (UnresolvedParameterReturnValue::After, MetricConsumerPhase::Before)
-                | (UnresolvedParameterReturnValue::After, MetricConsumerPhase::Both) => {
-                    // The consumer is using the metric in the "before" phase, but the parameter is
-                    // providing an "after" value. This is not valid because the "after" value is not
-                    // valid in the "before" phase, so we cannot resolve it to a metric.
-                    Err(MetricU64ResolutionError::ParameterNotRegisteredInCorrectPhase {
-                        parameter: name.clone(),
-                        consumer_phase,
-                        return_value: parameter_return_value,
-                    })
-                }
-                (UnresolvedParameterReturnValue::After, MetricConsumerPhase::After) => {
-                    // The consumer is using the metric in the "after" phase, and the parameter is
-                    // providing an "after" value, so we can resolve it to a metric provided the
-                    // parameter index contains an "after" index.
-                    match idx.after {
-                        Some(after_idx) => Ok(MetricU64::ParameterU64 {
-                            indices: ParameterReturnValue::After(after_idx),
-                        }),
-                        None => Err(MetricU64ResolutionError::ParameterNotRegisteredInCorrectPhase {
-                            parameter: name.clone(),
-                            consumer_phase,
-                            return_value: parameter_return_value,
-                        }),
-                    }
-                }
-                (UnresolvedParameterReturnValue::AfterOrElseInitial, MetricConsumerPhase::Before) => {
-                    // The consumer is using the metric in the "before" phase, but the parameter is
-                    // providing an "after" value. However, they have specified that using any
-                    // initial value is acceptable, so we can resolve it to a metric provided the
-                    // parameter index contains an "after" index.
-                    match idx.after {
-                        Some(after_idx) => Ok(MetricU64::ParameterU64 {
-                            indices: ParameterReturnValue::After(after_idx),
-                        }),
-                        None => Err(MetricU64ResolutionError::ParameterNotRegisteredInCorrectPhase {
-                            parameter: name.clone(),
-                            consumer_phase,
-                            return_value: parameter_return_value,
-                        }),
-                    }
-                }
-                (UnresolvedParameterReturnValue::AfterOrElseInitial, MetricConsumerPhase::After) => {
-                    // The consumer is using the metric in the "after" phase, and the parameter is
-                    // providing an "after" value, so we can resolve it to a metric provided the
-                    // parameter index contains an "after" index.
-                    match idx.after {
-                        Some(after_idx) => Ok(MetricU64::ParameterU64 {
-                            indices: ParameterReturnValue::After(after_idx),
-                        }),
-                        None => Err(MetricU64ResolutionError::ParameterNotRegisteredInCorrectPhase {
-                            parameter: name.clone(),
-                            consumer_phase,
-                            return_value: parameter_return_value,
-                        }),
-                    }
-                }
-                (UnresolvedParameterReturnValue::AfterOrElseInitial, MetricConsumerPhase::Both) => {
-                    // The consumer is using the metric in both "before" and "after" phases, and the
-                    // parameter is providing an "after" value. However, they have specified that using any
-                    // initial value is acceptable in the "before" phase, so we can resolve it to a metric provided the
-                    // parameter index contains an "after" index.
-                    match idx.after {
-                        Some(after_idx) => Ok(MetricU64::ParameterU64 {
-                            indices: ParameterReturnValue::After(after_idx),
-                        }),
-                        None => Err(MetricU64ResolutionError::ParameterNotRegisteredInCorrectPhase {
-                            parameter: name.clone(),
-                            consumer_phase,
-                            return_value: parameter_return_value,
-                        }),
-                    }
-                }
-                (UnresolvedParameterReturnValue::Both, MetricConsumerPhase::Before) => {
-                    // The consumer is using the metric in the "before" phase, and the parameter is
-                    // providing both "before" and "after" values. We can resolve it to a metric provided the
-                    // parameter index contains a "before" index.
-                    match idx.before {
-                        Some(before_idx) => Ok(MetricU64::ParameterU64 {
-                            indices: ParameterReturnValue::Before(before_idx),
-                        }),
-                        None => Err(MetricU64ResolutionError::ParameterNotRegisteredInCorrectPhase {
-                            parameter: name.clone(),
-                            consumer_phase,
-                            return_value: parameter_return_value,
-                        }),
-                    }
-                }
-                (UnresolvedParameterReturnValue::Both, MetricConsumerPhase::After) => {
-                    // The consumer is using the metric in the "after" phase, and the parameter is
-                    // providing both "before" and "after" values. We can resolve it to a metric provided the
-                    // parameter index contains an "after" index.
-                    match idx.after {
-                        Some(after_idx) => Ok(MetricU64::ParameterU64 {
-                            indices: ParameterReturnValue::After(after_idx),
-                        }),
-                        None => Err(MetricU64ResolutionError::ParameterNotRegisteredInCorrectPhase {
-                            parameter: name.clone(),
-                            consumer_phase,
-                            return_value: parameter_return_value,
-                        }),
-                    }
-                }
-                (UnresolvedParameterReturnValue::Both, MetricConsumerPhase::Both) => {
-                    // The consumer is using the metric in both "before" and "after" phases, and the
-                    // parameter is providing both "before" and "after" values. We can resolve it to a metric provided the
-                    // parameter index contains both a "before" and an "after" index.
-                    match (idx.before, idx.after) {
-                        (Some(before_idx), Some(after_idx)) => Ok(MetricU64::ParameterU64 {
-                            indices: ParameterReturnValue::Requested {
-                                before: before_idx,
-                                after: after_idx,
-                            },
-                        }),
-                        _ => Err(MetricU64ResolutionError::ParameterNotRegisteredInCorrectPhase {
-                            parameter: name.clone(),
-                            consumer_phase,
-                            return_value: parameter_return_value,
-                        }),
-                    }
-                }
-            }
+            let source = resolve_parameter_return_value(idx.before, idx.after, parameter_return_value, consumer_phase)
+                .ok_or_else(|| MetricU64ResolutionError::ParameterNotRegisteredInCorrectPhase {
+                    parameter: name.clone(),
+                    consumer_phase,
+                    return_value: parameter_return_value,
+                })?;
+
+            Ok(MetricU64::ParameterU64 { source })
         }
     }
 }
@@ -1967,199 +1359,53 @@ fn resolve_parameter_index_multi_to_metric_u64(
     consumer_phase: MetricConsumerPhase,
 ) -> Result<MetricU64, MetricU64ResolutionError> {
     match idx {
-        // Constant and simple can always be resolved to a metric.
-        ParameterIndex::Const(index) => Ok(ConstantMetricU64::MultiParameterValue {
-            index,
-            key: key.to_string(),
-        }
-        .into()),
-        ParameterIndex::Simple(index) => Ok(SimpleMetricU64::MultiParameterValue {
-            index,
-            key: key.to_string(),
-        }
-        .into()),
+        // Constant and simple can always be resolved to a metric, regardless of the consumer phase
+        // as long as the parameter return value is "before".
+        ParameterIndex::Const(index) => match parameter_return_value {
+            UnresolvedParameterReturnValue::Before => Ok(ConstantMetricU64::MultiParameterValue {
+                index,
+                key: key.to_string(),
+            }
+            .into()),
+            UnresolvedParameterReturnValue::After
+            | UnresolvedParameterReturnValue::AfterOrElseInitial
+            | UnresolvedParameterReturnValue::Both => {
+                Err(MetricU64ResolutionError::ParameterNotRegisteredInCorrectPhase {
+                    parameter: name.clone(),
+                    consumer_phase,
+                    return_value: parameter_return_value,
+                })
+            }
+        },
+        ParameterIndex::Simple(index) => match parameter_return_value {
+            UnresolvedParameterReturnValue::Before => Ok(SimpleMetricU64::MultiParameterValue {
+                index,
+                key: key.to_string(),
+            }
+            .into()),
+            UnresolvedParameterReturnValue::After
+            | UnresolvedParameterReturnValue::AfterOrElseInitial
+            | UnresolvedParameterReturnValue::Both => {
+                Err(MetricU64ResolutionError::ParameterNotRegisteredInCorrectPhase {
+                    parameter: name.clone(),
+                    consumer_phase,
+                    return_value: parameter_return_value,
+                })
+            }
+        },
         // General parameters must be validated against the consumer phase to determine if they can be resolved to a metric.
         ParameterIndex::General(idx) => {
-            match (parameter_return_value, consumer_phase) {
-                (UnresolvedParameterReturnValue::Before, MetricConsumerPhase::Before) => {
-                    // The consumer is using the metric in the "before" phase, and the parameter is
-                    // providing a "before" value, so we can resolve it to a metric provided the
-                    // parameter index contains a "before" index.
-                    match idx.before {
-                        Some(before_idx) => Ok(MetricU64::ParameterMulti {
-                            indices: ParameterReturnValue::Before(before_idx),
-                            key: key.to_string(),
-                        }),
-                        None => Err(MetricU64ResolutionError::ParameterNotRegisteredInCorrectPhase {
-                            parameter: name.clone(),
-                            consumer_phase,
-                            return_value: parameter_return_value,
-                        }),
-                    }
-                }
-                (UnresolvedParameterReturnValue::Before, MetricConsumerPhase::After) => {
-                    // The consumer is using the metric in the "after" phase, but the parameter is
-                    // providing a "before" value. This is fine because the "before" value is still
-                    // valid in the "after" phase, so we can resolve it to a metric provided the
-                    // parameter index contains a "before" index.
-                    match idx.before {
-                        Some(before_idx) => Ok(MetricU64::ParameterMulti {
-                            indices: ParameterReturnValue::Before(before_idx),
-                            key: key.to_string(),
-                        }),
-                        None => Err(MetricU64ResolutionError::ParameterNotRegisteredInCorrectPhase {
-                            parameter: name.clone(),
-                            consumer_phase,
-                            return_value: parameter_return_value,
-                        }),
-                    }
-                }
-                (UnresolvedParameterReturnValue::Before, MetricConsumerPhase::Both) => {
-                    // The consumer is using the metric in both "before" and "after" phases, and the
-                    // parameter is providing a "before" value. This is fine because the "before"
-                    // value is valid in both phases, so we can resolve it to a metric provided the
-                    // parameter index contains a "before" index.
-                    match idx.before {
-                        Some(before_idx) => Ok(MetricU64::ParameterMulti {
-                            indices: ParameterReturnValue::Before(before_idx),
-                            key: key.to_string(),
-                        }),
-                        None => Err(MetricU64ResolutionError::ParameterNotRegisteredInCorrectPhase {
-                            parameter: name.clone(),
-                            consumer_phase,
-                            return_value: parameter_return_value,
-                        }),
-                    }
-                }
-                (UnresolvedParameterReturnValue::After, MetricConsumerPhase::Before)
-                | (UnresolvedParameterReturnValue::After, MetricConsumerPhase::Both) => {
-                    // The consumer is using the metric in the "before" phase, but the parameter is
-                    // providing an "after" value. This is not valid because the "after" value is not
-                    // valid in the "before" phase, so we cannot resolve it to a metric.
-                    Err(MetricU64ResolutionError::ParameterNotRegisteredInCorrectPhase {
-                        parameter: name.clone(),
-                        consumer_phase,
-                        return_value: parameter_return_value,
-                    })
-                }
-                (UnresolvedParameterReturnValue::After, MetricConsumerPhase::After) => {
-                    // The consumer is using the metric in the "after" phase, and the parameter is
-                    // providing an "after" value, so we can resolve it to a metric provided the
-                    // parameter index contains an "after" index.
-                    match idx.after {
-                        Some(after_idx) => Ok(MetricU64::ParameterMulti {
-                            indices: ParameterReturnValue::After(after_idx),
-                            key: key.to_string(),
-                        }),
-                        None => Err(MetricU64ResolutionError::ParameterNotRegisteredInCorrectPhase {
-                            parameter: name.clone(),
-                            consumer_phase,
-                            return_value: parameter_return_value,
-                        }),
-                    }
-                }
-                (UnresolvedParameterReturnValue::AfterOrElseInitial, MetricConsumerPhase::Before) => {
-                    // The consumer is using the metric in the "before" phase, but the parameter is
-                    // providing an "after" value. However, they have specified that using any
-                    // initial value is acceptable, so we can resolve it to a metric provided the
-                    // parameter index contains an "after" index.
-                    match idx.after {
-                        Some(after_idx) => Ok(MetricU64::ParameterMulti {
-                            indices: ParameterReturnValue::After(after_idx),
-                            key: key.to_string(),
-                        }),
-                        None => Err(MetricU64ResolutionError::ParameterNotRegisteredInCorrectPhase {
-                            parameter: name.clone(),
-                            consumer_phase,
-                            return_value: parameter_return_value,
-                        }),
-                    }
-                }
-                (UnresolvedParameterReturnValue::AfterOrElseInitial, MetricConsumerPhase::After) => {
-                    // The consumer is using the metric in the "after" phase, and the parameter is
-                    // providing an "after" value, so we can resolve it to a metric provided the
-                    // parameter index contains an "after" index.
-                    match idx.after {
-                        Some(after_idx) => Ok(MetricU64::ParameterMulti {
-                            indices: ParameterReturnValue::After(after_idx),
-                            key: key.to_string(),
-                        }),
-                        None => Err(MetricU64ResolutionError::ParameterNotRegisteredInCorrectPhase {
-                            parameter: name.clone(),
-                            consumer_phase,
-                            return_value: parameter_return_value,
-                        }),
-                    }
-                }
-                (UnresolvedParameterReturnValue::AfterOrElseInitial, MetricConsumerPhase::Both) => {
-                    // The consumer is using the metric in both "before" and "after" phases, and the
-                    // parameter is providing an "after" value. However, they have specified that using any
-                    // initial value is acceptable in the "before" phase, so we can resolve it to a metric provided the
-                    // parameter index contains an "after" index.
-                    match idx.after {
-                        Some(after_idx) => Ok(MetricU64::ParameterMulti {
-                            indices: ParameterReturnValue::After(after_idx),
-                            key: key.to_string(),
-                        }),
-                        None => Err(MetricU64ResolutionError::ParameterNotRegisteredInCorrectPhase {
-                            parameter: name.clone(),
-                            consumer_phase,
-                            return_value: parameter_return_value,
-                        }),
-                    }
-                }
-                (UnresolvedParameterReturnValue::Both, MetricConsumerPhase::Before) => {
-                    // The consumer is using the metric in the "before" phase, and the parameter is
-                    // providing both "before" and "after" values. We can resolve it to a metric provided the
-                    // parameter index contains a "before" index.
-                    match idx.before {
-                        Some(before_idx) => Ok(MetricU64::ParameterMulti {
-                            indices: ParameterReturnValue::Before(before_idx),
-                            key: key.to_string(),
-                        }),
-                        None => Err(MetricU64ResolutionError::ParameterNotRegisteredInCorrectPhase {
-                            parameter: name.clone(),
-                            consumer_phase,
-                            return_value: parameter_return_value,
-                        }),
-                    }
-                }
-                (UnresolvedParameterReturnValue::Both, MetricConsumerPhase::After) => {
-                    // The consumer is using the metric in the "after" phase, and the parameter is
-                    // providing both "before" and "after" values. We can resolve it to a metric provided the
-                    // parameter index contains an "after" index.
-                    match idx.after {
-                        Some(after_idx) => Ok(MetricU64::ParameterMulti {
-                            indices: ParameterReturnValue::After(after_idx),
-                            key: key.to_string(),
-                        }),
-                        None => Err(MetricU64ResolutionError::ParameterNotRegisteredInCorrectPhase {
-                            parameter: name.clone(),
-                            consumer_phase,
-                            return_value: parameter_return_value,
-                        }),
-                    }
-                }
-                (UnresolvedParameterReturnValue::Both, MetricConsumerPhase::Both) => {
-                    // The consumer is using the metric in both "before" and "after" phases, and the
-                    // parameter is providing both "before" and "after" values. We can resolve it to a metric provided the
-                    // parameter index contains both a "before" and an "after" index.
-                    match (idx.before, idx.after) {
-                        (Some(before_idx), Some(after_idx)) => Ok(MetricU64::ParameterMulti {
-                            indices: ParameterReturnValue::Requested {
-                                before: before_idx,
-                                after: after_idx,
-                            },
-                            key: key.to_string(),
-                        }),
-                        _ => Err(MetricU64ResolutionError::ParameterNotRegisteredInCorrectPhase {
-                            parameter: name.clone(),
-                            consumer_phase,
-                            return_value: parameter_return_value,
-                        }),
-                    }
-                }
-            }
+            let source = resolve_parameter_return_value(idx.before, idx.after, parameter_return_value, consumer_phase)
+                .ok_or_else(|| MetricU64ResolutionError::ParameterNotRegisteredInCorrectPhase {
+                    parameter: name.clone(),
+                    consumer_phase,
+                    return_value: parameter_return_value,
+                })?;
+
+            Ok(MetricU64::ParameterMulti {
+                source,
+                key: key.to_string(),
+            })
         }
     }
 }

--- a/pywr-core/src/network.rs
+++ b/pywr-core/src/network.rs
@@ -3,6 +3,7 @@ use crate::aggregated_storage_node::{
     AggregatedStorageNode, AggregatedStorageNodeBuilder, AggregatedStorageNodeBuilderError,
 };
 use crate::edge::Edge;
+use crate::metric::CalculationPhase;
 use crate::models::{ModelDomain, MultiNetworkTransferIndex};
 use crate::node::{Node, NodeBuilder, NodeBuilderError, NodeError, UnresolvedNode};
 use crate::parameters::{
@@ -777,7 +778,7 @@ impl Network {
                     // TODO clear the current parameter values state (i.e. set them all to zero).
 
                     let start_p_calc = Instant::now();
-                    self.compute_components(
+                    self.before(
                         timestep,
                         scenario_index,
                         current_state,
@@ -841,7 +842,7 @@ impl Network {
                     // TODO clear the current parameter values state (i.e. set them all to zero).
 
                     let start_p_calc = Instant::now();
-                    self.compute_components(timestep, scenario_index, current_state, p_internal_state, None)
+                    self.before(timestep, scenario_index, current_state, p_internal_state, None)
                         .unwrap();
 
                     // State now contains updated parameter values BUT original network state
@@ -901,7 +902,7 @@ impl Network {
                 // TODO clear the current parameter values state (i.e. set them all to zero).
 
                 let start_p_calc = Instant::now();
-                self.compute_components(timestep, scenario_index, current_state, p_internal_states, None)
+                self.before(timestep, scenario_index, current_state, p_internal_states, None)
                     .unwrap();
 
                 // State now contains updated parameter values BUT original network state
@@ -992,7 +993,7 @@ impl Network {
     /// set initial volume). For parameters this involves computing the current value for the
     /// the timestep. The `state` object is progressively updated with these values during this
     /// method.
-    fn compute_components(
+    fn before(
         &self,
         timestep: &Timestep,
         scenario_index: &ScenarioIndex,
@@ -1000,6 +1001,7 @@ impl Network {
         internal_states: &mut ParameterStates,
         timings: Option<&mut ComponentTimings>,
     ) -> Result<(), NetworkStepError> {
+        state.set_calculation_phase(CalculationPhase::Before);
         // TODO reset parameter state to zero
 
         // First we update the simple parameters
@@ -1049,7 +1051,7 @@ impl Network {
         metric_set_states: &mut [MetricSetState],
         timings: Option<&mut ComponentTimings>,
     ) -> Result<(), NetworkStepError> {
-        // TODO reset parameter state to zero
+        state.set_calculation_phase(CalculationPhase::After);
 
         // No "after" on nodes and virtual nodes
 
@@ -2611,7 +2613,7 @@ mod tests {
             metric_set_internal_states,
         } = &mut network_state;
         network
-            .compute_components(
+            .before(
                 &timesteps[0],
                 scenario,
                 &mut states[0],
@@ -2690,7 +2692,7 @@ mod tests {
             for scenario in scenarios {
                 let scenario_id = scenario.simulation_id();
                 network
-                    .compute_components(
+                    .before(
                         timestep,
                         scenario,
                         &mut states[scenario_id],

--- a/pywr-core/src/parameters/mod.rs
+++ b/pywr-core/src/parameters/mod.rs
@@ -418,10 +418,11 @@ impl<T> From<ConstParameterIndex<T>> for ParameterIndex<T> {
 
 /// Specifies whether to use the 'before' or 'after' parameter values.
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub enum ParameterReturnValue {
+pub enum UnresolvedParameterReturnValue {
     Before,
     After,
     AfterOrElseInitial,
+    Both,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]

--- a/pywr-core/src/state/mod.rs
+++ b/pywr-core/src/state/mod.rs
@@ -2,7 +2,7 @@ mod flow;
 mod storage;
 
 use crate::edge::Edge;
-use crate::metric::SimpleMetricF64Error;
+use crate::metric::{CalculationPhase, SimpleMetricF64Error};
 use crate::models::MultiNetworkTransferIndex;
 use crate::network::{EdgeIndex, Network, NodeIndex, VirtualStorageIndex};
 use crate::node::Node;
@@ -793,9 +793,19 @@ pub struct State {
     parameters_general_after: ParameterValues,
 
     inter_network_values: Vec<f64>,
+    // The current phase of the calculation
+    current_phase: CalculationPhase,
 }
 
 impl State {
+    pub fn get_calculation_phase(&self) -> CalculationPhase {
+        self.current_phase
+    }
+
+    pub fn set_calculation_phase(&mut self, phase: CalculationPhase) {
+        self.current_phase = phase;
+    }
+
     /// Get a reference to the network state.
     pub fn get_network_state(&self) -> &NetworkState {
         &self.network
@@ -1261,6 +1271,7 @@ impl StateBuilder {
             parameters_general_before,
             parameters_general_after,
             inter_network_values: vec![0.0; self.num_inter_network_values.unwrap_or(0)],
+            current_phase: CalculationPhase::Before,
         }
     }
 }

--- a/pywr-schema/src/metric.rs
+++ b/pywr-schema/src/metric.rs
@@ -517,15 +517,17 @@ pub enum ParameterReturnValue {
     Before,
     After,
     AfterOrElseInitial,
+    Both,
 }
 
 #[cfg(feature = "core")]
-impl From<ParameterReturnValue> for pywr_core::parameters::ParameterReturnValue {
+impl From<ParameterReturnValue> for pywr_core::parameters::UnresolvedParameterReturnValue {
     fn from(v: ParameterReturnValue) -> Self {
         match v {
             ParameterReturnValue::Before => Self::Before,
             ParameterReturnValue::After => Self::After,
             ParameterReturnValue::AfterOrElseInitial => Self::AfterOrElseInitial,
+            ParameterReturnValue::Both => Self::Both,
         }
     }
 }

--- a/pywr-schema/tests/hydropower1-expected.csv
+++ b/pywr-schema/tests/hydropower1-expected.csv
@@ -1,0 +1,7 @@
+time_start,time_end,simulation_id,label,metric_set,name,attribute,value
+2015-01-01T00:00:00,2015-01-02T00:00:00,0,0,parameters,total_turbines,before,10.0
+2015-01-01T00:00:00,2015-01-02T00:00:00,0,0,parameters,total_turbines,after,9.81
+2015-01-02T00:00:00,2015-01-03T00:00:00,0,0,parameters,total_turbines,before,10.0
+2015-01-02T00:00:00,2015-01-03T00:00:00,0,0,parameters,total_turbines,after,9.81
+2015-01-03T00:00:00,2015-01-04T00:00:00,0,0,parameters,total_turbines,before,10.0
+2015-01-03T00:00:00,2015-01-04T00:00:00,0,0,parameters,total_turbines,after,9.81

--- a/pywr-schema/tests/hydropower1.json
+++ b/pywr-schema/tests/hydropower1.json
@@ -1,0 +1,174 @@
+{
+  "metadata": {
+    "title": "Turbine 1",
+    "description": "An example of using the HydropowerTarget parameter.",
+    "minimum_version": "0.1"
+  },
+  "time": {
+    "start": "2015-01-01",
+    "end": "2015-01-03",
+    "timestep": {
+      "type": "Days",
+      "days": 1
+    }
+  },
+  "network": {
+    "nodes": [
+      {
+        "meta": {
+          "name": "supply1"
+        },
+        "type": "Input",
+        "max_flow": {
+          "type": "Literal",
+          "value": 15.0
+        }
+      },
+      {
+        "meta": {
+          "name": "link1"
+        },
+        "type": "Link",
+        "max_flow": {
+          "type": "Parameter",
+          "name": "turbine1",
+          "return_value": "Before"
+        }
+      },
+      {
+        "meta": {
+          "name": "demand1"
+        },
+        "type": "Output",
+        "max_flow": {
+          "type": "Parameter",
+          "name": "demand"
+        },
+        "cost": {
+          "type": "Literal",
+          "value": -10
+        }
+      }
+    ],
+    "edges": [
+      {
+        "from_node": "supply1",
+        "to_node": "link1"
+      },
+      {
+        "from_node": "link1",
+        "to_node": "demand1"
+      }
+    ],
+    "parameters": [
+      {
+        "meta": {
+          "name": "demand"
+        },
+        "type": "Constant",
+        "value": {
+          "type": "Literal",
+          "value": 10.0
+        }
+      },
+      {
+        "meta": {
+          "name": "turbine1"
+        },
+        "type": "HydropowerTarget",
+        "actual_flow": {
+          "type": "Node",
+          "name": "link1",
+          "attribute": "Inflow"
+        },
+        "target": {
+          "type": "Literal",
+          "value": 9.81
+        },
+        "turbine_elevation": 100.0,
+        "min_head": 0.0,
+        "efficiency": 1.0,
+        "water_density": 1000.0,
+        "flow_unit_conversion": 1.0,
+        "energy_unit_conversion": 1e-6
+      },
+      {
+        "meta": {
+          "name": "total_flow_target"
+        },
+        "type": "Aggregated",
+        "phase": "Before",
+        "agg_func": {
+          "type": "Sum"
+        },
+        "metrics": [
+          {
+            "type": "Parameter",
+            "name": "turbine1",
+            "return_value": "Before"
+          }
+        ]
+      },
+      {
+        "meta": {
+          "name": "total_power"
+        },
+        "type": "Aggregated",
+        "phase": "After",
+        "agg_func": {
+          "type": "Sum"
+        },
+        "metrics": [
+          {
+            "type": "Parameter",
+            "name": "turbine1",
+            "return_value": "After"
+          }
+        ]
+      },
+      {
+        "meta": {
+          "name": "total_turbines"
+        },
+        "type": "Aggregated",
+        "phase": "Both",
+        "agg_func": {
+          "type": "Sum"
+        },
+        "metrics": [
+          {
+            "type": "Parameter",
+            "name": "turbine1",
+            "return_value": "Both"
+          }
+        ]
+      }
+    ],
+    "metric_sets": [
+      {
+        "name": "parameters",
+        "metrics": [
+          {
+            "type": "Parameter",
+            "name": "total_turbines",
+            "return_value": "Before"
+          },
+          {
+            "type": "Parameter",
+            "name": "total_turbines",
+            "return_value": "After"
+          }
+        ]
+      }
+    ],
+    "outputs": [
+      {
+        "name": "nodes",
+        "type": "CSV",
+        "format": "Long",
+        "filename": "hydropower1-expected.csv",
+        "metric_set": "parameters"
+      }
+    ]
+  }
+}

--- a/pywr-schema/tests/hydropower1.json
+++ b/pywr-schema/tests/hydropower1.json
@@ -94,40 +94,6 @@
       },
       {
         "meta": {
-          "name": "total_flow_target"
-        },
-        "type": "Aggregated",
-        "phase": "Before",
-        "agg_func": {
-          "type": "Sum"
-        },
-        "metrics": [
-          {
-            "type": "Parameter",
-            "name": "turbine1",
-            "return_value": "Before"
-          }
-        ]
-      },
-      {
-        "meta": {
-          "name": "total_power"
-        },
-        "type": "Aggregated",
-        "phase": "After",
-        "agg_func": {
-          "type": "Sum"
-        },
-        "metrics": [
-          {
-            "type": "Parameter",
-            "name": "turbine1",
-            "return_value": "After"
-          }
-        ]
-      },
-      {
-        "meta": {
           "name": "total_turbines"
         },
         "type": "Aggregated",

--- a/pywr-schema/tests/test_models.rs
+++ b/pywr-schema/tests/test_models.rs
@@ -108,6 +108,7 @@ model_tests! {
     test_reservoir_failure_levels1: ("reservoir-failure-levels1.json", vec![("reservoir-failure-levels1-expected.csv", ResultsShape::Long)], vec![], vec![]),
     test_daily_profile1: ("daily-profile1.json", vec![("daily-profile1-expected.csv", ResultsShape::Long)], vec![], vec![]),
     test_turbine1: ("turbine1.json", vec![("turbine1-expected.csv", ResultsShape::Long)], vec![], vec![]),
+    test_hydropower1: ("hydropower1.json", vec![("hydropower1-expected.csv", ResultsShape::Long)], vec![], vec![]),
 }
 
 /// Test Pandas backend for reading timeseries data.


### PR DESCRIPTION
The current implementation, while allowing metrics to compute values in each phase, does not allow referencing a parameter's value aligned to the current phase. This change allows fetching the parameter's value as per the current the calculation phase. Therefore, it allows computing more complex chains of "Both" values. For example, calculating aggregations of both values with a single aggregation parameter.