### PR TITLE
docs: Improve license notifications.

### DIFF
--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 James Tomlinson
+Copyright (c) 2026 James Tomlinson Associates Ltd.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,5 @@
+Pywr v2
+Copyright 2026 James Tomlinson Associates Ltd.
+
+This product includes software developed by
+COIN-OR (https://www.coin-or.org).

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@
 [![Forks][forks-shield]][forks-url]
 [![Stargazers][stars-shield]][stars-url]
 [![Issues][issues-shield]][issues-url]
-[![MIT License][license-shield]][license-url]
+[![MIT License][license-shield]][license-mit-url]
+[![Apache License](https://img.shields.io/badge/License-Apache--2.0-green?style=for-the-badge)][license-apache-url]
 [![LinkedIn][linkedin-shield]][linkedin-url]
 
 
@@ -75,9 +76,9 @@
 ## About The Project
 
 Pywr-1.x is a Python library which utilises Cython for performance. Over time this has resulted in a "core"
-set of data structures and objects that are written in Cython to gain maximum performance. Cython has the nice
-benefit of making it easy to extend that core functionality using regular Python. However, the border between what
-is Python and what is Cython is a bit blurred and not well designed in certain places.
+set of data structures and objects that are written in Cython to gain maximum performance. Cython has the nice benefit
+of making it easy to extend that core functionality using regular Python. However, the border between what is Python and
+what is Cython is a bit blurred and not well designed in certain places.
 
 One option for the future development of Pywr (e.g. Pywr-2.x) would be a more explicit separation between the compute
 "core" and higher level functionality. Rust is a candidate for writing that core largely independent of Python, and
@@ -117,17 +118,17 @@ See instructions in the [Pywr book](https://pywr.github.io/pywr-next/getting_sta
 
 #### Compiling from source
 
-This repository contains a version of Clp using Git submodules. In order to build those submodules
-must be initialised first.
+This repository contains a version of Clp using Git submodules. In order to build those submodules must be initialised
+first.
 
 ```bash
 git submodule init
 git submodule update
 ```
 
-Rust is required for installation of the Python extension. To create a Python development installation
-requires first compiling the Rust library and then the Python extension. The following example uses
-a virtual environment to install the Python dependencies, compile the Pywr extension and run the Pywr Python CLI.
+Rust is required for installation of the Python extension. To create a Python development installation requires first
+compiling the Rust library and then the Python extension. The following example uses a virtual environment to install
+the Python dependencies, compile the Pywr extension and run the Pywr Python CLI.
 
 ```bash
 python -m venv .venv # create a new virtual environment
@@ -148,8 +149,8 @@ python -m pywr  # run the Pywr Python CLI
 
 ### Rust CLI
 
-A basic command line interface is included such that you can use this version of Pywr without Python.
-This CLI is in the `pywr-cli` crate.
+A basic command line interface is included such that you can use this version of Pywr without Python. This CLI is in the
+`pywr-cli` crate.
 
 To see the CLI commands available run the following:
 
@@ -165,8 +166,7 @@ cargo run -p pywr-cli -- run tests/models/simple1.json
 
 ### Python CLI
 
-If the Python extension has been compiled using the above instructions a model can be run using the basic Python
-CLI.
+If the Python extension has been compiled using the above instructions a model can be run using the basic Python CLI.
 
 ```bash
 python -m pywr run tests/models/simple1.json
@@ -174,16 +174,15 @@ python -m pywr run tests/models/simple1.json
 
 ## Porting a Pywr v1.x model to v2.x
 
-This version of Pywr is not backward compatible with Pywr v1.x. One of the major reasons for this version is the
-lack of a strong schema in the Pywr v1.x JSON files. Pywr v2.x uses an updated JSON schema that is defined in this
-repository. Therefore, v1.x JSON files must be converted to the v2.x JSON schema. This conversion can be undertaken
-manually, but there is also a work-in-progress conversion tool. The conversion tool uses a v1.x schema defined in
+This version of Pywr is not backward compatible with Pywr v1.x. One of the major reasons for this version is the lack of
+a strong schema in the Pywr v1.x JSON files. Pywr v2.x uses an updated JSON schema that is defined in this repository.
+Therefore, v1.x JSON files must be converted to the v2.x JSON schema. This conversion can be undertaken manually, but
+there is also a work-in-progress conversion tool. The conversion tool uses a v1.x schema defined in
 the [pywr-schema](https://github.com/pywr/pywr-schema) project.
 
-**Please note that conversion from Pywr v1.x to v2.x is experimental and not all features of Pywr are implemented
-in `pywr-schema` or have been implemented in Pywr v2.x yet. Due to the changes between these versions it is very
-likely an automatic conversion will not completely convert your model, and it _WILL_ require manual testing and
-checking.**
+**Please note that conversion from Pywr v1.x to v2.x is experimental and not all features of Pywr are implemented in
+`pywr-schema` or have been implemented in Pywr v2.x yet. Due to the changes between these versions it is very likely an
+automatic conversion will not completely convert your model, and it _WILL_ require manual testing and checking.**
 
 ```bash
 cargo run --no-default-features -- convert /path/to/my/v1.x/model.json
@@ -218,8 +217,8 @@ Feature flags:
 
 ### Pywr-schema
 
-A Rust library for validating Pywr JSON files against a schema, and then building a model from the schema
-using `pywr-core`.
+A Rust library for validating Pywr JSON files against a schema, and then building a model from the schema using
+`pywr-core`.
 
 Feature flags:
 
@@ -266,8 +265,7 @@ Contributions are what make the open source community such an amazing place to l
 contributions you make are **greatly appreciated**.
 
 If you have a suggestion that would make this better, please fork the repo and create a pull request. You can also
-simply open an issue with the tag "enhancement".
-Don't forget to give the project a star! Thanks again!
+simply open an issue with the tag "enhancement". Don't forget to give the project a star! Thanks again!
 
 1. Fork the Project
 2. Create your Feature Branch (`git checkout -b feature/AmazingFeature`)
@@ -319,7 +317,9 @@ Project Link: [https://github.com/pywr/pywr-next](https://github.com/pywr/pywr-n
 
 [license-shield]: https://img.shields.io/github/license/pywr/pywr-next.svg?style=for-the-badge
 
-[license-url]: https://github.com/pywr/pywr-next/blob/main/LICENSE
+[license-mit-url]: https://github.com/pywr/pywr-next/blob/main/LICENSE-MIT
+
+[license-apache-url]: https://github.com/pywr/pywr-next/blob/main/LICENSE-APACHE
 
 [linkedin-shield]: https://img.shields.io/badge/-LinkedIn-black.svg?style=for-the-badge&logo=linkedin&colorB=555
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,8 @@ authors = [
 ]
 readme = "README.md"
 requires-python = ">=3.10"
-license = "MIT OR Apache-2.0"
+license = "(MIT OR Apache-2.0) AND EPL-2.0"
+license-files = ["LICENSE-APACHE", "LICENSE-MIT", "coin-or-sys/vendor/Cbc/LICENSE"]
 dependencies = [
     "pandas",
     "polars>=1.43.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,12 @@ authors = [
 readme = "README.md"
 requires-python = ">=3.10"
 license = "(MIT OR Apache-2.0) AND EPL-2.0"
-license-files = ["LICENSE-APACHE", "LICENSE-MIT", "coin-or-sys/vendor/Cbc/LICENSE"]
+license-files = [
+    "LICENSE-APACHE",
+    "LICENSE-MIT",
+    "NOTICE",
+    "coin-or-sys/vendor/Cbc/LICENSE"
+]
 dependencies = [
     "pandas",
     "polars>=1.43.2",


### PR DESCRIPTION
- Fix Python sdist build by including "license-files" in pyproject.toml
- Add separate license files for MIT and Apache-2.0.
- Include the EPL-2.0 in the license list for Python. We bundled the COIN-OR (Cbc, Clp, etc) dependencies so this license applies to that source code.
- Add a NOTICE file to comply with Apache-2.0 licence. Refer to the COIN-OR dependencies in there.