### PR TITLE
feat: Add simple row bounds sense check.

### DIFF
--- a/pywr-core/src/solvers/builder.rs
+++ b/pywr-core/src/solvers/builder.rs
@@ -494,6 +494,15 @@ where
                     NodeBounds::Volume(bounds) => (-bounds.available / dt, bounds.missing / dt),
                 };
 
+            if lb > ub {
+                return Err(SolverSolveError::NodeBoundsInfeasible {
+                    name: node.name().to_string(),
+                    sub_name: node.sub_name().map(|s| s.to_string()),
+                    lower_bound: lb,
+                    upper_bound: ub,
+                });
+            }
+
             match row.row_type {
                 NodeRowType::Continuous => {
                     // Regular node constraint
@@ -614,6 +623,15 @@ where
                 // Node is inactive, so set bounds to be unbounded
                 (self.builder.f64_neg_max, self.builder.f64_max)
             };
+
+            if lb > ub {
+                return Err(SolverSolveError::VirtualStorageBoundsInfeasible {
+                    name: node.name().to_string(),
+                    sub_name: node.sub_name().map(|s| s.to_string()),
+                    lower_bound: lb,
+                    upper_bound: ub,
+                });
+            }
 
             self.builder.apply_row_bounds(*row_id, lb, ub);
         }
@@ -849,6 +867,17 @@ where
                 Some(NodeBounds::Flow(bounds)) => Some(bounds),
                 _ => None,
             };
+
+            if let Some(bounds) = bounds {
+                if bounds.min_flow > bounds.max_flow {
+                    return Err(SolverSetupError::NodeBoundsInfeasible {
+                        name: node.name().to_string(),
+                        sub_name: node.sub_name().map(|s| s.to_string()),
+                        lower_bound: bounds.min_flow,
+                        upper_bound: bounds.max_flow,
+                    });
+                }
+            }
 
             // If there are binary variables associated with this node, then we need to add a row
             // that enforces each binary variable's constraints

--- a/pywr-core/src/solvers/mod.rs
+++ b/pywr-core/src/solvers/mod.rs
@@ -111,6 +111,13 @@ pub enum SolverSetupError {
     NoEdgesDefined,
     #[error("Node index not found: {0}")]
     NodeIndexNotFound(NodeIndex),
+    #[error("Node bounds [{lower_bound}, {upper_bound}] are infeasible for node `{name}` and sub-name `{}`", .sub_name.as_deref().unwrap_or("None"))]
+    NodeBoundsInfeasible {
+        name: String,
+        sub_name: Option<String>,
+        lower_bound: f64,
+        upper_bound: f64,
+    },
     #[cfg(feature = "highs")]
     #[error("Highs error: {0}")]
     HighsError(#[from] highs::HighsStatusError),
@@ -154,6 +161,20 @@ pub enum SolverSolveError {
     NetworkStateError(#[from] crate::state::NetworkStateError),
     #[error("State error: {0}")]
     StateError(#[from] crate::state::StateError),
+    #[error("Node bounds [{lower_bound}, {upper_bound}] are infeasible for node `{name}` and sub-name `{}`", .sub_name.as_deref().unwrap_or("None"))]
+    NodeBoundsInfeasible {
+        name: String,
+        sub_name: Option<String>,
+        lower_bound: f64,
+        upper_bound: f64,
+    },
+    #[error("Virtual storage bounds [{lower_bound}, {upper_bound}] are infeasible for node `{name}` and sub-name `{}`", .sub_name.as_deref().unwrap_or("None"))]
+    VirtualStorageBoundsInfeasible {
+        name: String,
+        sub_name: Option<String>,
+        lower_bound: f64,
+        upper_bound: f64,
+    },
     #[cfg(feature = "clp")]
     #[error("Clp error: {0}")]
     ClpSolveError(#[from] ClpSolveStatusError),


### PR DESCRIPTION
This should catch some simple bounds errors with useful error messages instead of an obscure LP infeasibility. It does not check that successive application of bounds results infeasible values.