### PR TITLE
refactor: Improve variable names for Network references.

### DIFF
--- a/pywr-core/src/aggregated_node.rs
+++ b/pywr-core/src/aggregated_node.rs
@@ -474,20 +474,20 @@ impl AggregatedNode {
     #[must_use]
     pub fn get_norm_factor_pairs(
         &self,
-        model: &Network,
+        network: &Network,
         state: &State,
     ) -> Option<Result<Vec<NodeFactorPair<'_>>, FactorError>> {
         if let Some(factors) = self.get_factors() {
             let pairs = match factors {
                 Factors::Proportion { factors } => {
-                    get_norm_proportional_factor_pairs(factors, &self.nodes, model, state)
+                    get_norm_proportional_factor_pairs(factors, &self.nodes, network, state)
                         .map_err(FactorError::Proportional)
                 }
                 Factors::Ratio { factors } => {
-                    get_norm_ratio_factor_pairs(factors, &self.nodes, model, state).map_err(FactorError::Ratio)
+                    get_norm_ratio_factor_pairs(factors, &self.nodes, network, state).map_err(FactorError::Ratio)
                 }
                 Factors::Coefficients { factors, rhs } => {
-                    get_coefficient_factor_pairs(factors, &self.nodes, rhs.as_ref(), model, state)
+                    get_coefficient_factor_pairs(factors, &self.nodes, rhs.as_ref(), network, state)
                         .map_err(FactorError::Coefficient)
                 }
             };
@@ -503,8 +503,8 @@ impl AggregatedNode {
     ///
     /// If the constraint is a metric any error when attempting to retrieve
     /// that metric will be returned. See [`MetricF64::get_value`] for more information.
-    pub fn get_min_flow(&self, model: &Network, state: &State) -> Result<f64, MetricF64Error> {
-        self.flow_constraints.get_min_flow(model, state)
+    pub fn get_min_flow(&self, network: &Network, state: &State) -> Result<f64, MetricF64Error> {
+        self.flow_constraints.get_min_flow(network, state)
     }
 
     /// Get the max flow constraint value.
@@ -513,8 +513,8 @@ impl AggregatedNode {
     ///
     /// If the constraint is a metric any error when attempting to retrieve
     /// that metric will be returned. See [`MetricF64::get_value`] for more information.
-    pub fn get_max_flow(&self, model: &Network, state: &State) -> Result<f64, MetricF64Error> {
-        self.flow_constraints.get_max_flow(model, state)
+    pub fn get_max_flow(&self, network: &Network, state: &State) -> Result<f64, MetricF64Error> {
+        self.flow_constraints.get_max_flow(network, state)
     }
 
     /// Get the min and max flow bounds as a tuple.
@@ -523,8 +523,8 @@ impl AggregatedNode {
     ///
     /// If either constraint is a metric any error when attempting to retrieve
     /// that metric will be returned. See [`MetricF64::get_value`] for more information.
-    pub fn get_flow_bounds(&self, model: &Network, state: &State) -> Result<(f64, f64), AggregatedNodeError> {
-        match (self.get_min_flow(model, state), self.get_max_flow(model, state)) {
+    pub fn get_flow_bounds(&self, network: &Network, state: &State) -> Result<(f64, f64), AggregatedNodeError> {
+        match (self.get_min_flow(network, state), self.get_max_flow(network, state)) {
             (Ok(min_flow), Ok(max_flow)) => Ok((min_flow, max_flow)),
             _ => Err(AggregatedNodeError::FlowConstraintsUndefined),
         }
@@ -728,7 +728,7 @@ pub enum ProportionalFactorError {
 fn get_norm_proportional_factor_pairs<'a>(
     factors: &[MetricF64],
     nodes: &'a [Vec<NodeIndex>],
-    model: &Network,
+    network: &Network,
     state: &State,
 ) -> Result<Vec<NodeFactorPair<'a>>, ProportionalFactorError> {
     if factors.len() != nodes.len() - 1 {
@@ -742,7 +742,7 @@ fn get_norm_proportional_factor_pairs<'a>(
     let values: Vec<f64> = factors
         .iter()
         .map(|f| {
-            let v = f.get_value(model, state)?;
+            let v = f.get_value(network, state)?;
             if v < 0.0 {
                 Err(ProportionalFactorError::NegativeOrZeroFactor { value: v })
             } else {
@@ -888,7 +888,7 @@ pub enum RatioFactorError {
 fn get_norm_ratio_factor_pairs<'a>(
     factors: &[MetricF64],
     nodes: &'a [Vec<NodeIndex>],
-    model: &Network,
+    network: &Network,
     state: &State,
 ) -> Result<Vec<NodeFactorPair<'a>>, RatioFactorError> {
     // TODO handle error cases more gracefully
@@ -900,7 +900,7 @@ fn get_norm_ratio_factor_pairs<'a>(
     }
 
     let n0 = nodes[0].as_slice();
-    let f0 = factors[0].get_value(model, state)?;
+    let f0 = factors[0].get_value(network, state)?;
     if f0 < 0.0 {
         return Err(RatioFactorError::NegativeOrZeroFactor { value: f0 });
     }
@@ -910,7 +910,7 @@ fn get_norm_ratio_factor_pairs<'a>(
         .zip(factors)
         .skip(1)
         .map(|(n1, f1)| {
-            let v1 = f1.get_value(model, state)?;
+            let v1 = f1.get_value(network, state)?;
 
             Ok(NodeFactorPair::new(
                 NodeFactor::new(n0, 1.0),
@@ -1009,7 +1009,7 @@ fn get_coefficient_factor_pairs<'a>(
     factors: &[MetricF64],
     nodes: &'a [Vec<NodeIndex>],
     rhs: Option<&MetricF64>,
-    model: &Network,
+    network: &Network,
     state: &State,
 ) -> Result<Vec<NodeFactorPair<'a>>, CoefficientFactorError> {
     // TODO handle error cases more gracefully
@@ -1024,10 +1024,10 @@ fn get_coefficient_factor_pairs<'a>(
         return Err(CoefficientFactorError::MoreThanTwoFactors);
     }
 
-    let f0 = factors[0].get_value(model, state)?;
-    let f1 = factors[1].get_value(model, state)?;
+    let f0 = factors[0].get_value(network, state)?;
+    let f1 = factors[1].get_value(network, state)?;
     let rhs = match rhs {
-        Some(rhs) => rhs.get_value(model, state)?,
+        Some(rhs) => rhs.get_value(network, state)?,
         None => 0.0,
     };
 

--- a/pywr-core/src/edge.rs
+++ b/pywr-core/src/edge.rs
@@ -43,7 +43,7 @@ impl Edge {
         self.to_node_index
     }
 
-    pub fn cost(&self, nodes: &[Node], model: &Network, state: &State) -> Result<f64, EdgeError> {
+    pub fn cost(&self, nodes: &[Node], network: &Network, state: &State) -> Result<f64, EdgeError> {
         let from_node = nodes
             .get(*self.from_node_index.deref())
             .ok_or(EdgeError::FromNodeIndexNotFound(self.from_node_index))?;
@@ -52,10 +52,10 @@ impl Edge {
             .ok_or(EdgeError::ToNodeIndexNotFound(self.from_node_index))?;
 
         let from_cost = from_node
-            .get_outgoing_cost(model, state)
+            .get_outgoing_cost(network, state)
             .map_err(|e| EdgeError::NodeError(Box::new(e)))?;
         let to_cost = to_node
-            .get_incoming_cost(model, state)
+            .get_incoming_cost(network, state)
             .map_err(|e| EdgeError::NodeError(Box::new(e)))?;
 
         Ok(from_cost + to_cost)

--- a/pywr-core/src/parameters/hydropower.rs
+++ b/pywr-core/src/parameters/hydropower.rs
@@ -41,9 +41,9 @@ pub struct HydropowerTargetParameter {
 }
 
 impl HydropowerTargetParameter {
-    fn head(&self, model: &Network, state: &State) -> Result<f64, GeneralCalculationError> {
+    fn head(&self, network: &Network, state: &State) -> Result<f64, GeneralCalculationError> {
         let head = if let Some(water_elevation) = &self.water_elevation {
-            water_elevation.get_value(model, state)? - self.turbine_elevation
+            water_elevation.get_value(network, state)? - self.turbine_elevation
         } else {
             self.turbine_elevation
         };

--- a/pywr-core/src/recorders/memory.rs
+++ b/pywr-core/src/recorders/memory.rs
@@ -294,7 +294,7 @@ impl Recorder for MemoryRecorder {
         &self,
         _timestep: &Timestep,
         _scenario_indices: &[ScenarioIndex],
-        _model: &Network,
+        _network: &Network,
         _state: &[State],
         metric_set_states: &[Vec<MetricSetState>],
         internal_state: &mut Option<Box<dyn RecorderInternalState>>,

--- a/pywr-core/src/recorders/metric_set.rs
+++ b/pywr-core/src/recorders/metric_set.rs
@@ -22,8 +22,8 @@ pub struct OutputMetric {
 }
 
 impl OutputMetric {
-    pub fn get_value(&self, model: &Network, state: &State) -> Result<f64, MetricF64Error> {
-        self.metric.get_value(model, state)
+    pub fn get_value(&self, network: &Network, state: &State) -> Result<f64, MetricF64Error> {
+        self.metric.get_value(network, state)
     }
 
     pub fn name(&self) -> &str {
@@ -128,7 +128,7 @@ impl MetricSet {
         &self,
         timestep: &Timestep,
         _scenario_index: &ScenarioIndex,
-        model: &Network,
+        network: &Network,
         state: &State,
         internal_state: &mut MetricSetState,
     ) -> Result<(), MetricSetSaveError> {
@@ -137,7 +137,7 @@ impl MetricSet {
             .metrics
             .iter()
             .map(|metric| {
-                let value = metric.get_value(model, state)?;
+                let value = metric.get_value(network, state)?;
                 Ok::<PeriodValue<f64>, MetricF64Error>(PeriodValue::new(timestep.date, timestep.duration, value))
             })
             .collect::<Result<Vec<_>, _>>()?;

--- a/pywr-core/src/recorders/mod.rs
+++ b/pywr-core/src/recorders/mod.rs
@@ -175,7 +175,7 @@ pub trait Recorder: Send + Sync + Debug {
     fn setup(
         &self,
         _domain: &ModelDomain,
-        _model: &Network,
+        _network: &Network,
     ) -> Result<Option<Box<dyn RecorderInternalState>>, RecorderSetupError> {
         Ok(None)
     }
@@ -185,7 +185,7 @@ pub trait Recorder: Send + Sync + Debug {
         &self,
         _timestep: &Timestep,
         _scenario_indices: &[ScenarioIndex],
-        _model: &Network,
+        _network: &Network,
         _state: &[State],
         _metric_set_states: &[Vec<MetricSetState>],
         _internal_state: &mut Option<Box<dyn RecorderInternalState>>,
@@ -244,7 +244,7 @@ impl Recorder for Array2Recorder {
     fn setup(
         &self,
         domain: &ModelDomain,
-        _model: &Network,
+        _network: &Network,
     ) -> Result<Option<Box<dyn RecorderInternalState>>, RecorderSetupError> {
         let array: Array2<f64> = Array::zeros((domain.time().len(), domain.scenarios().len()));
 
@@ -256,7 +256,7 @@ impl Recorder for Array2Recorder {
         &self,
         timestep: &Timestep,
         scenario_indices: &[ScenarioIndex],
-        model: &Network,
+        network: &Network,
         state: &[State],
         _metric_set_states: &[Vec<MetricSetState>],
         internal_state: &mut Option<Box<dyn RecorderInternalState>>,
@@ -266,7 +266,7 @@ impl Recorder for Array2Recorder {
 
         // This panics if out-of-bounds
         for scenario_index in scenario_indices {
-            let value = self.metric.get_value(model, &state[scenario_index.simulation_id()])?;
+            let value = self.metric.get_value(network, &state[scenario_index.simulation_id()])?;
             array[[timestep.index, scenario_index.simulation_id()]] = value
         }
 
@@ -329,7 +329,7 @@ impl Recorder for AssertionF64Recorder {
         &self,
         timestep: &Timestep,
         scenario_indices: &[ScenarioIndex],
-        model: &Network,
+        network: &Network,
         state: &[State],
         _metric_set_states: &[Vec<MetricSetState>],
         _internal_state: &mut Option<Box<dyn RecorderInternalState>>,
@@ -345,7 +345,7 @@ impl Recorder for AssertionF64Recorder {
                 None => panic!("Simulation produced results out of range."),
             };
 
-            let actual_value = self.metric.get_value(model, &state[scenario_index.simulation_id()])?;
+            let actual_value = self.metric.get_value(network, &state[scenario_index.simulation_id()])?;
 
             if !actual_value.approx_eq(
                 expected_value,
@@ -447,7 +447,7 @@ impl Recorder for AssertionU64Recorder {
         &self,
         timestep: &Timestep,
         scenario_indices: &[ScenarioIndex],
-        model: &Network,
+        network: &Network,
         state: &[State],
         _metric_set_states: &[Vec<MetricSetState>],
         _internal_state: &mut Option<Box<dyn RecorderInternalState>>,
@@ -463,7 +463,7 @@ impl Recorder for AssertionU64Recorder {
                 None => panic!("Simulation produced results out of range."),
             };
 
-            let actual_value = self.metric.get_value(model, &state[scenario_index.simulation_id()])?;
+            let actual_value = self.metric.get_value(network, &state[scenario_index.simulation_id()])?;
 
             if actual_value != expected_value {
                 panic!(
@@ -558,7 +558,7 @@ where
         &self,
         timestep: &Timestep,
         scenario_indices: &[ScenarioIndex],
-        model: &Network,
+        network: &Network,
         state: &[State],
         _metric_set_states: &[Vec<MetricSetState>],
         _internal_state: &mut Option<Box<dyn RecorderInternalState>>,
@@ -567,7 +567,7 @@ where
 
         for scenario_index in scenario_indices {
             let expected_value = (self.expected_func)(timestep, scenario_index);
-            let actual_value = self.metric.get_value(model, &state[scenario_index.simulation_id()])?;
+            let actual_value = self.metric.get_value(network, &state[scenario_index.simulation_id()])?;
 
             if !approx_eq!(
                 f64,

--- a/pywr-core/src/solvers/cbc/mod.rs
+++ b/pywr-core/src/solvers/cbc/mod.rs
@@ -250,12 +250,12 @@ impl Solver for CbcSolver {
     }
 
     fn setup(
-        model: &Network,
+        network: &Network,
         values: &ConstParameterValues,
         _settings: &Self::Settings,
     ) -> Result<Box<Self>, SolverSetupError> {
         let builder = SolverBuilder::new(f64::MAX, -f64::MAX);
-        let built = builder.create(model, values)?;
+        let built = builder.create(network, values)?;
 
         let solver = CbcSolver::from_builder(built);
         Ok(Box::new(solver))
@@ -263,12 +263,12 @@ impl Solver for CbcSolver {
 
     fn solve(
         &mut self,
-        model: &Network,
+        network: &Network,
         timestep: &Timestep,
         state: &mut State,
     ) -> Result<SolverTimings, SolverSolveError> {
         let mut timings = SolverTimings::default();
-        self.builder.update(model, timestep, state, &mut timings)?;
+        self.builder.update(network, timestep, state, &mut timings)?;
 
         let now = Instant::now();
         self.cbc.change_objective_coefficients(self.builder.col_obj_coef());
@@ -295,14 +295,14 @@ impl Solver for CbcSolver {
         network_state.reset();
 
         let start_save_solution = Instant::now();
-        for edge in model.edges().iter() {
+        for edge in network.edges().iter() {
             let col = self.builder.col_for_edge(&edge.index()) as usize;
             let flow = solution[col];
             // Round very small values to zero
             let flow = if flow.abs() < 1e-10 { 0.0 } else { flow };
             network_state.add_flow(edge, timestep, flow)?;
         }
-        state.complete(model, timestep)?;
+        state.complete(network, timestep)?;
         timings.save_solution += start_save_solution.elapsed();
 
         Ok(timings)

--- a/pywr-core/src/solvers/clp/mod.rs
+++ b/pywr-core/src/solvers/clp/mod.rs
@@ -373,12 +373,12 @@ impl Solver for ClpSolver {
     }
 
     fn setup(
-        model: &Network,
+        network: &Network,
         values: &ConstParameterValues,
         _settings: &Self::Settings,
     ) -> Result<Box<Self>, SolverSetupError> {
         let builder = SolverBuilder::new(f64::MAX, -f64::MAX);
-        let built = builder.create(model, values)?;
+        let built = builder.create(network, values)?;
 
         let solver = ClpSolver::from_builder(built);
         Ok(Box::new(solver))
@@ -386,12 +386,12 @@ impl Solver for ClpSolver {
 
     fn solve(
         &mut self,
-        model: &Network,
+        network: &Network,
         timestep: &Timestep,
         state: &mut State,
     ) -> Result<SolverTimings, SolverSolveError> {
         let mut timings = SolverTimings::default();
-        self.builder.update(model, timestep, state, &mut timings)?;
+        self.builder.update(network, timestep, state, &mut timings)?;
 
         let now = Instant::now();
         self.clp_simplex
@@ -420,12 +420,12 @@ impl Solver for ClpSolver {
         network_state.reset();
 
         let start_save_solution = Instant::now();
-        for edge in model.edges().iter() {
+        for edge in network.edges().iter() {
             let col = self.builder.col_for_edge(&edge.index()) as usize;
             let flow = solution[col];
             network_state.add_flow(edge, timestep, flow)?;
         }
-        state.complete(model, timestep)?;
+        state.complete(network, timestep)?;
         timings.save_solution += start_save_solution.elapsed();
 
         Ok(timings)

--- a/pywr-core/src/solvers/microlp/mod.rs
+++ b/pywr-core/src/solvers/microlp/mod.rs
@@ -99,12 +99,12 @@ impl Solver for MicroLpSolver {
     }
 
     fn setup(
-        model: &Network,
+        network: &Network,
         values: &ConstParameterValues,
         _settings: &Self::Settings,
     ) -> Result<Box<Self>, SolverSetupError> {
         let builder = SolverBuilder::new(f64::INFINITY, f64::NEG_INFINITY);
-        let built = builder.create(model, values)?;
+        let built = builder.create(network, values)?;
 
         let solver = MicroLpSolver { builder: built };
         Ok(Box::new(solver))
@@ -112,12 +112,12 @@ impl Solver for MicroLpSolver {
 
     fn solve(
         &mut self,
-        model: &Network,
+        network: &Network,
         timestep: &Timestep,
         state: &mut State,
     ) -> Result<SolverTimings, SolverSolveError> {
         let mut timings = SolverTimings::default();
-        self.builder.update(model, timestep, state, &mut timings)?;
+        self.builder.update(network, timestep, state, &mut timings)?;
 
         self.builder.apply_updated_coefficients();
 
@@ -146,12 +146,12 @@ impl Solver for MicroLpSolver {
         network_state.reset();
 
         let start_save_solution = Instant::now();
-        for edge in model.edges().iter() {
+        for edge in network.edges().iter() {
             let col = self.builder.col_for_edge(&edge.index());
             let flow = solution[col];
             network_state.add_flow(edge, timestep, flow)?;
         }
-        state.complete(model, timestep)?;
+        state.complete(network, timestep)?;
         timings.save_solution += start_save_solution.elapsed();
 
         Ok(timings)

--- a/pywr-core/src/solvers/mod.rs
+++ b/pywr-core/src/solvers/mod.rs
@@ -196,13 +196,13 @@ pub trait Solver: Send {
     /// An array of features that this solver provides.
     fn features() -> &'static [SolverFeatures];
     fn setup(
-        model: &Network,
+        network: &Network,
         values: &ConstParameterValues,
         settings: &Self::Settings,
     ) -> Result<Box<Self>, SolverSetupError>;
     fn solve(
         &mut self,
-        model: &Network,
+        network: &Network,
         timestep: &Timestep,
         state: &mut State,
     ) -> Result<SolverTimings, SolverSolveError>;
@@ -214,10 +214,11 @@ pub trait MultiStateSolver: Send {
     fn name() -> &'static str;
     /// An array of features that this solver provides.
     fn features() -> &'static [SolverFeatures];
-    fn setup(model: &Network, num_scenarios: usize, settings: &Self::Settings) -> Result<Box<Self>, SolverSetupError>;
+    fn setup(network: &Network, num_scenarios: usize, settings: &Self::Settings)
+    -> Result<Box<Self>, SolverSetupError>;
     fn solve(
         &mut self,
-        model: &Network,
+        network: &Network,
         timestep: &Timestep,
         states: &mut [State],
     ) -> Result<SolverTimings, SolverSolveError>;

--- a/pywr-core/src/state/mod.rs
+++ b/pywr-core/src/state/mod.rs
@@ -526,12 +526,12 @@ impl NetworkState {
     ///
     /// This final step ensures that derived states (e.g. virtual storage volume) are updated
     /// once all the flows have been updated.
-    fn update_derived_states(&mut self, model: &Network, timestep: &Timestep) -> Result<(), NetworkStateError> {
+    fn update_derived_states(&mut self, network: &Network, timestep: &Timestep) -> Result<(), NetworkStateError> {
         // Update virtual storage node states
         for (state, node) in self
             .virtual_storage_states
             .iter_mut()
-            .zip(model.virtual_storage_nodes().iter())
+            .zip(network.virtual_storage_nodes().iter())
         {
             // Only update if the node is active
             if node.is_active(timestep) {
@@ -540,7 +540,7 @@ impl NetworkState {
                     .map(|(idx, factor)| match self.node_states.get(*idx.deref()) {
                         None => Err(NetworkStateError::NodeIndexNotFound(*idx)),
                         Some(s) => {
-                            let node = model
+                            let node = network
                                 .nodes()
                                 .get(*idx.deref())
                                 .ok_or(NetworkStateError::NodeIndexNotFound(*idx))?;
@@ -1153,8 +1153,8 @@ impl State {
     /// This final step ensures, once all the flows have been updated, that:
     ///   - Derived states (e.g. virtual storage volume) are updated
     ///   - Volumes are within bounds
-    pub fn complete(&mut self, model: &Network, timestep: &Timestep) -> Result<(), StateError> {
-        for node in model.nodes().iter() {
+    pub fn complete(&mut self, network: &Network, timestep: &Timestep) -> Result<(), StateError> {
+        for node in network.nodes().iter() {
             if let Node::Storage(storage) = node {
                 let node_index = node.index();
                 let min_volume = storage.get_min_volume(self)?;
@@ -1164,9 +1164,9 @@ impl State {
             }
         }
 
-        self.network.update_derived_states(model, timestep)?;
+        self.network.update_derived_states(network, timestep)?;
 
-        for node in model.virtual_storage_nodes().iter() {
+        for node in network.virtual_storage_nodes().iter() {
             let node_index = node.index();
             let min_volume = node.get_min_volume(self)?;
             let max_volume = node.get_max_volume(self)?;


### PR DESCRIPTION
Older API used a Model type, and variable names still used "model" instead of the more correct "network".